### PR TITLE
Add new issue for StrictObjectEquality checks

### DIFF
--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -1,5 +1,5 @@
-use std::{hash::Hasher, str::FromStr};
 use core::hash::Hash;
+use std::{hash::Hasher, str::FromStr};
 
 use hakana_str::StrId;
 use rustc_hash::FxHashSet;
@@ -107,6 +107,7 @@ pub enum IssueKind {
     RedundantTruthinessCheck,
     RedundantTypeComparison,
     ShadowedLoopVar,
+    StrictObjectEquality,
     TaintedData(Box<SinkType>),
     TestOnlyCall,
     UndefinedIntArrayOffset,

--- a/tests/inference/TypeReconciliation/Conditional/preventStrictEqualityObjectType/input.hack
+++ b/tests/inference/TypeReconciliation/Conditional/preventStrictEqualityObjectType/input.hack
@@ -1,0 +1,8 @@
+class A {}
+function foo(A $a, A $b) : bool {
+    return $a === $b;
+}
+function foo2(A $a, A $b) : bool {
+    return $a !== $b;
+}
+$a = foo(new A(), new A());

--- a/tests/inference/TypeReconciliation/Conditional/preventStrictEqualityObjectType/output.txt
+++ b/tests/inference/TypeReconciliation/Conditional/preventStrictEqualityObjectType/output.txt
@@ -1,0 +1,2 @@
+ERROR: StrictObjectEquality - input.hack:3:12 - Strict equality compares A objects by reference rather than value
+ERROR: StrictObjectEquality - input.hack:6:12 - Strict equality compares A objects by reference rather than value


### PR DESCRIPTION
Add new issue for StrictObjectEquality checks to prevent cases where objects are inadvertently compared by reference instead of value. 