### PR TITLE
Exempt variables holding a `classname` from `ClassnameUsedAsString`

### DIFF
--- a/tests/add-fixmes/ClassnameUsedAsString/asArgument/input.hack
+++ b/tests/add-fixmes/ClassnameUsedAsString/asArgument/input.hack
@@ -29,6 +29,9 @@ namespace {
 		$c->string_method(C::class, 4);
 
 		classname_function(C::class);
+
+		$cls_var = C::class;
+		string_function($cls_var);
 	}
 }
 

--- a/tests/add-fixmes/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/add-fixmes/ClassnameUsedAsString/asArgument/output.txt
@@ -36,6 +36,9 @@ namespace {
 		$c->string_method(C::class, 4);
 
 		classname_function(C::class);
+
+		$cls_var = C::class;
+		string_function($cls_var);
 	}
 }
 

--- a/tests/fix/ClassnameUsedAsString/asArgument/input.hack
+++ b/tests/fix/ClassnameUsedAsString/asArgument/input.hack
@@ -29,6 +29,9 @@ namespace {
 		$c->string_method(C::class, 4);
 
 		classname_function(C::class);
+
+		$cls_var = C::class;
+		string_function($cls_var);
 	}
 }
 

--- a/tests/fix/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/fix/ClassnameUsedAsString/asArgument/output.txt
@@ -29,6 +29,9 @@ namespace {
 		$c->string_method(C::class, 4);
 
 		classname_function(C::class);
+
+		$cls_var = C::class;
+		string_function($cls_var);
 	}
 }
 

--- a/tests/inference/ClassnameUsedAsString/asArgument/input.hack
+++ b/tests/inference/ClassnameUsedAsString/asArgument/input.hack
@@ -29,6 +29,9 @@ namespace {
 		$c->string_method(C::class, 4);
 
 		classname_function(C::class);
+
+		$cls_var = C::class;
+		string_function($cls_var);
 	}
 }
 

--- a/tests/inference/ClassnameUsedAsString/asArgument/output.txt
+++ b/tests/inference/ClassnameUsedAsString/asArgument/output.txt
@@ -5,6 +5,6 @@ ERROR: ClassnameUsedAsString - input.hack:22:3 - Using C in this position will l
 ERROR: ClassnameUsedAsString - input.hack:23:3 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
 ERROR: ClassnameUsedAsString - input.hack:24:3 - Using C in this position will lead to an implicit runtime conversion to string, please use "nameof C" instead
 ERROR: ClassnameUsedAsString - input.hack:26:3 - Using \N\E in this position will lead to an implicit runtime conversion to string, please use "nameof \N\E" instead
-ERROR: ClassnameUsedAsString - input.hack:40:4 - Using D in this position will lead to an implicit runtime conversion to string, please use "nameof D" instead
-ERROR: ClassnameUsedAsString - input.hack:41:4 - Using \C in this position will lead to an implicit runtime conversion to string, please use "nameof \C" instead
-ERROR: ClassnameUsedAsString - input.hack:42:4 - Using self in this position will lead to an implicit runtime conversion to string, please use "nameof self" instead
+ERROR: ClassnameUsedAsString - input.hack:43:4 - Using D in this position will lead to an implicit runtime conversion to string, please use "nameof D" instead
+ERROR: ClassnameUsedAsString - input.hack:44:4 - Using \C in this position will lead to an implicit runtime conversion to string, please use "nameof \C" instead
+ERROR: ClassnameUsedAsString - input.hack:45:4 - Using self in this position will lead to an implicit runtime conversion to string, please use "nameof self" instead


### PR DESCRIPTION
The Hack typechecker requires the RHS argument of `nameof` to be a classname literal, such as `C` or `self`; `nameof $some_var_holding_classname` does not typecheck. So, keep variables holding a classname untouched even when they are used in a string context, as they do not cause type errors anyways.