### PR TITLE
Fix trailing newline in test comparison

### DIFF
--- a/src/cli/test_runners/test_runner.rs
+++ b/src/cli/test_runners/test_runner.rs
@@ -309,7 +309,7 @@ impl TestRunner {
                 }
             }
 
-            if migration_candidates.join("\n") == expected_candidates_contents {
+            if migration_candidates.join("\n").trim() == expected_candidates_contents.trim() {
                 (".".to_string(), Some(result.1), Some(result.0))
             } else {
                 test_diagnostics.push((


### PR DESCRIPTION
It's hard to save a file without a trailing newline which makes test comparisons fail. Comparing the trimmed versions of actual and expected makes tests pass.