### PR TITLE
Fix ill-formed Hack code in ImplicitAsioJoin tests

### DIFF
--- a/tests/fix/ImplicitAsioJoin/instanceMethod/input.hack
+++ b/tests/fix/ImplicitAsioJoin/instanceMethod/input.hack
@@ -16,7 +16,7 @@ function caller(): int {
     return $obj->sync_method();
 }
 
-async function async caller(): int {
+async function async_caller(): int {
     $obj = new TestClass();
     // This should be fixed to await $obj->async_method() instead.
     return $obj->sync_method();

--- a/tests/fix/ImplicitAsioJoin/instanceMethod/output.txt
+++ b/tests/fix/ImplicitAsioJoin/instanceMethod/output.txt
@@ -16,7 +16,7 @@ function caller(): int {
     return Asio\join($obj->async_method());
 }
 
-async function async caller(): int {
+async function async_caller(): int {
     $obj = new TestClass();
     // This should be fixed to await $obj->async_method() instead.
     return await $obj->async_method();


### PR DESCRIPTION
The tests in 06e43db contain a function with an ill-formed name. Although this didn't fail parsing, let's ensure the name is valid to avoid confusion.