### PR TITLE
Detect unused function calls

### DIFF
--- a/src/code_info/functionlike_info.rs
+++ b/src/code_info/functionlike_info.rs
@@ -92,6 +92,8 @@ pub struct FunctionLikeInfo {
 
     pub is_async: bool,
 
+    pub must_use: bool,
+
     pub mutation_free: bool,
 
     pub effects: FnEffect,
@@ -177,6 +179,7 @@ impl FunctionLikeInfo {
             attributes: Vec::new(),
             method_info: None,
             is_async: false,
+            must_use: false,
             ignore_taint_path: false,
             user_defined: false,
             dynamically_callable: false,

--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -115,6 +115,7 @@ pub enum IssueKind {
     UnusedClass,
     UnusedStatement,
     UnusedFunction,
+    UnusedFunctionCall,
     UnusedInterface,
     UnusedParameter,
     UnusedPipeVariable,

--- a/src/code_info_builder/functionlike_scanner.rs
+++ b/src/code_info_builder/functionlike_scanner.rs
@@ -420,6 +420,9 @@ pub(crate) fn get_functionlike(
 
                 functionlike_info.removed_taints = Some(removed_types);
             }
+            "Hakana\\MustUse" => {
+                functionlike_info.must_use = true;
+            }
             "__EntryPoint" => {
                 functionlike_info.dynamically_callable = true;
                 functionlike_info.ignore_taint_path = true;

--- a/tests/inference/FunctionCall/unusedFunctionCall/input.hack
+++ b/tests/inference/FunctionCall/unusedFunctionCall/input.hack
@@ -1,0 +1,8 @@
+<<Hakana\MustUse>>
+function must_use(): int {
+    return 0;
+}
+
+function foo(): void {
+    must_use();
+}

--- a/tests/inference/FunctionCall/unusedFunctionCall/output.txt
+++ b/tests/inference/FunctionCall/unusedFunctionCall/output.txt
@@ -1,0 +1,1 @@
+UnusedFunctionCall


### PR DESCRIPTION
This changes adds the ability to report UnusedFunctionCall issues when code does not use the return value of functions annotated with the `<<Hakana\MustUse>>` attribute.

Future changes could extend this to method calls, or infer must_use based on more sophisticated criteria (contexts and capabilities, looking for side effects in the body of the function, etc.)

The motivation for this change was a bug that looks like this:

```hack
if ($condition) create_error('not_allowed');
```

where a `return` statement is missing. As written the code has no effect.