### PR TITLE
Add tests for `nameof` value inference

### DIFF
--- a/tests/inference/Class/nameofLiteral/input.hack
+++ b/tests/inference/Class/nameofLiteral/input.hack
@@ -1,0 +1,24 @@
+abstract class A {
+    public static function static_name(): void {
+        $static_name = nameof static;
+        if ($static_name == 'quux') {
+            echo "impossible\n";
+        }
+    }
+}
+
+final class B extends A {
+    public function foo(bool $something): void {
+        $bar = $something ? nameof self : nameof parent;
+        if ($bar == 'quux') {
+            echo "impossible\n";
+        }
+
+        $nameof_c = nameof C;
+        if ($nameof_c == 'quux') {
+            echo "impossible\n";
+        }
+    }
+}
+
+final class C {}

--- a/tests/inference/Class/nameofLiteral/output.txt
+++ b/tests/inference/Class/nameofLiteral/output.txt
@@ -1,0 +1,3 @@
+ERROR: ImpossibleTypeComparison - input.hack:4:13 - Type string(A) is never =string(quux)
+ERROR: ImpossibleTypeComparison - input.hack:13:13 - Type string(A)|string(B) is never =string(quux)
+ERROR: ImpossibleTypeComparison - input.hack:18:13 - Type string(C) is never =string(quux)


### PR DESCRIPTION
29f846f90393b00d42b9077123415cd3678b714a gave Hakana the ability to resolve the string literal returned by a `nameof` expression. Add tests for this functionality.