### PR TITLE
ImplicitAsioJoin: Ensure replacement candidate can be invoked

### DIFF
--- a/tests/fix/ImplicitAsioJoin/instanceMethodVisibility/input.hack
+++ b/tests/fix/ImplicitAsioJoin/instanceMethodVisibility/input.hack
@@ -1,0 +1,47 @@
+namespace {
+    abstract class A {
+        protected async function prot_async_method(): Awaitable<int> {
+            await \HH\Asio\later();
+            return 42;
+        }
+
+        public function sync_method(): int {
+            return \HH\Asio\join($this->prot_async_method());
+        }
+    }
+
+    final class B extends A {
+        public async function foo(): Awaitable<int> {
+            await \HH\Asio\later();
+            return $this->sync_method() + C::sync_method();
+        }
+
+        public function sync_foo(): int {
+            return \HH\Asio\join($this->foo());
+        }
+    }
+
+    final class C {
+        private static async function priv_async_method(): Awaitable<int> {
+            await \HH\Asio\later();
+            return 42;
+        }
+
+        public static function sync_method(): int {
+            return \HH\Asio\join(self::priv_async_method());
+        }
+
+        public static async function sync_caller(): Awaitable<int> {
+            await \HH\Asio\later();
+            return rand() + self::sync_method();
+        }
+    }
+
+    async function from_function(): Awaitable<int> {
+        await \HH\Asio\later();
+
+        $b = new B();
+
+        return $b->sync_method() + $b->sync_foo() + C::sync_method();
+    }
+}

--- a/tests/fix/ImplicitAsioJoin/instanceMethodVisibility/output.txt
+++ b/tests/fix/ImplicitAsioJoin/instanceMethodVisibility/output.txt
@@ -1,0 +1,47 @@
+namespace {
+    abstract class A {
+        protected async function prot_async_method(): Awaitable<int> {
+            await \HH\Asio\later();
+            return 42;
+        }
+
+        public function sync_method(): int {
+            return \HH\Asio\join($this->prot_async_method());
+        }
+    }
+
+    final class B extends A {
+        public async function foo(): Awaitable<int> {
+            await \HH\Asio\later();
+            return (await $this->prot_async_method()) + C::sync_method();
+        }
+
+        public function sync_foo(): int {
+            return \HH\Asio\join($this->foo());
+        }
+    }
+
+    final class C {
+        private static async function priv_async_method(): Awaitable<int> {
+            await \HH\Asio\later();
+            return 42;
+        }
+
+        public static function sync_method(): int {
+            return \HH\Asio\join(self::priv_async_method());
+        }
+
+        public static async function sync_caller(): Awaitable<int> {
+            await \HH\Asio\later();
+            return rand() + await self::priv_async_method();
+        }
+    }
+
+    async function from_function(): Awaitable<int> {
+        await \HH\Asio\later();
+
+        $b = new B();
+
+        return $b->sync_method() + (await $b->foo()) + C::sync_method();
+    }
+}

--- a/tests/inference/ImplicitAsioJoin/instanceMethodVisibility/input.hack
+++ b/tests/inference/ImplicitAsioJoin/instanceMethodVisibility/input.hack
@@ -1,0 +1,47 @@
+namespace {
+    abstract class A {
+        protected async function prot_async_method(): Awaitable<int> {
+            await \HH\Asio\later();
+            return 42;
+        }
+
+        public function sync_method(): int {
+            return \HH\Asio\join($this->prot_async_method());
+        }
+    }
+
+    final class B extends A {
+        public async function foo(): Awaitable<int> {
+            await \HH\Asio\later();
+            return $this->sync_method() + C::sync_method();
+        }
+
+        public function sync_foo(): int {
+            return \HH\Asio\join($this->foo());
+        }
+    }
+
+    final class C {
+        private static async function priv_async_method(): Awaitable<int> {
+            await \HH\Asio\later();
+            return 42;
+        }
+
+        public static function sync_method(): int {
+            return \HH\Asio\join(self::priv_async_method());
+        }
+
+        public static async function sync_caller(): Awaitable<int> {
+            await \HH\Asio\later();
+            return rand() + self::sync_method();
+        }
+    }
+
+    async function from_function(): Awaitable<int> {
+        await \HH\Asio\later();
+
+        $b = new B();
+
+        return $b->sync_method() + $b->sync_foo() + C::sync_method();
+    }
+}

--- a/tests/inference/ImplicitAsioJoin/instanceMethodVisibility/output.txt
+++ b/tests/inference/ImplicitAsioJoin/instanceMethodVisibility/output.txt
@@ -1,0 +1,6 @@
+ERROR: ImplicitAsioJoin - input.hack:16:20 - Call to a method B::sync_method that just wraps an async version A::prot_async_method
+ERROR: ImplicitAsioJoin - input.hack:16:43 - Call to a method C::sync_method that just wraps an async version C::priv_async_method
+ERROR: ImplicitAsioJoin - input.hack:36:29 - Call to a method C::sync_method that just wraps an async version self::priv_async_method
+ERROR: ImplicitAsioJoin - input.hack:45:16 - Call to a method B::sync_method that just wraps an async version A::prot_async_method
+ERROR: ImplicitAsioJoin - input.hack:45:36 - Call to a method B::sync_foo that just wraps an async version B::foo
+ERROR: ImplicitAsioJoin - input.hack:45:53 - Call to a method C::sync_method that just wraps an async version C::priv_async_method


### PR DESCRIPTION
When checking instance methods, the async candidate method proposed by `ImplicitAsioJoin` may not be callable from the context where its sync equivalent is being used, e.g. because it is private. Add appropriate access checks so that we don't emit invalid code during an autofix, but raise the issue nonetheless so that developers can determine whether to refactor affected code or suppress the issue.