### PR TITLE
Prepare for Rust 2024's `if let` rescoping

### DIFF
--- a/src/analyzer/expr/binop/assignment_analyzer.rs
+++ b/src/analyzer/expr/binop/assignment_analyzer.rs
@@ -710,23 +710,21 @@ fn handle_assignment_with_boolean_logic(
             IndexMap::from([(Assertion::Falsy.to_hash(), Assertion::Falsy)]),
         );
 
-        let assignment_clauses = if let Ok(assignment_clauses) =
-            hakana_algebra::combine_ored_clauses(
-                vec![Clause::new(
-                    possibilities,
-                    var_object_id,
-                    var_object_id,
-                    None,
-                    None,
-                    None,
-                )],
-                right_clauses.into_iter().map(|v| (*v).clone()).collect(),
-                cond_object_id,
-            ) {
+        let assignment_clauses = hakana_algebra::combine_ored_clauses(
+            vec![Clause::new(
+                possibilities,
+                var_object_id,
+                var_object_id,
+                None,
+                None,
+                None,
+            )],
+            right_clauses.into_iter().map(|v| (*v).clone()).collect(),
+            cond_object_id,
+        )
+        .map_or(vec![], |assignment_clauses| {
             assignment_clauses.into_iter().map(Rc::new).collect()
-        } else {
-            vec![]
-        };
+        });
 
         context.clauses.extend(assignment_clauses);
     }

