### PR TITLE
ClassnameUsedAsString: Improve classname resolution

### DIFF
--- a/tests/add-fixmes/ClassnameUsedAsString/asArgument/input.hack
+++ b/tests/add-fixmes/ClassnameUsedAsString/asArgument/input.hack
@@ -1,18 +1,45 @@
-final class C {
-	public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
-	public function string_method(string $s, int $x): void {}
+namespace {
+	abstract class P {}
+
+	final class C extends P {
+		public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+		public function string_method(string $s, int $x): void {}
+
+		public function foo(): void {
+			$this->string_method(self::class, 4);
+			$this->string_method(static::class, 5);
+			$this->string_method(parent::class, 5);
+		}
+	}
+
+	function string_function(string $s): void {}
+
+	function classname_function(classname<C> $cls): void {}
+
+	function caller(): void {
+		$c = new C();
+		$int = 5;
+		C::static_string_method($int, C::class, 5.6);
+		string_function(C::class);
+		$c->string_method(C::class, 4);
+
+		string_function(\N\E::class);
+
+		/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+		$c->string_method(C::class, 4);
+
+		classname_function(C::class);
+	}
 }
 
-function string_function(string $s): void {}
+namespace N {
+	final class D {}
 
-function classname_function(classname<C> $cls): void {}
-
-function caller(): void {
-	$c = new C();
-	$int = 5;
-	C::static_string_method($int, C::class, 5.6);
-	string_function(C::class);
-	$c->string_method(C::class, 4);
-
-	classname_function(C::class);
+	final class E {
+		public static function foo(): void {
+			\string_function(D::class);
+			\string_function(\C::class);
+			\string_function(self::class);
+		}
+	}
 }

--- a/tests/add-fixmes/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/add-fixmes/ClassnameUsedAsString/asArgument/output.txt
@@ -1,21 +1,55 @@
-final class C {
-	public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
-	public function string_method(string $s, int $x): void {}
+namespace {
+	abstract class P {}
+
+	final class C extends P {
+		public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+		public function string_method(string $s, int $x): void {}
+
+		public function foo(): void {
+			/* HAKANA_FIXME[ClassnameUsedAsString] Using self in this position will lead to an implicit runtime conversion to string, please use "nameof self" instead */
+			$this->string_method(self::class, 4);
+			/* HAKANA_FIXME[ClassnameUsedAsString] Using static in this position will lead to an implicit runtime conversion to string, please use "nameof static" instead */
+			$this->string_method(static::class, 5);
+			/* HAKANA_FIXME[ClassnameUsedAsString] Using parent in this position will lead to an implicit runtime conversion to string, please use "nameof parent" instead */
+			$this->string_method(parent::class, 5);
+		}
+	}
+
+	function string_function(string $s): void {}
+
+	function classname_function(classname<C> $cls): void {}
+
+	function caller(): void {
+		$c = new C();
+		$int = 5;
+		/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+		C::static_string_method($int, C::class, 5.6);
+		/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+		string_function(C::class);
+		/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+		$c->string_method(C::class, 4);
+
+		/* HAKANA_FIXME[ClassnameUsedAsString] Using \N\E in this position will lead to an implicit runtime conversion to string, please use "nameof \N\E" instead */
+		string_function(\N\E::class);
+
+		/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+		$c->string_method(C::class, 4);
+
+		classname_function(C::class);
+	}
 }
 
-function string_function(string $s): void {}
+namespace N {
+	final class D {}
 
-function classname_function(classname<C> $cls): void {}
-
-function caller(): void {
-	$c = new C();
-	$int = 5;
-	/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
-	C::static_string_method($int, C::class, 5.6);
-	/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
-	string_function(C::class);
-	/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
-	$c->string_method(C::class, 4);
-
-	classname_function(C::class);
+	final class E {
+		public static function foo(): void {
+			/* HAKANA_FIXME[ClassnameUsedAsString] Using D in this position will lead to an implicit runtime conversion to string, please use "nameof D" instead */
+			\string_function(D::class);
+			/* HAKANA_FIXME[ClassnameUsedAsString] Using \C in this position will lead to an implicit runtime conversion to string, please use "nameof \C" instead */
+			\string_function(\C::class);
+			/* HAKANA_FIXME[ClassnameUsedAsString] Using self in this position will lead to an implicit runtime conversion to string, please use "nameof self" instead */
+			\string_function(self::class);
+		}
+	}
 }

--- a/tests/fix/ClassnameUsedAsString/asArgument/input.hack
+++ b/tests/fix/ClassnameUsedAsString/asArgument/input.hack
@@ -1,21 +1,45 @@
-final class C {
-    public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
-    public function string_method(string $s, int $x): void {}
+namespace {
+	abstract class P {}
+
+	final class C extends P {
+		public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+		public function string_method(string $s, int $x): void {}
+
+		public function foo(): void {
+			$this->string_method(self::class, 4);
+			$this->string_method(static::class, 5);
+			$this->string_method(parent::class, 5);
+		}
+	}
+
+	function string_function(string $s): void {}
+
+	function classname_function(classname<C> $cls): void {}
+
+	function caller(): void {
+		$c = new C();
+		$int = 5;
+		C::static_string_method($int, C::class, 5.6);
+		string_function(C::class);
+		$c->string_method(C::class, 4);
+
+		string_function(\N\E::class);
+
+		/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+		$c->string_method(C::class, 4);
+
+		classname_function(C::class);
+	}
 }
 
-function string_function(string $s): void {}
+namespace N {
+	final class D {}
 
-function classname_function(classname<C> $cls): void {}
-
-function caller(): void {
-    $c = new C();
-    $int = 5;
-    C::static_string_method($int, C::class, 5.6);
-    string_function(C::class);
-    $c->string_method(C::class, 4);
-
-    /* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
-	$c->string_method(C::class, 4);
-
-    classname_function(C::class);
+	final class E {
+		public static function foo(): void {
+			\string_function(D::class);
+			\string_function(\C::class);
+			\string_function(self::class);
+		}
+	}
 }

--- a/tests/fix/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/fix/ClassnameUsedAsString/asArgument/output.txt
@@ -1,21 +1,45 @@
-final class C {
-    public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
-    public function string_method(string $s, int $x): void {}
+namespace {
+	abstract class P {}
+
+	final class C extends P {
+		public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+		public function string_method(string $s, int $x): void {}
+
+		public function foo(): void {
+			$this->string_method(nameof self, 4);
+			$this->string_method(nameof static, 5);
+			$this->string_method(nameof parent, 5);
+		}
+	}
+
+	function string_function(string $s): void {}
+
+	function classname_function(classname<C> $cls): void {}
+
+	function caller(): void {
+		$c = new C();
+		$int = 5;
+		C::static_string_method($int, nameof C, 5.6);
+		string_function(nameof C);
+		$c->string_method(nameof C, 4);
+
+		string_function(nameof \N\E);
+
+		/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+		$c->string_method(C::class, 4);
+
+		classname_function(C::class);
+	}
 }
 
-function string_function(string $s): void {}
+namespace N {
+	final class D {}
 
-function classname_function(classname<C> $cls): void {}
-
-function caller(): void {
-    $c = new C();
-    $int = 5;
-    C::static_string_method($int, nameof \C, 5.6);
-    string_function(nameof \C);
-    $c->string_method(nameof \C, 4);
-
-    /* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
-	$c->string_method(C::class, 4);
-
-    classname_function(C::class);
+	final class E {
+		public static function foo(): void {
+			\string_function(nameof D);
+			\string_function(nameof \C);
+			\string_function(nameof self);
+		}
+	}
 }

--- a/tests/inference/ClassnameUsedAsString/asArgument/input.hack
+++ b/tests/inference/ClassnameUsedAsString/asArgument/input.hack
@@ -1,21 +1,45 @@
-final class C {
-	public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
-	public function string_method(string $s, int $x): void {}
+namespace {
+	abstract class P {}
+
+	final class C extends P {
+		public static function static_string_method(int $ignored, string $s, mixed $foo): void {}
+		public function string_method(string $s, int $x): void {}
+
+		public function foo(): void {
+			$this->string_method(self::class, 4);
+			$this->string_method(static::class, 5);
+			$this->string_method(parent::class, 5);
+		}
+	}
+
+	function string_function(string $s): void {}
+
+	function classname_function(classname<C> $cls): void {}
+
+	function caller(): void {
+		$c = new C();
+		$int = 5;
+		C::static_string_method($int, C::class, 5.6);
+		string_function(C::class);
+		$c->string_method(C::class, 4);
+
+		string_function(\N\E::class);
+
+		/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
+		$c->string_method(C::class, 4);
+
+		classname_function(C::class);
+	}
 }
 
-function string_function(string $s): void {}
+namespace N {
+	final class D {}
 
-function classname_function(classname<C> $cls): void {}
-
-function caller(): void {
-	$c = new C();
-	$int = 5;
-	C::static_string_method($int, C::class, 5.6);
-	string_function(C::class);
-	$c->string_method(C::class, 4);
-
-	/* HAKANA_FIXME[ClassnameUsedAsString] Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead */
-	$c->string_method(C::class, 4);
-
-	classname_function(C::class);
+	final class E {
+		public static function foo(): void {
+			\string_function(D::class);
+			\string_function(\C::class);
+			\string_function(self::class);
+		}
+	}
 }

--- a/tests/inference/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/inference/ClassnameUsedAsString/asArgument/output.txt
@@ -1,3 +1,10 @@
-ERROR: ClassnameUsedAsString - input.hack:13:2 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
-ERROR: ClassnameUsedAsString - input.hack:14:2 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
-ERROR: ClassnameUsedAsString - input.hack:15:2 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
+ERROR: ClassnameUsedAsString - input.hack:9:4 - Using self in this position will lead to an implicit runtime conversion to string, please use "nameof self" instead
+ERROR: ClassnameUsedAsString - input.hack:10:4 - Using static in this position will lead to an implicit runtime conversion to string, please use "nameof static" instead
+ERROR: ClassnameUsedAsString - input.hack:11:4 - Using parent in this position will lead to an implicit runtime conversion to string, please use "nameof parent" instead
+ERROR: ClassnameUsedAsString - input.hack:22:3 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
+ERROR: ClassnameUsedAsString - input.hack:23:3 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
+ERROR: ClassnameUsedAsString - input.hack:24:3 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
+ERROR: ClassnameUsedAsString - input.hack:26:3 - Using \N\E in this position will lead to an implicit runtime conversion to string, please use "nameof \N\E" instead
+ERROR: ClassnameUsedAsString - input.hack:40:4 - Using D in this position will lead to an implicit runtime conversion to string, please use "nameof D" instead
+ERROR: ClassnameUsedAsString - input.hack:41:4 - Using \C in this position will lead to an implicit runtime conversion to string, please use "nameof \C" instead
+ERROR: ClassnameUsedAsString - input.hack:42:4 - Using self in this position will lead to an implicit runtime conversion to string, please use "nameof self" instead


### PR DESCRIPTION
In https://github.com/slackhq/hakana/pull/45, @muglug suggested we implement a better classname resolution mechanism for the ClassnameUsedAsString autofix. I did not see one at the time, but it turns out there's a simple one: we can take the class constant expression that forms `C::class` and simply get the literal class name string from it, which is what we already do when determining the literal string value of a `nameof` expression during expression analysis.

The main benefit of this is that not only does this automatically return a correctly qualified class name string, it also correctly handles references like self/static/parent, since it just returns the literal. The latter currently get resolved by the autofix, so e.g. static::class would end up being autofixed to whatever `static` was referring to, which is undesired.

Add tests for the behavior.