### PR TITLE
ImplicitAsioJoin: Improve formatting for long method chains

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 tokio = { version = "1.26.0", features = ["full"] }
 similar = "2.7.0"
+regex = "1.11.2"
 
 [lib]
 path = "lib.rs"

--- a/src/code_info/analysis_result.rs
+++ b/src/code_info/analysis_result.rs
@@ -18,6 +18,8 @@ use crate::{
 #[derive(Clone, Debug)]
 pub enum Replacement {
     Remove,
+    // Remove newlines and leading whitespace within a given range.
+    RemoveNewlines,
     TrimPrecedingWhitespace(u32),
     TrimPrecedingWhitespaceAndTrailingComma(u32),
     TrimTrailingWhitespace(u32),

--- a/tests/fix/ImplicitAsioJoin/methodChainFormatting/input.hack
+++ b/tests/fix/ImplicitAsioJoin/methodChainFormatting/input.hack
@@ -1,0 +1,44 @@
+final class R1 {
+    public static function create(): R1 {
+        return new R1();
+    }
+    public function getNext(): R2 {
+        return new R2();
+    }
+}
+
+final class R2 {
+    public async function async_method(): Awaitable<R3> {
+        await \HH\Asio\usleep(100000);
+        return new R3();
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): R3 {
+        return Asio\join($this->async_method());
+    }
+}
+
+final class R3 {
+    public function final_method(): void {
+        echo "final\n";
+    }
+}
+
+function caller(): int {
+    // This should be fixed to Asio\join(R1::create()->getNext()->async_method()) instead,
+    // stripping newlines within the wrapped expression.
+    return R1::create()
+        ->getNext()
+        ->sync_method()
+        ->final_method();
+}
+
+async function async_caller(): int {
+    // This should be fixed to (await R1::create()->getNext()->async_method()) instead,
+    // stripping newlines within the wrapped expression.
+    return R1::create()
+        ->getNext()
+        ->sync_method()
+        ->final_method();
+}

--- a/tests/fix/ImplicitAsioJoin/methodChainFormatting/output.txt
+++ b/tests/fix/ImplicitAsioJoin/methodChainFormatting/output.txt
@@ -1,0 +1,40 @@
+final class R1 {
+    public static function create(): R1 {
+        return new R1();
+    }
+    public function getNext(): R2 {
+        return new R2();
+    }
+}
+
+final class R2 {
+    public async function async_method(): Awaitable<R3> {
+        await \HH\Asio\usleep(100000);
+        return new R3();
+    }
+
+    // This sync method just wraps the async version
+    public function sync_method(): R3 {
+        return Asio\join($this->async_method());
+    }
+}
+
+final class R3 {
+    public function final_method(): void {
+        echo "final\n";
+    }
+}
+
+function caller(): int {
+    // This should be fixed to Asio\join(R1::create()->getNext()->async_method()) instead,
+    // stripping newlines within the wrapped expression.
+    return Asio\join(R1::create()->getNext()->async_method())
+        ->final_method();
+}
+
+async function async_caller(): int {
+    // This should be fixed to (await R1::create()->getNext()->async_method()) instead,
+    // stripping newlines within the wrapped expression.
+    return (await R1::create()->getNext()->async_method())
+        ->final_method();
+}


### PR DESCRIPTION
Currently, the ImplicitAsioJoin autofix leaves the LHS expression completely untouched when asyncifying instance method calls. This is suboptimal if the LHS expression is a long method chain that is broken into multiple lines, as the boundaries of the resulting expression will be difficult to discern, e.g.:

```hack
async function test(A $bar): Awaitable<void> {
	$foo = (await $bar->getSomething()
		->call()
		->otherCall())
		->sync();
}
```

So, add a new replacement type that removes newlines and leading whitespace within a target source range and apply it to the LHS expression (if one exists) as part of the ImplicitAsioJoin autofix.