### PR TITLE
Fix nameof handling

### DIFF
--- a/src/analyzer/expression_analyzer.rs
+++ b/src/analyzer/expression_analyzer.rs
@@ -469,7 +469,6 @@ pub(crate) fn analyze(
         | aast::Expr_::Pair(_)
         | aast::Expr_::ETSplice(_)
         | aast::Expr_::Hole(_)
-        | aast::Expr_::Nameof(_)
         | aast::Expr_::Invalid(_) => {
             analysis_data.maybe_add_issue(
                 Issue::new(
@@ -482,6 +481,10 @@ pub(crate) fn analyze(
                 statements_analyzer.get_file_path_actual(),
             );
             //return Err(AnalysisError::UserError);
+        }
+        aast::Expr_::Nameof(_) => {
+            // The Hack typechecker already verifies that `nameof` was passed a valid classlike.
+            // Do nothing.
         }
         aast::Expr_::Package(_) => todo!(),
         aast::Expr_::Assign(boxed) => {

--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -78,6 +78,7 @@ pub enum IssueKind {
     MixedPropertyAssignment,
     MixedPropertyTypeCoercion,
     MixedReturnStatement,
+    NameofUsedOutsideClassWithoutLiteral,
     NoJoinInAsyncFunction,
     NonExhaustiveSwitchStatement,
     NonExistentClass,

--- a/tests/inference/ArrayFunctionCall/arrayFilterIgnoreNullable/input.hack
+++ b/tests/inference/ArrayFunctionCall/arrayFilterIgnoreNullable/input.hack
@@ -7,7 +7,7 @@ final class A {
         $arr = array_filter(
             static::getRows(),
             (A $row): bool ==> {
-                return is_a($row, static::class);
+                return is_a($row, nameof static);
             }
         );
     }

--- a/tests/inference/Class/allowAbstractInstantiationOnPossibleChild/input.hack
+++ b/tests/inference/Class/allowAbstractInstantiationOnPossibleChild/input.hack
@@ -2,7 +2,7 @@
 abstract class A {}
 
 function foo(string $a_class) : void {
-    if (is_a($a_class, A::class, true)) {
+    if (is_a($a_class, nameof A, true)) {
         new $a_class();
     }
 }

--- a/tests/inference/Class/returnStringAfterIsACheckWithClassConst/input.hack
+++ b/tests/inference/Class/returnStringAfterIsACheckWithClassConst/input.hack
@@ -1,6 +1,6 @@
 final class Foo{}
 function bar(string $maybeBaz) : string {
-  if (!is_a($maybeBaz, Foo::class, true)) {
+  if (!is_a($maybeBaz, nameof Foo, true)) {
     throw new Exception("not Foo");
   }
   return $maybeBaz;

--- a/tests/inference/ClassLikeString/noCrashWhenClassExists/input.hack
+++ b/tests/inference/ClassLikeString/noCrashWhenClassExists/input.hack
@@ -1,5 +1,5 @@
 final class A {}
 
-if (class_exists(A::class)) {
+if (class_exists(nameof A)) {
     new \RuntimeException();
 }

--- a/tests/inference/ClassLikeString/noCrashWhenClassExistsNegated/input.hack
+++ b/tests/inference/ClassLikeString/noCrashWhenClassExistsNegated/input.hack
@@ -1,5 +1,5 @@
 final class A {}
 
-if (!class_exists(A::class)) {
+if (!class_exists(nameof A)) {
     new \RuntimeException();
 }

--- a/tests/inference/FunctionCall/strposFirstParamAllowClassString/input.hack
+++ b/tests/inference/FunctionCall/strposFirstParamAllowClassString/input.hack
@@ -1,3 +1,3 @@
 function sayHello(string $needle): void {
-    if (strpos(DateTime::class, $needle)) {}
+    if (strpos(nameof DateTime, $needle)) {}
 }

--- a/tests/inference/NameofUsedOutsideClassWithoutLiteral/insideFunction/input.hack
+++ b/tests/inference/NameofUsedOutsideClassWithoutLiteral/insideFunction/input.hack
@@ -1,0 +1,20 @@
+final class C {
+    public static function foo(): void {
+        echo nameof C;
+        echo nameof self;
+        echo nameof static;
+    }
+
+    public function bar(): void {
+        echo nameof C;
+        echo nameof self;
+        echo nameof static;
+    }
+}
+
+function only_literal_classname_allowed_here(): void {
+    echo nameof C;
+    echo nameof self;
+    echo nameof static;
+    echo nameof parent;
+}

--- a/tests/inference/NameofUsedOutsideClassWithoutLiteral/insideFunction/output.txt
+++ b/tests/inference/NameofUsedOutsideClassWithoutLiteral/insideFunction/output.txt
@@ -1,0 +1,3 @@
+ERROR: NameofUsedOutsideClassWithoutLiteral - input.hack:17:10 - nameof used outside of a class context with a non-literal target
+ERROR: NameofUsedOutsideClassWithoutLiteral - input.hack:18:10 - nameof used outside of a class context with a non-literal target
+ERROR: NameofUsedOutsideClassWithoutLiteral - input.hack:19:10 - nameof used outside of a class context with a non-literal target

--- a/tests/inference/Trait/isAClassTraitUserClassConstant/input.hack
+++ b/tests/inference/Trait/isAClassTraitUserClassConstant/input.hack
@@ -1,6 +1,6 @@
 trait T {
     public function f(): void {
-        if (is_a(static::class, B::class, true)) { }
+        if (is_a(static::class, nameof B, true)) { }
     }
 }
 

--- a/tests/inference/Trait/isAClassTraitUserStringClass/input.hack
+++ b/tests/inference/Trait/isAClassTraitUserStringClass/input.hack
@@ -1,6 +1,6 @@
 trait T {
     public function f(): void {
-        if (is_a(static::class, B::class, true)) { }
+        if (is_a(static::class, nameof B, true)) { }
     }
 }
 

--- a/tests/inference/TypeReconciliation/Conditional/isAClass/input.hack
+++ b/tests/inference/TypeReconciliation/Conditional/isAClass/input.hack
@@ -1,5 +1,5 @@
 final class A {}
 $a_class = rand(0, 1) ? A::class : "blargle";
-if (is_a($a_class, A::class, true)) {
+if (is_a($a_class, nameof A, true)) {
   echo "cool";
 }


### PR DESCRIPTION
Now that c90615f17a017d0355a4e37c19094bd22650af25 is merged, it turns out some tests are failing, but did not trigger a failure in CI. This will be fixed in a followup commit, but until then, fix the failing tests and ensure Hakana doesn't treat `nameof` as an unrecognized expression.