### PR TITLE
Handle arbitrary LHS expressions and expression chains for ImplicitAsioJoin

### DIFF
--- a/src/analyzer/classlike_analyzer.rs
+++ b/src/analyzer/classlike_analyzer.rs
@@ -88,6 +88,7 @@ impl<'a> ClassLikeAnalyzer<'a> {
             &statements_analyzer.comments,
             &statements_analyzer.get_config().all_custom_issues,
             None,
+            None,
             classlike_storage.meta_start.start_offset,
             None,
         );

--- a/src/analyzer/expr/call/existing_atomic_method_call_analyzer.rs
+++ b/src/analyzer/expr/call/existing_atomic_method_call_analyzer.rs
@@ -247,7 +247,7 @@ pub(crate) fn analyze(
                     FunctionLikeIdentifier::Method(method_id.0, method_id.1),
                     async_version,
                     false, // methods are not sub-expressions by default
-                    lhs_var_id,
+                    lhs_expr,
                 );
             }
         }

--- a/src/analyzer/file_analyzer.rs
+++ b/src/analyzer/file_analyzer.rs
@@ -57,6 +57,7 @@ impl<'a> FileAnalyzer<'a> {
             &Vec::from_iter(self.file_source.comments.iter()),
             &self.get_config().all_custom_issues,
             None,
+            None,
             0,
             None,
         );

