### PR TITLE
ImplicitAsioJoin: Guard against duplicate inserts

### DIFF
--- a/tests/fix/ImplicitAsioJoin/instanceMethodPolymorphy/input.hack
+++ b/tests/fix/ImplicitAsioJoin/instanceMethodPolymorphy/input.hack
@@ -1,0 +1,38 @@
+abstract class TestClass {
+    public function __construct(private int $x);
+
+    public async function async_method(): Awaitable<int> {
+        await \HH\Asio\usleep(100000);
+        return $this->x;
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): int {
+        return Asio\join($this->async_method());
+    }
+}
+
+final class A extends TestClass {}
+final class B extends TestClass {}
+
+function polymorphic_fn(bool $something): Awaitable<void> {
+    if ($something) {
+        $obj = new A();
+    } else {
+        $obj = new B();
+    }
+
+    // This should be fixed to Asio\join($obj->async_method())
+    $obj->sync_method();
+}
+
+async function async_polymorphic_fn(bool $something): Awaitable<void> {
+    if ($something) {
+        $obj = new A();
+    } else {
+        $obj = new B();
+    }
+
+    // This should be fixed to await $obj->async_method()
+    $obj->sync_method();
+}

--- a/tests/fix/ImplicitAsioJoin/instanceMethodPolymorphy/output.txt
+++ b/tests/fix/ImplicitAsioJoin/instanceMethodPolymorphy/output.txt
@@ -1,0 +1,38 @@
+abstract class TestClass {
+    public function __construct(private int $x);
+
+    public async function async_method(): Awaitable<int> {
+        await \HH\Asio\usleep(100000);
+        return $this->x;
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): int {
+        return Asio\join($this->async_method());
+    }
+}
+
+final class A extends TestClass {}
+final class B extends TestClass {}
+
+function polymorphic_fn(bool $something): Awaitable<void> {
+    if ($something) {
+        $obj = new A();
+    } else {
+        $obj = new B();
+    }
+
+    // This should be fixed to Asio\join($obj->async_method())
+    Asio\join($obj->async_method());
+}
+
+async function async_polymorphic_fn(bool $something): Awaitable<void> {
+    if ($something) {
+        $obj = new A();
+    } else {
+        $obj = new B();
+    }
+
+    // This should be fixed to await $obj->async_method()
+    await $obj->async_method();
+}

--- a/tests/fix/ImplicitAsioJoin/instanceMethodVariants/input.hack
+++ b/tests/fix/ImplicitAsioJoin/instanceMethodVariants/input.hack
@@ -1,0 +1,30 @@
+final class TestClass {
+
+    public async function async_method(): Awaitable<int> {
+        await \HH\Asio\usleep(100000);
+        return 42;
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): int {
+        return Asio\join($this->async_method());
+    }
+}
+
+function foreach_fn(vec<int> $something): void {
+    $obj = new TestClass();
+    foreach ($something as $_) {
+        $obj = new TestClass();
+        // This should be fixed to Asio\join($obj->async_method())
+        $foo = $obj->sync_method();
+    }
+}
+
+async function async_foreach_fn(vec<int> $something): Awaitable<void> {
+    $obj = new TestClass();
+    foreach ($something as $_) {
+        $obj = new TestClass();
+         // This should be fixed to await $obj->async_method()
+        $foo = $obj->sync_method();
+    }
+}

--- a/tests/fix/ImplicitAsioJoin/instanceMethodVariants/output.txt
+++ b/tests/fix/ImplicitAsioJoin/instanceMethodVariants/output.txt
@@ -1,0 +1,30 @@
+final class TestClass {
+
+    public async function async_method(): Awaitable<int> {
+        await \HH\Asio\usleep(100000);
+        return 42;
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): int {
+        return Asio\join($this->async_method());
+    }
+}
+
+function foreach_fn(vec<int> $something): void {
+    $obj = new TestClass();
+    foreach ($something as $_) {
+        $obj = new TestClass();
+        // This should be fixed to Asio\join($obj->async_method())
+        $foo = Asio\join($obj->async_method());
+    }
+}
+
+async function async_foreach_fn(vec<int> $something): Awaitable<void> {
+    $obj = new TestClass();
+    foreach ($something as $_) {
+        $obj = new TestClass();
+         // This should be fixed to await $obj->async_method()
+        $foo = await $obj->async_method();
+    }
+}


### PR DESCRIPTION
In certain situations, function call analysis may run more than once for a given invocation. Consider this code:

```hack
abstract class Base {
	public function async_method(): Awaitable<void> {
		// ...
	}

	public function sync_method(): void {
		Asio\join($this->async_method());
	}
}

class A extends Base {}
class B extends Base {}

<<__EntryPoint>>
async function main(): Awaitable<void> {
	if (rand() % 2 == 0) {
		$obj = new A();
	} else {
		$obj = new B();
	}

	$obj->sync_method();
}
```

In 2b1694bb58442c96c10e1537e03c47ffc5fd48bc, we changed the ImplicitAsioJoin autofix to support arbitrary LHS expressions for instance methods by preserving the LHS expression and inserting `await`/`Asio\join(` directly before it instead of replacing the full method invocation. This, however, means the autofix now inserts a duplicate `await`/`Asio\join` when each time it is invoked. So, guard against multiple runs against the same method invocation by only inserting `await`/`Asio\join` if we have not done so already.