### PR TITLE
Write actual output for comparison in migration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Cargo.lock
 */Cargo.lock
 .hakana_cache
 */.hakana_cache
+tests/**/*/actual.txt

--- a/src/cli/test_runners/test_runner.rs
+++ b/src/cli/test_runners/test_runner.rs
@@ -258,6 +258,7 @@ impl TestRunner {
         {
             let input_file = format!("{}/input.hack", dir);
             let output_file = format!("{}/output.txt", dir);
+            let actual_file = format!("{}/actual.txt", dir);
             let input_contents = fs::read_to_string(&input_file).unwrap();
             let expected_output_contents = fs::read_to_string(output_file).unwrap();
 
@@ -283,6 +284,8 @@ impl TestRunner {
             } else {
                 input_contents
             };
+
+            fs::write(actual_file, &output_contents).unwrap();
 
             if output_contents == expected_output_contents {
                 (".".to_string(), Some(result.1), Some(result.0))


### PR DESCRIPTION
This PR changes the test runner to write the actual output to a file in the test directory for migration tests. This makes it easy to diff and easy to accept changes if actual.txt is correct (instead of copying individual changes from input to output, you can `cp actual.txt output.txt`)

This change also adds these files to `.gitignore`.