### PR TITLE
Emit an FQN when autofixing ClassnameUsedAsString

### DIFF
--- a/src/analyzer/expr/call/arguments_analyzer.rs
+++ b/src/analyzer/expr/call/arguments_analyzer.rs
@@ -1567,7 +1567,7 @@ fn check_classname_passed_as_string(
                     .is_production(statements_analyzer.codebase)
                     || analysis_data.get_matching_hakana_fixme(&issue).is_none()
                 {
-                    let nameof_expr = format!("nameof {}", class_name);
+                    let nameof_expr = format!("nameof \\{}", class_name);
                     analysis_data.add_replacement(
                         (arg_pos.start_offset() as u32, arg_pos.end_offset() as u32),
                         Replacement::Substitute(nameof_expr),

--- a/tests/fix/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/fix/ClassnameUsedAsString/asArgument/output.txt
@@ -10,9 +10,9 @@ function classname_function(classname<C> $cls): void {}
 function caller(): void {
     $c = new C();
     $int = 5;
-    C::static_string_method($int, nameof C, 5.6);
-    string_function(nameof C);
-    $c->string_method(nameof C, 4);
+    C::static_string_method($int, nameof \C, 5.6);
+    string_function(nameof \C);
+    $c->string_method(nameof \C, 4);
 
     /* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
 	$c->string_method(C::class, 4);


### PR DESCRIPTION
The autofix for ClassnameUsedAsString currently does not prefix the output classname with a `\`, which leads to type errors when operating on namespaced code. So, make sure it always emits an FQN.