--- a/src/analyzer/function_analysis_data.rs
+++ b/src/analyzer/function_analysis_data.rs
@@ -31,6 +31,7 @@ pub struct FunctionAnalysisData {
     pub replacements: BTreeMap<(u32, u32), Replacement>,
     pub insertions: BTreeMap<u32, Vec<String>>,
     pub current_stmt_offset: Option<StmtStart>,
+    pub current_stmt_end: Option<u32>,
     pub applicable_fixme_start: u32,
     pub expr_fixme_positions: FxHashMap<(u32, u32), StmtStart>,
     pub symbol_references: SymbolReferences,
@@ -64,6 +65,7 @@ impl FunctionAnalysisData {
         comments: &Vec<&(Pos, Comment)>,
         all_custom_issues: &FxHashSet<String>,
         current_stmt_offset: Option<StmtStart>,
+        current_stmt_end: Option<u32>,
         applicable_fixme_start: u32,
         hakana_fixme_or_ignores: Option<
             BTreeMap<u32, Vec<(IssueKind, (u32, u32, u32, u32, bool))>>,
@@ -86,6 +88,7 @@ impl FunctionAnalysisData {
             replacements: BTreeMap::new(),
             insertions: BTreeMap::new(),
             current_stmt_offset,
+            current_stmt_end,
             applicable_fixme_start,
             hh_fixmes: file_source.hh_fixmes.clone(),
             symbol_references: SymbolReferences::new(),

--- a/src/analyzer/functionlike_analyzer.rs
+++ b/src/analyzer/functionlike_analyzer.rs
@@ -465,6 +465,11 @@ impl<'a> FunctionLikeAnalyzer<'a> {
             } else {
                 None
             },
+            if let Some(parent_analysis_data) = &parent_analysis_data {
+                parent_analysis_data.current_stmt_end
+            } else {
+                None
+            },
             functionlike_storage.meta_start.start_offset,
             parent_analysis_data
                 .as_ref()

--- a/src/analyzer/stmt_analyzer.rs
+++ b/src/analyzer/stmt_analyzer.rs
@@ -56,6 +56,7 @@ pub(crate) fn analyze(
             add_newline: true,
         });
     }
+    analysis_data.current_stmt_end = Some(stmt.0.end_offset() as u32);
 
     if statements_analyzer.get_config().remove_fixmes {
         for (fixme_line, b) in analysis_data.hakana_fixme_or_ignores.iter_mut() {

--- a/tests/fix/ImplicitAsioJoin/instanceMethod/input.hack
+++ b/tests/fix/ImplicitAsioJoin/instanceMethod/input.hack
@@ -7,7 +7,11 @@ final class TestClass {
     // This sync method just wraps the async version
     public function sync_method(): int {
         return Asio\join($this->async_method());
-    } 
+    }
+
+    public static function factory(): TestClass {
+        return new self();
+    }
 }
 
 function caller(): int {
@@ -16,8 +20,28 @@ function caller(): int {
     return $obj->sync_method();
 }
 
+function caller_expr(): int {
+    // This should be fixed to Asio\join((new TestClass())->async_method()) instead.
+    return (new TestClass())->sync_method();
+}
+
+function factory_expr(): int {
+    // This should be fixed to Asio\join(TestClass::factory()->async_method()) instead.
+    return TestClass::factory()->sync_method();
+}
+
 async function async_caller(): int {
     $obj = new TestClass();
     // This should be fixed to await $obj->async_method() instead.
     return $obj->sync_method();
+}
+
+async function async_caller_expr(): int {
+    // This should be fixed to await (new TestClass())->async_method() instead.
+    return (new TestClass())->sync_method();
+}
+
+async function async_factory_expr(): int {
+    // This should be fixed to await TestClass::factory()->async_method() instead.
+    return TestClass::factory()->sync_method();
 }

--- a/tests/fix/ImplicitAsioJoin/instanceMethod/output.txt
+++ b/tests/fix/ImplicitAsioJoin/instanceMethod/output.txt
@@ -7,7 +7,11 @@ final class TestClass {
     // This sync method just wraps the async version
     public function sync_method(): int {
         return Asio\join($this->async_method());
-    } 
+    }
+
+    public static function factory(): TestClass {
+        return new self();
+    }
 }
 
 function caller(): int {
@@ -16,8 +20,28 @@ function caller(): int {
     return Asio\join($obj->async_method());
 }
 
+function caller_expr(): int {
+    // This should be fixed to Asio\join((new TestClass())->async_method()) instead.
+    return Asio\join((new TestClass())->async_method());
+}
+
+function factory_expr(): int {
+    // This should be fixed to Asio\join(TestClass::factory()->async_method()) instead.
+    return Asio\join(TestClass::factory()->async_method());
+}
+
 async function async_caller(): int {
     $obj = new TestClass();
     // This should be fixed to await $obj->async_method() instead.
     return await $obj->async_method();
+}
+
+async function async_caller_expr(): int {
+    // This should be fixed to await (new TestClass())->async_method() instead.
+    return await (new TestClass())->async_method();
+}
+
+async function async_factory_expr(): int {
+    // This should be fixed to await TestClass::factory()->async_method() instead.
+    return await TestClass::factory()->async_method();
 }

--- a/tests/fix/ImplicitAsioJoin/nestedSyncToAsync/input.hack
+++ b/tests/fix/ImplicitAsioJoin/nestedSyncToAsync/input.hack
@@ -1,0 +1,64 @@
+final class Inner {
+    public function foo(): void {
+        echo "foo\n";
+    }
+}
+
+final class TestClass {
+    public async function async_method(): Awaitable<Inner> {
+        await \HH\Asio\usleep(100000);
+        return new Inner();
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): Inner {
+        return Asio\join($this->async_method());
+    }
+
+    public async function async_vec(): Awaitable<vec<int>> {
+        return vec[0];
+    }
+
+    // This sync method just wraps the async version
+    public function sync_vec(): vec<int> {
+        return Asio\join($this->async_vec());
+    }
+
+    public static function factory(): TestClass {
+        return new self();
+    }
+}
+
+function caller(): int {
+    $obj = new TestClass();
+    // This should be fixed to Asio\join($obj->async_method())->foo() instead.
+    return $obj->sync_method()->foo();
+}
+
+function factory_expr(): int {
+    // This should be fixed to Asio\join(TestClass::factory()->async_method())->foo() instead.
+    return TestClass::factory()->sync_method()->foo();
+}
+
+async function async_caller(): int {
+    $obj = new TestClass();
+    // This should be fixed to (await $obj->async_method())->foo() instead.
+    return $obj->sync_method()->foo();
+}
+
+async function async_factory_expr(): int {
+    // This should be fixed to (await TestClass::factory()->async_method())->foo() instead.
+    return TestClass::factory()->sync_method()->foo();
+}
+
+async function await_assignments(): Awaitable<void> {
+    // This should be fixed to (await TestClass::factory()->async_method())->foo() instead.
+    $foo = TestClass::factory()->sync_method()->foo();
+    // This should be fixed to await TestClass::factory()->async_method() instead.
+    $bar = TestClass::factory()->sync_method();
+}
+
+async function await_array_access(): Awaitable<void> {
+    // This should be fixed to (await TestClass::factory()->async_vec())[0] instead.
+    $test = TestClass::factory()->sync_vec()[0];
+}

--- a/tests/fix/ImplicitAsioJoin/nestedSyncToAsync/output.txt
+++ b/tests/fix/ImplicitAsioJoin/nestedSyncToAsync/output.txt
@@ -1,0 +1,64 @@
+final class Inner {
+    public function foo(): void {
+        echo "foo\n";
+    }
+}
+
+final class TestClass {
+    public async function async_method(): Awaitable<Inner> {
+        await \HH\Asio\usleep(100000);
+        return new Inner();
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): Inner {
+        return Asio\join($this->async_method());
+    }
+
+    public async function async_vec(): Awaitable<vec<int>> {
+        return vec[0];
+    }
+
+    // This sync method just wraps the async version
+    public function sync_vec(): vec<int> {
+        return Asio\join($this->async_vec());
+    }
+
+    public static function factory(): TestClass {
+        return new self();
+    }
+}
+
+function caller(): int {
+    $obj = new TestClass();
+    // This should be fixed to Asio\join($obj->async_method())->foo() instead.
+    return Asio\join($obj->async_method())->foo();
+}
+
+function factory_expr(): int {
+    // This should be fixed to Asio\join(TestClass::factory()->async_method())->foo() instead.
+    return Asio\join(TestClass::factory()->async_method())->foo();
+}
+
+async function async_caller(): int {
+    $obj = new TestClass();
+    // This should be fixed to (await $obj->async_method())->foo() instead.
+    return (await $obj->async_method())->foo();
+}
+
+async function async_factory_expr(): int {
+    // This should be fixed to (await TestClass::factory()->async_method())->foo() instead.
+    return (await TestClass::factory()->async_method())->foo();
+}
+
+async function await_assignments(): Awaitable<void> {
+    // This should be fixed to (await TestClass::factory()->async_method())->foo() instead.
+    $foo = (await TestClass::factory()->async_method())->foo();
+    // This should be fixed to await TestClass::factory()->async_method() instead.
+    $bar = await TestClass::factory()->async_method();
+}
+
+async function await_array_access(): Awaitable<void> {
+    // This should be fixed to (await TestClass::factory()->async_vec())[0] instead.
+    $test = (await TestClass::factory()->async_vec())[0];
+}

--- a/tests/fix/ImplicitAsioJoin/syncToAsync/input.hack
+++ b/tests/fix/ImplicitAsioJoin/syncToAsync/input.hack
@@ -1,16 +1,32 @@
-async function fetch_data_async(): Awaitable<int> {
-    return 42;
+class Inner {
+    public function test(): void {
+        echo "test\n";
+    }
+}
+
+async function fetch_data_async(): Awaitable<Inner> {
+    return new Inner();
 }
 
 // This sync function just wraps the async version
-function fetch_data(): int {
+function fetch_data(): Inner {
     return Asio\join(fetch_data_async());
 }
 
-function caller(): int {
+function caller(): Inner {
     return fetch_data(); // This should be fixed to Asio\join(fetch_data_async())
 }
 
-async function async_caller(): Awaitable<int> {
+async function async_caller(): Awaitable<Inner> {
     return fetch_data(); // This should be fixed to await fetch_data_async()
+}
+
+function sync_nested(): void {
+    // This should be fixed to Asio\join(fetch_data_async())->foo()
+    fetch_data()->foo();
+}
+
+async function async_nested(): Awaitable<void> {
+    // This should be fixed to (await fetch_data_async())->foo()
+    fetch_data()->foo();
 }

--- a/tests/fix/ImplicitAsioJoin/syncToAsync/output.txt
+++ b/tests/fix/ImplicitAsioJoin/syncToAsync/output.txt
@@ -1,16 +1,32 @@
-async function fetch_data_async(): Awaitable<int> {
-    return 42;
+class Inner {
+    public function test(): void {
+        echo "test\n";
+    }
+}
+
+async function fetch_data_async(): Awaitable<Inner> {
+    return new Inner();
 }
 
 // This sync function just wraps the async version
-function fetch_data(): int {
+function fetch_data(): Inner {
     return Asio\join(fetch_data_async());
 }
 
-function caller(): int {
+function caller(): Inner {
     return Asio\join(\fetch_data_async()); // This should be fixed to Asio\join(fetch_data_async())
 }
 
-async function async_caller(): Awaitable<int> {
+async function async_caller(): Awaitable<Inner> {
     return (await \fetch_data_async()); // This should be fixed to await fetch_data_async()
+}
+
+function sync_nested(): void {
+    // This should be fixed to Asio\join(fetch_data_async())->foo()
+    Asio\join(\fetch_data_async())->foo();
+}
+
+async function async_nested(): Awaitable<void> {
+    // This should be fixed to (await fetch_data_async())->foo()
+    (await \fetch_data_async())->foo();
 }


### PR DESCRIPTION
Having run the updated `ImplicitAsioJoin` autofix with instance method handling, it turns out the autofix runs into issues when processing instance method calls where the LHS expression is anything other than a variable, or if the sync method call being converted is part of a larger method or expression chain.

For instance, both of the below calls would be mangled:
```hack

$foo = SomeClass::factory()->sync_method();

$bar = $quux->sync_method()->next_method();

$baz = $karamba->sync_method()[2];
```

So:

* Split the replacement emitted by the autofix into two parts: an insertion of `await` / `Asio\join` (as appropriate) before
  the start offset of the call (and thus before any LHS expression), and a replacement of the call expression itself. Limit the latter to exclude the LHS expression if one exists.
* Track the end position of the current statement in FunctionAnalysisData and have the ImplicitAsioJoin autofix refer to it to try and determine whether other expressions may follow beyond the end of the call being autofixed, parenthesizing any `await`s that get emitted if the end offsets do not line up.