### PR TITLE
Added a BannedNamespace IssueKind.

### DIFF
--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -16,6 +16,7 @@ use crate::{
 pub enum IssueKind {
     AbstractInstantiation,
     BannedFunction,
+    BannedNamespace,
     ExtendFinalClass,
     CannotInferGenericParam,
     CloneInsideLoop,
@@ -332,6 +333,10 @@ pub fn get_issue_from_comment(
         || trimmed_text.starts_with("HHAST_IGNORE_ERROR[BannedFunctions]")
     {
         return Some(Ok(IssueKind::BannedFunction));
+    } else if trimmed_text.starts_with("HHAST_FIXME[BannedNamespaces]")
+        || trimmed_text.starts_with("HHAST_IGNORE_ERROR[BannedNamespaces]")
+    {
+        return Some(Ok(IssueKind::BannedNamespace));
     }
 
     None


### PR DESCRIPTION
## Description:
Added a new `IssueKind` called BannedNamespace for scenarios where we want to ban the usage of functions under a given namespace.