### PR TITLE
Support autofixing ImplicitAsioJoin for instance method calls

### DIFF
--- a/src/analyzer/expr/call/existing_atomic_method_call_analyzer.rs
+++ b/src/analyzer/expr/call/existing_atomic_method_call_analyzer.rs
@@ -247,6 +247,7 @@ pub(crate) fn analyze(
                     FunctionLikeIdentifier::Method(method_id.0, method_id.1),
                     async_version,
                     false, // methods are not sub-expressions by default
+                    lhs_var_id,
                 );
             }
         }

--- a/tests/fix/ImplicitAsioJoin/instanceMethod/input.hack
+++ b/tests/fix/ImplicitAsioJoin/instanceMethod/input.hack
@@ -1,0 +1,23 @@
+final class TestClass {
+    public async function async_method(): Awaitable<int> {
+        await \HH\Asio\usleep(100000);
+        return 42;
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): int {
+        return Asio\join($this->async_method());
+    } 
+}
+
+function caller(): int {
+    $obj = new TestClass();
+    // This should be fixed to Asio\join($obj->async_method()) instead.
+    return $obj->sync_method();
+}
+
+async function async caller(): int {
+    $obj = new TestClass();
+    // This should be fixed to await $obj->async_method() instead.
+    return $obj->sync_method();
+}

--- a/tests/fix/ImplicitAsioJoin/instanceMethod/output.txt
+++ b/tests/fix/ImplicitAsioJoin/instanceMethod/output.txt
@@ -1,0 +1,23 @@
+final class TestClass {
+    public async function async_method(): Awaitable<int> {
+        await \HH\Asio\usleep(100000);
+        return 42;
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): int {
+        return Asio\join($this->async_method());
+    } 
+}
+
+function caller(): int {
+    $obj = new TestClass();
+    // This should be fixed to Asio\join($obj->async_method()) instead.
+    return Asio\join($obj->async_method());
+}
+
+async function async caller(): int {
+    $obj = new TestClass();
+    // This should be fixed to await $obj->async_method() instead.
+    return await $obj->async_method();
+}


### PR DESCRIPTION
Currently, the ImplicitAsioJoin autofix does not behave correctly for instance method invocations, as it has no knowledge of the variable that the instance method was invoked on and thus always ends up outputting a static method call.

As a fix, pass the name of the variable that the instance method is invoked on to check_implicit_asio_join() if appropriate, and have get_async_version_name() output an instance method invocation on this variable if provided and in an autofix context. Add tests.