### PR TITLE
Add ClassnameUsedAsString issue with autofix in argument context

### DIFF
--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -17,6 +17,7 @@ pub enum IssueKind {
     AbstractInstantiation,
     BannedFunction,
     CannotInferGenericParam,
+    ClassnameUsedAsString,
     CloneInsideLoop,
     CustomIssue(Box<String>),
     DuplicateEnumValue,

--- a/tests/add-fixmes/ClassnameUsedAsString/asArgument/input.hack
+++ b/tests/add-fixmes/ClassnameUsedAsString/asArgument/input.hack
@@ -1,0 +1,18 @@
+final class C {
+	public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+	public function string_method(string $s, int $x): void {}
+}
+
+function string_function(string $s): void {}
+
+function classname_function(classname<C> $cls): void {}
+
+function caller(): void {
+	$c = new C();
+	$int = 5;
+	C::static_string_method($int, C::class, 5.6);
+	string_function(C::class);
+	$c->string_method(C::class, 4);
+
+	classname_function(C::class);
+}

--- a/tests/add-fixmes/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/add-fixmes/ClassnameUsedAsString/asArgument/output.txt
@@ -1,0 +1,21 @@
+final class C {
+	public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+	public function string_method(string $s, int $x): void {}
+}
+
+function string_function(string $s): void {}
+
+function classname_function(classname<C> $cls): void {}
+
+function caller(): void {
+	$c = new C();
+	$int = 5;
+	/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+	C::static_string_method($int, C::class, 5.6);
+	/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+	string_function(C::class);
+	/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+	$c->string_method(C::class, 4);
+
+	classname_function(C::class);
+}

--- a/tests/fix/ClassnameUsedAsString/asArgument/input.hack
+++ b/tests/fix/ClassnameUsedAsString/asArgument/input.hack
@@ -1,0 +1,21 @@
+final class C {
+    public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+    public function string_method(string $s, int $x): void {}
+}
+
+function string_function(string $s): void {}
+
+function classname_function(classname<C> $cls): void {}
+
+function caller(): void {
+    $c = new C();
+    $int = 5;
+    C::static_string_method($int, C::class, 5.6);
+    string_function(C::class);
+    $c->string_method(C::class, 4);
+
+    /* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+	$c->string_method(C::class, 4);
+
+    classname_function(C::class);
+}

--- a/tests/fix/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/fix/ClassnameUsedAsString/asArgument/output.txt
@@ -1,0 +1,21 @@
+final class C {
+    public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+    public function string_method(string $s, int $x): void {}
+}
+
+function string_function(string $s): void {}
+
+function classname_function(classname<C> $cls): void {}
+
+function caller(): void {
+    $c = new C();
+    $int = 5;
+    C::static_string_method($int, nameof C, 5.6);
+    string_function(nameof C);
+    $c->string_method(nameof C, 4);
+
+    /* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+	$c->string_method(C::class, 4);
+
+    classname_function(C::class);
+}

--- a/tests/inference/ClassnameUsedAsString/asArgument/input.hack
+++ b/tests/inference/ClassnameUsedAsString/asArgument/input.hack
@@ -1,0 +1,21 @@
+final class C {
+	public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+	public function string_method(string $s, int $x): void {}
+}
+
+function string_function(string $s): void {}
+
+function classname_function(classname<C> $cls): void {}
+
+function caller(): void {
+	$c = new C();
+	$int = 5;
+	C::static_string_method($int, C::class, 5.6);
+	string_function(C::class);
+	$c->string_method(C::class, 4);
+
+	/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+	$c->string_method(C::class, 4);
+
+	classname_function(C::class);
+}

--- a/tests/inference/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/inference/ClassnameUsedAsString/asArgument/output.txt
@@ -1,0 +1,3 @@
+ERROR: ClassnameUsedAsString - input.hack:13:2 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
+ERROR: ClassnameUsedAsString - input.hack:14:2 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
+ERROR: ClassnameUsedAsString - input.hack:15:2 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead


### PR DESCRIPTION
I ran an updated Hack typechecker against a webapp checkout in a local VM. One of the noisiest new issues is the use of a classname literal in a string context; Hack now wants us to explicitly use `nameof C` instead of `C::class` here to avoid an implicit conversion to string at runtime.

So, add a new issue type for detecting `classname<T>` used in a string context, and have it detect and autofix the vastly most common case of using a classname literal as an argument to a function which takes string. The Hack typechecker does not seem to raise an error as of yet if the classname is passed to the function as a variable rather than a literal and most webapp cases seem to directly pass a literal anyways, so ignore this case in Hakana as well. We can always make our issue more comprehensive as a followup.