--- a/src/analyzer/expr/ternary_analyzer.rs
+++ b/src/analyzer/expr/ternary_analyzer.rs
@@ -167,10 +167,8 @@ pub(crate) fn analyze(
 
     if_scope.reasonable_clauses = ternary_clauses.into_iter().map(Rc::new).collect();
 
-    if let Ok(negated_if_clauses) = hakana_algebra::negate_formula(if_clauses) {
-        if_scope.negated_clauses = negated_if_clauses;
-    } else {
-        if_scope.negated_clauses = formula_generator::get_formula(
+    if_scope.negated_clauses = hakana_algebra::negate_formula(if_clauses).unwrap_or_else(|_| {
+        formula_generator::get_formula(
             cond_object_id,
             cond_object_id,
             &aast::Expr(
@@ -183,8 +181,8 @@ pub(crate) fn analyze(
             false,
             false,
         )
-        .unwrap_or_default();
-    }
+        .unwrap_or_default()
+    });
 
     let negated_clauses = hakana_algebra::simplify_cnf({
         let mut c = context.clauses.iter().map(|v| &**v).collect::<Vec<_>>();

--- a/src/analyzer/scope/mod.rs
+++ b/src/analyzer/scope/mod.rs
@@ -503,26 +503,24 @@ impl BlockContext {
 }
 
 fn should_keep_clause(clause: &Rc<Clause>, remove_var_id: &str, new_type: Option<&TUnion>) -> bool {
-    if let Some(possibilities) = clause
+    clause
         .possibilities
         .get(&ClauseKey::Name(VarName::new(remove_var_id.to_string())))
-    {
-        if possibilities.len() == 1 {
-            let assertion = possibilities.values().next().unwrap();
+        .map_or(true, |possibilities| {
+            if possibilities.len() == 1 {
+                let assertion = possibilities.values().next().unwrap();
 
-            if let Assertion::IsType(assertion_type) = assertion {
-                if let Some(new_type) = new_type {
-                    if new_type.is_single() {
-                        return new_type.get_single() == assertion_type;
+                if let Assertion::IsType(assertion_type) = assertion {
+                    if let Some(new_type) = new_type {
+                        if new_type.is_single() {
+                            return new_type.get_single() == assertion_type;
+                        }
                     }
                 }
             }
-        }
 
-        false
-    } else {
-        true
-    }
+            false
+        })
 }
 
 #[inline]

--- a/src/analyzer/stmt/ifelse_analyzer.rs
+++ b/src/analyzer/stmt/ifelse_analyzer.rs
@@ -169,10 +169,8 @@ pub(crate) fn analyze(
         .reasonable_clauses
         .clone_from(&if_body_context.clauses);
 
-    if let Ok(negated_if_clauses) = hakana_algebra::negate_formula(if_clauses) {
-        if_scope.negated_clauses = negated_if_clauses;
-    } else {
-        if_scope.negated_clauses = formula_generator::get_formula(
+    if_scope.negated_clauses = hakana_algebra::negate_formula(if_clauses).unwrap_or_else(|_| {
+        formula_generator::get_formula(
             cond_object_id,
             cond_object_id,
             &aast::Expr(
@@ -185,8 +183,8 @@ pub(crate) fn analyze(
             false,
             false,
         )
-        .unwrap_or_default();
-    }
+        .unwrap_or_default()
+    });
 
     let (new_negated_types, _) = hakana_algebra::get_truths_from_formula(
         hakana_algebra::simplify_cnf({

--- a/src/analyzer/stmt/switch_case_analyzer.rs
+++ b/src/analyzer/stmt/switch_case_analyzer.rs
@@ -423,31 +423,28 @@ fn extend_switch_negated_clauses(
     case_clauses_for_negation: Vec<Clause>,
     case_equality_expr: &aast::Expr<(), ()>,
 ) {
-    let negated_case_clauses = if let Ok(negated_case_clauses) =
-        hakana_algebra::negate_formula(case_clauses_for_negation)
-    {
-        negated_case_clauses
-    } else {
-        let case_equality_expr_id = (
-            case_equality_expr.pos().start_offset() as u32,
-            case_equality_expr.pos().end_offset() as u32,
-        );
+    let negated_case_clauses = hakana_algebra::negate_formula(case_clauses_for_negation)
+        .unwrap_or_else(|_| {
+            let case_equality_expr_id = (
+                case_equality_expr.pos().start_offset() as u32,
+                case_equality_expr.pos().end_offset() as u32,
+            );
 
-        formula_generator::get_formula(
-            case_equality_expr_id,
-            case_equality_expr_id,
-            &aast::Expr(
-                (),
-                case_equality_expr.pos().clone(),
-                aast::Expr_::Unop(Box::new((ast_defs::Uop::Unot, case_equality_expr.clone()))),
-            ),
-            assertion_context,
-            analysis_data,
-            false,
-            false,
-        )
-        .unwrap_or_default()
-    };
+            formula_generator::get_formula(
+                case_equality_expr_id,
+                case_equality_expr_id,
+                &aast::Expr(
+                    (),
+                    case_equality_expr.pos().clone(),
+                    aast::Expr_::Unop(Box::new((ast_defs::Uop::Unot, case_equality_expr.clone()))),
+                ),
+                assertion_context,
+                analysis_data,
+                false,
+                false,
+            )
+            .unwrap_or_default()
+        });
 
     switch_scope.negated_clauses.extend(negated_case_clauses);
 }

--- a/src/orchestrator/populator.rs
+++ b/src/orchestrator/populator.rs
@@ -370,10 +370,9 @@ fn populate_classlike_storage(
     symbol_references: &mut SymbolReferences,
     safe_symbols: &FxHashSet<StrId>,
 ) {
-    let mut storage = if let Some(storage) = codebase.classlike_infos.remove(classlike_name) {
-        storage
-    } else {
-        return;
+    let mut storage = match codebase.classlike_infos.remove(classlike_name) {
+        Some(storage) => storage,
+        _ => return,
     };
 
     if storage.is_populated {


### PR DESCRIPTION
Rust 2024 changes the lifetime of temporary values in the scrutinee of `if let` blocks.[1] The autofix that runs as part of `cargo fix` is conservative and will mangle any affected `if let` blocks into equivalent `match` expressions.

Most of the affected blocks in Hakana can actually be better expressed by chaining `.map_or` or `.unwrap_or_else`, which is less verbose. Update these accordingly.

[1] https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html