### PR TITLE
Identify MustUse values passed to await, Asio\join

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ That will create a binary at `./target/release/hakana-default`
 
 ## Running tests
 
-You can run all tests with: `cargo run --release test tests`
+You can run all tests with: `cargo run --bin hakana --release test tests`
 
-You can run an individual test with `cargo run test <path-to-test-dir>`
+You can run an individual test with `cargo run --bin hakana test <path-to-test-dir>`

--- a/src/analyzer/stmt_analyzer.rs
+++ b/src/analyzer/stmt_analyzer.rs
@@ -348,7 +348,7 @@ fn detect_unused_statement_expressions(
     if let Some(functionlike_id) = functionlike_id {
         if let FunctionLikeIdentifier::Function(function_id) = functionlike_id {
             let codebase = statements_analyzer.get_codebase();
-            if let Some(functionlike_info) = codebase
+            if let Some(_functionlike_info) = codebase
                 .functionlike_infos
                 .get(&(function_id, StrId::EMPTY))
             {

--- a/tests/unused/UnusedExpression/unusedFunctionCallAsync/input.hack
+++ b/tests/unused/UnusedExpression/unusedFunctionCallAsync/input.hack
@@ -1,0 +1,12 @@
+<<Hakana\MustUse>>
+async function must_use_async(): Awaitable<int> {
+    return 0;
+}
+
+function foo(): void {
+    Asio\join(must_use_async());
+}
+
+function foo_async(): void {
+    await must_use_async();
+}

--- a/tests/unused/UnusedExpression/unusedFunctionCallAsync/output.txt
+++ b/tests/unused/UnusedExpression/unusedFunctionCallAsync/output.txt
@@ -1,0 +1,2 @@
+ERROR: UnusedFunctionCall - input.hack:7:5 - This function is annotated with MustUse but the returned value is not used
+ERROR: UnusedFunctionCall - input.hack:11:5 - This function is annotated with MustUse but the returned value is not used


### PR DESCRIPTION
This PR improves detection of unused values returned from functions annotated with `<<Hakana\MustUse>>` (see #5).

## Details

Previously these cases were not flagged:

```hack
await must_use();
Asio\join(must_use());
```

I added then removed code to identify `must_use() as nonnull` but since that can throw, it isn't free of side effects even if it's probably not intended.

The current implementation flags the entire expression statement with the lint error. If we prefer to scope it to the function call in, I can return the `Pos` from `has_unused_must_use`.

```
await must_use();
^^^^^^^^^^^^^^^^

// vs

await must_use();
      ^^^^^^^^^^
```