### PR TITLE
Migrate to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-default"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 [[bin]]

--- a/docs/customizing_hakana.md
+++ b/docs/customizing_hakana.md
@@ -12,7 +12,7 @@ Cargo.toml:
 [package]
 name = "hakana-custom"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 [dependencies]

--- a/src/aast_utils/Cargo.toml
+++ b/src/aast_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-aast-helper"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 path = "lib.rs"

--- a/src/algebra/Cargo.toml
+++ b/src/algebra/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-algebra"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 md5 = "0.7.0"

--- a/src/algebra/lib.rs
+++ b/src/algebra/lib.rs
@@ -594,7 +594,7 @@ pub fn negate_formula(mut clauses: Vec<Clause>) -> Result<Vec<Clause>, String> {
     if clauses.is_empty() {
         let mut rng = rand::thread_rng();
 
-        let n2: u32 = rng.gen();
+        let n2: u32 = rng.r#gen();
         return Ok(vec![Clause::new(
             BTreeMap::new(),
             (n2, n2),
@@ -610,7 +610,7 @@ pub fn negate_formula(mut clauses: Vec<Clause>) -> Result<Vec<Clause>, String> {
     if impossible_clauses.is_empty() {
         let mut rng = rand::thread_rng();
 
-        let n2: u32 = rng.gen();
+        let n2: u32 = rng.r#gen();
         return Ok(vec![Clause::new(
             BTreeMap::new(),
             (n2, n2),
@@ -626,7 +626,7 @@ pub fn negate_formula(mut clauses: Vec<Clause>) -> Result<Vec<Clause>, String> {
     if negated.is_empty() {
         let mut rng = rand::thread_rng();
 
-        let n2: u32 = rng.gen();
+        let n2: u32 = rng.r#gen();
         return Ok(vec![Clause::new(
             BTreeMap::new(),
             (n2, n2),

--- a/src/analyzer/Cargo.toml
+++ b/src/analyzer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-analyzer"
 version = "0.1.16"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 regex = "1"

--- a/src/analyzer/expr/call/existing_atomic_method_call_analyzer.rs
+++ b/src/analyzer/expr/call/existing_atomic_method_call_analyzer.rs
@@ -404,7 +404,7 @@ fn handle_shapes_static_method(
 
                         for atomic_type in new_type.types.iter_mut() {
                             if let TAtomic::TDict(TDict {
-                                known_items: Some(ref mut known_items),
+                                known_items: Some(known_items),
                                 ..
                             }) = atomic_type
                             {

--- a/src/analyzer/reconciler/assertion_reconciler.rs
+++ b/src/analyzer/reconciler/assertion_reconciler.rs
@@ -858,8 +858,8 @@ pub(crate) fn intersect_atomic_with_atomic(
             }
         }
         (
-            TAtomic::TGenericParam { ref as_type, .. }
-            | TAtomic::TClassTypeConstant { ref as_type, .. },
+            TAtomic::TGenericParam { as_type, .. }
+            | TAtomic::TClassTypeConstant { as_type, .. },
             TAtomic::TMixedWithFlags(_, _, _, true),
         ) => {
             let type_1_atomic = type_1_atomic.replace_template_extends(

--- a/src/analyzer/reconciler/mod.rs
+++ b/src/analyzer/reconciler/mod.rs
@@ -404,7 +404,7 @@ fn adjust_array_type(
 
         match base_atomic_type {
             TAtomic::TDict(TDict {
-                ref mut known_items,
+                known_items,
                 ..
             }) => {
                 let dictkey = if has_string_offset {
@@ -426,7 +426,7 @@ fn adjust_array_type(
                 }
             }
             TAtomic::TVec(TVec {
-                ref mut known_items,
+                known_items,
                 ..
             }) => {
                 if let Ok(arraykey_offset) = arraykey_offset.parse::<usize>() {

--- a/src/analyzer/reconciler/simple_negated_assertion_reconciler.rs
+++ b/src/analyzer/reconciler/simple_negated_assertion_reconciler.rs
@@ -1730,7 +1730,7 @@ fn reconcile_empty_countable(
                     acceptable_types.push(new_atomic);
                 }
             }
-            TAtomic::TGenericParam { ref as_type, .. } => {
+            TAtomic::TGenericParam { as_type, .. } => {
                 did_remove_type = true;
                 if !as_type.is_mixed() {
                     let atomic = atomic.replace_template_extends(reconcile_empty_countable(

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-cli"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 hakana-orchestrator = { path = "../orchestrator" }

--- a/src/cli/lib.rs
+++ b/src/cli/lib.rs
@@ -650,7 +650,7 @@ pub fn init(
                     Some(val.parse::<u64>().unwrap())
                 } else {
                     let mut rng = rand::thread_rng();
-                    Some(rng.gen())
+                    Some(rng.r#gen())
                 }
             } else {
                 None
@@ -1664,7 +1664,7 @@ fn replace_contents(
             .extend(insertion.into_iter().rev().map(Replacement::Substitute));
     }
 
-    for ((mut start, mut end), replacements) in replacements.iter().rev() {
+    for (&(mut start, mut end), replacements) in replacements.iter().rev() {
         for replacement in replacements {
             match replacement {
                 Replacement::Remove => {

--- a/src/code_info/Cargo.toml
+++ b/src/code_info/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-code-info"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 path = "lib.rs"

--- a/src/code_info/t_atomic.rs
+++ b/src/code_info/t_atomic.rs
@@ -1397,11 +1397,11 @@ impl TAtomic {
 
     pub fn add_intersection_type(&mut self, atomic: TAtomic) {
         if let TAtomic::TNamedObject {
-            ref mut extra_types,
+            extra_types,
             ..
         }
         | TAtomic::TGenericParam {
-            ref mut extra_types,
+            extra_types,
             ..
         } = self
         {
@@ -1480,7 +1480,7 @@ impl TAtomic {
     pub fn remove_placeholders(&mut self) {
         match self {
             TAtomic::TDict(TDict {
-                params: Some(ref mut params),
+                params: Some(params),
                 ..
             }) => {
                 if let TAtomic::TPlaceholder = params.0.get_single() {
@@ -1500,7 +1500,7 @@ impl TAtomic {
                 }
             }
             TAtomic::TKeyset {
-                ref mut type_param, ..
+                type_param, ..
             } => {
                 if let TAtomic::TPlaceholder = type_param.get_single() {
                     *type_param =
@@ -1508,8 +1508,8 @@ impl TAtomic {
                 }
             }
             TAtomic::TNamedObject {
-                ref mut name,
-                type_params: Some(ref mut type_params),
+                name,
+                type_params: Some(type_params),
                 ..
             } => {
                 if name == &StrId::KEYED_CONTAINER
@@ -1797,8 +1797,8 @@ pub fn populate_atomic_type(
 ) {
     match t_atomic {
         TAtomic::TDict(TDict {
-            ref mut params,
-            ref mut known_items,
+            params,
+            known_items,
             ..
         }) => {
             if let Some(params) = params {
@@ -1830,7 +1830,7 @@ pub fn populate_atomic_type(
                 }
             }
         }
-        TAtomic::TClosure(ref mut closure) => {
+        TAtomic::TClosure(closure) => {
             if let Some(ref mut return_type) = closure.return_type {
                 populate_union_type(
                     return_type,
@@ -1854,7 +1854,7 @@ pub fn populate_atomic_type(
             }
         }
         TAtomic::TKeyset {
-            ref mut type_param, ..
+            type_param, ..
         } => {
             populate_union_type(
                 type_param,
@@ -1865,8 +1865,8 @@ pub fn populate_atomic_type(
             );
         }
         TAtomic::TVec(TVec {
-            ref mut type_param,
-            ref mut known_items,
+            type_param,
+            known_items,
             ..
         }) => {
             populate_union_type(
@@ -1889,7 +1889,7 @@ pub fn populate_atomic_type(
                 }
             }
         }
-        TAtomic::TAwaitable { ref mut value, .. } => {
+        TAtomic::TAwaitable { value, .. } => {
             populate_union_type(
                 value,
                 codebase_symbols,
@@ -1900,12 +1900,12 @@ pub fn populate_atomic_type(
         }
         TAtomic::TNamedObject {
             name,
-            ref mut type_params,
+            type_params,
             ..
         }
         | TAtomic::TTypeAlias {
             name,
-            ref mut type_params,
+            type_params,
             ..
         } => {
             if let Some(type_params) = type_params {
@@ -1935,7 +1935,7 @@ pub fn populate_atomic_type(
             ReferenceSource::ClasslikeMember(in_signature, a, b) => symbol_references
                 .add_class_member_reference_to_symbol((*a, *b), *name, *in_signature),
         },
-        TAtomic::TReference {
+        &mut TAtomic::TReference {
             ref name,
             ref mut type_params,
         } => {
@@ -2004,7 +2004,7 @@ pub fn populate_atomic_type(
                 };
             }
         }
-        TAtomic::TMemberReference {
+        &mut TAtomic::TMemberReference {
             ref classlike_name,
             ref member_name,
         } => {
@@ -2051,7 +2051,7 @@ pub fn populate_atomic_type(
             );
         }
         TAtomic::TGenericParam {
-            ref mut as_type, ..
+            as_type, ..
         } => {
             populate_union_type(
                 as_type,

--- a/src/code_info/t_union.rs
+++ b/src/code_info/t_union.rs
@@ -781,13 +781,13 @@ pub fn populate_union_type(
     let types = &mut t_union.types;
 
     for atomic in types.iter_mut() {
-        if let TAtomic::TClassname { ref mut as_type }
-        | TAtomic::TTypename { ref mut as_type }
+        if let TAtomic::TClassname { as_type }
+        | TAtomic::TTypename { as_type }
         | TAtomic::TGenericClassname {
-            ref mut as_type, ..
+            as_type, ..
         }
         | TAtomic::TGenericTypename {
-            ref mut as_type, ..
+            as_type, ..
         } = atomic
         {
             let mut new_as_type = (**as_type).clone();

--- a/src/code_info/ttype/template/standin_type_replacer.rs
+++ b/src/code_info/ttype/template/standin_type_replacer.rs
@@ -319,7 +319,7 @@ fn replace_atomic<'a>(
             ref mut params,
             ..
         }) => {
-            if let Some(ref mut known_items) = known_items {
+            if let Some(known_items) = known_items {
                 for (offset, (_, property)) in known_items {
                     let input_type_param = if let Some(TAtomic::TDict(TDict {
                         known_items: Some(ref input_known_items),
@@ -526,7 +526,7 @@ fn replace_atomic<'a>(
             remapped_params,
             ..
         } => {
-            if let Some(ref mut type_params) = type_params {
+            if let Some(type_params) = type_params {
                 let mapped_type_params = if let Some(TAtomic::TNamedObject {
                     type_params: Some(_),
                     ..
@@ -548,7 +548,7 @@ fn replace_atomic<'a>(
                     let input_type_param = match &input_type {
                         Some(input_inner) => match input_inner {
                             TAtomic::TNamedObject {
-                                type_params: Some(ref input_type_parts),
+                                type_params: Some(input_type_parts),
                                 ..
                             } => input_type_parts.get(offset).cloned(),
                             TAtomic::TDict(TDict { .. })
@@ -622,7 +622,7 @@ fn replace_atomic<'a>(
             ref name,
             ..
         } => {
-            if let Some(ref mut type_params) = type_params {
+            if let Some(type_params) = type_params {
                 let mapped_type_params = if let Some(TAtomic::TTypeAlias {
                     type_params: Some(input_type_params),
                     name: input_name,

--- a/src/code_info/ttype/type_combiner.rs
+++ b/src/code_info/ttype/type_combiner.rs
@@ -809,7 +809,7 @@ fn scrape_type_properties(
 
         let object_type_key = get_combiner_key(fq_class_name, &type_params, codebase);
 
-        if let Some((_, ref existing_type_params)) =
+        if let Some((_, existing_type_params)) =
             combination.object_type_params.get(&object_type_key)
         {
             let mut new_type_params = Vec::new();

--- a/src/code_info/ttype/type_expander.rs
+++ b/src/code_info/ttype/type_expander.rs
@@ -134,9 +134,9 @@ fn expand_atomic(
     *cost += 1;
 
     if let TAtomic::TDict(TDict {
-        ref mut known_items,
-        ref mut params,
-        ref mut shape_name,
+        known_items,
+        params,
+        shape_name,
         ..
     }) = return_type_part
     {
@@ -179,8 +179,8 @@ fn expand_atomic(
             *shape_name = None;
         }
     } else if let TAtomic::TVec(TVec {
-        ref mut known_items,
-        ref mut type_param,
+        known_items,
+        type_param,
         ..
     }) = return_type_part
     {
@@ -210,7 +210,7 @@ fn expand_atomic(
 
         return;
     } else if let TAtomic::TKeyset {
-        ref mut type_param, ..
+        type_param, ..
     } = return_type_part
     {
         expand_union(
@@ -224,7 +224,7 @@ fn expand_atomic(
         );
 
         return;
-    } else if let TAtomic::TAwaitable { ref mut value } = return_type_part {
+    } else if let TAtomic::TAwaitable { value } = return_type_part {
         expand_union(
             codebase,
             interner,
@@ -237,9 +237,9 @@ fn expand_atomic(
 
         return;
     } else if let TAtomic::TNamedObject {
-        ref mut name,
-        ref mut type_params,
-        ref mut is_this,
+        name,
+        type_params,
+        is_this,
         ..
     } = return_type_part
     {
@@ -288,7 +288,7 @@ fn expand_atomic(
         }
 
         return;
-    } else if let TAtomic::TClosure(ref mut closure) = return_type_part {
+    } else if let TAtomic::TClosure(closure) = return_type_part {
         if let Some(ref mut return_type) = closure.return_type {
             expand_union(
                 codebase,
@@ -316,7 +316,7 @@ fn expand_atomic(
         }
     } else if let TAtomic::TGenericParam {
         param_name,
-        ref mut as_type,
+        as_type,
         ..
     } = return_type_part
     {
@@ -340,10 +340,10 @@ fn expand_atomic(
 
         return;
     } else if let TAtomic::TClassname {
-        ref mut as_type, ..
+        as_type, ..
     }
     | TAtomic::TTypename {
-        ref mut as_type, ..
+        as_type, ..
     } = return_type_part
     {
         let mut atomic_return_type_parts = vec![];
@@ -365,13 +365,13 @@ fn expand_atomic(
         }
 
         return;
-    } else if let TAtomic::TEnumLiteralCase {
+    } else if let &mut TAtomic::TEnumLiteralCase {
         ref enum_name,
         ref mut as_type,
         ref mut underlying_type,
         ..
     }
-    | TAtomic::TEnum {
+    | &mut TAtomic::TEnum {
         name: ref enum_name,
         ref mut as_type,
         ref mut underlying_type,
@@ -409,7 +409,7 @@ fn expand_atomic(
         }
 
         return;
-    } else if let TAtomic::TMemberReference {
+    } else if let &mut TAtomic::TMemberReference {
         ref classlike_name,
         ref member_name,
     } = return_type_part

--- a/src/code_info_builder/Cargo.toml
+++ b/src/code_info_builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-reflector"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 hakana-code-info = { path = "../code_info" }

--- a/src/executable_code_finder/Cargo.toml
+++ b/src/executable_code_finder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "executable-finder"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 hakana-analyzer = { path = "../analyzer" }

--- a/src/js_interop/Cargo.toml
+++ b/src/js_interop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "js_interop"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/language_server/Cargo.toml
+++ b/src/language_server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-language-server"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 hakana-orchestrator = { path = "../orchestrator" }

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-logger"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 path = "lib.rs"

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-orchestrator"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 hakana-reflector = { path = "../code_info_builder" }

--- a/src/str/Cargo.toml
+++ b/src/str/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-str"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
Changes are from `cargo fix --edition --workspace` plus setting `edition = 2024`.