### PR TITLE
Fix and run Rust unit tests in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ on:
     paths: ['src/**', 'tests/**', 'third-party/**', 'Cargo.toml', 'build.rs', 'init.sh', '.github/workflows/rust.yml']
   pull_request:
     branches: [ "main" ]
-    paths: ['src/**', 'tests/**', 'third-party/**', 'Cargo.toml', 'build.rs', 'init.sh']
+    paths: ['src/**', 'tests/**', 'third-party/**', 'Cargo.toml', 'build.rs', 'init.sh', '.github/workflows/rust.yml']
 
 env:
   CARGO_TERM_COLOR: always
@@ -28,4 +28,10 @@ jobs:
         eval $(opam env)
 
     - name: Build & Run tests
-      run: ./init.sh && cargo run --release --bin hakana test tests
+      run: |
+        ./init.sh
+        
+        cargo run --release --bin hakana test tests
+
+        # run Rust unit tests
+        cargo test --release --workspace

--- a/src/language_server/tests.rs
+++ b/src/language_server/tests.rs
@@ -1,48 +1,28 @@
-use serde_json::{json, Value};
-use std::io::{BufRead, BufReader, Write};
+use crate::serve;
+use serde_json::{Value, json};
 use std::path::PathBuf;
-use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::sync::atomic::{AtomicI64, Ordering};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, DuplexStream};
+use tokio::time::{Duration, timeout};
 
 /// Helper struct to manage the language server process
-struct LanguageServerProcess {
-    process: Child,
+struct LanguageServer {
+    client: DuplexStream,
     request_id: Arc<AtomicI64>,
 }
 
-impl LanguageServerProcess {
+impl LanguageServer {
     /// Spawn a new language server process
-    fn new() -> std::io::Result<Self> {
-        // Build the language server first to ensure it's up to date
-        let build_status = Command::new("cargo")
-            .args(&["build", "--release", "--bin", "hakana-language-server"])
-            .current_dir(get_project_root())
-            .status()?;
-
-        if !build_status.success() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to build language server",
-            ));
-        }
-
-        let process = Command::new(get_project_root().join("target/release/hakana-language-server"))
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .current_dir(get_test_directory())
-            .spawn()?;
-
-        Ok(Self {
-            process,
+    fn new(client: DuplexStream) -> Self {
+        Self {
+            client,
             request_id: Arc::new(AtomicI64::new(1)),
-        })
+        }
     }
 
     /// Send a JSON-RPC request to the language server
-    fn send_request(&mut self, method: &str, params: Value) -> std::io::Result<i64> {
+    async fn send_request(&mut self, method: &str, params: Value) -> std::io::Result<i64> {
         let id = self.request_id.fetch_add(1, Ordering::SeqCst);
         let request = json!({
             "jsonrpc": "2.0",
@@ -54,16 +34,13 @@ impl LanguageServerProcess {
         let content = serde_json::to_string(&request)?;
         let message = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
 
-        if let Some(stdin) = self.process.stdin.as_mut() {
-            stdin.write_all(message.as_bytes())?;
-            stdin.flush()?;
-        }
+        self.client.write_all(message.as_bytes()).await?;
 
         Ok(id)
     }
 
     /// Send a notification (no response expected)
-    fn send_notification(&mut self, method: &str, params: Value) -> std::io::Result<()> {
+    async fn send_notification(&mut self, method: &str, params: Value) -> std::io::Result<()> {
         let notification = json!({
             "jsonrpc": "2.0",
             "method": method,
@@ -73,71 +50,67 @@ impl LanguageServerProcess {
         let content = serde_json::to_string(&notification)?;
         let message = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
 
-        if let Some(stdin) = self.process.stdin.as_mut() {
-            stdin.write_all(message.as_bytes())?;
-            stdin.flush()?;
-        }
+        self.client.write_all(message.as_bytes()).await?;
 
         Ok(())
     }
 
     /// Read a single response from the language server
-    fn read_response(&mut self) -> std::io::Result<Value> {
-        if let Some(stdout) = self.process.stdout.as_mut() {
-            let mut reader = BufReader::new(stdout);
-            let mut headers = Vec::new();
+    async fn read_response(&mut self) -> std::io::Result<Value> {
+        let mut reader = BufReader::new(&mut self.client);
+        let mut headers = Vec::new();
 
-            // Read headers
-            loop {
-                let mut line = String::new();
-                reader.read_line(&mut line)?;
+        // Read headers
+        loop {
+            let mut line = String::new();
+            reader.read_line(&mut line).await?;
 
-                if line == "\r\n" || line == "\n" {
-                    break;
-                }
-                headers.push(line.trim().to_string());
+            if line == "\r\n" || line == "\n" {
+                break;
             }
-
-            // Parse Content-Length
-            let content_length: usize = headers
-                .iter()
-                .find(|h| h.starts_with("Content-Length:"))
-                .and_then(|h| h.split(':').nth(1))
-                .and_then(|s| s.trim().parse().ok())
-                .ok_or_else(|| {
-                    std::io::Error::new(std::io::ErrorKind::InvalidData, "Missing Content-Length")
-                })?;
-
-            // Read content
-            let mut buffer = vec![0u8; content_length];
-            std::io::Read::read_exact(&mut reader, &mut buffer)?;
-
-            let content = String::from_utf8(buffer)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-
-            serde_json::from_str(&content)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
-        } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::BrokenPipe,
-                "No stdout available",
-            ))
+            headers.push(line.trim().to_string());
         }
+
+        // Parse Content-Length
+        let content_length: usize = headers
+            .iter()
+            .find(|h| h.starts_with("Content-Length:"))
+            .and_then(|h| h.split(':').nth(1))
+            .and_then(|s| s.trim().parse().ok())
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "Missing Content-Length")
+            })?;
+
+        // Read content
+        let mut buffer = vec![0u8; content_length];
+        reader.read_exact(&mut buffer).await?;
+
+        let content = String::from_utf8(buffer)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        serde_json::from_str(&content)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
     }
 
     /// Read responses until we get the one with the matching ID or timeout
-    fn wait_for_response(&mut self, expected_id: i64, timeout_secs: u64) -> std::io::Result<Value> {
+    async fn wait_for_response(
+        &mut self,
+        expected_id: i64,
+        timeout_secs: u64,
+    ) -> std::io::Result<Value> {
         let start = std::time::Instant::now();
+        let timeout_duration = Duration::from_secs(timeout_secs);
 
         loop {
-            if start.elapsed() > Duration::from_secs(timeout_secs) {
+            if start.elapsed() > timeout_duration {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::TimedOut,
                     "Timeout waiting for response",
                 ));
             }
 
-            let response = self.read_response()?;
+            let result = timeout(timeout_duration, self.read_response()).await?;
+            let response = result?;
 
             // Check if this is the response we're waiting for
             if let Some(id) = response.get("id") {
@@ -148,14 +121,6 @@ impl LanguageServerProcess {
 
             // Otherwise continue reading (could be a notification or other response)
         }
-    }
-}
-
-impl Drop for LanguageServerProcess {
-    fn drop(&mut self) {
-        // Kill the process if it's still running
-        let _ = self.process.kill();
-        let _ = self.process.wait();
     }
 }
 
@@ -174,9 +139,30 @@ fn get_test_directory() -> PathBuf {
     get_project_root().join("tests/goto-definition/classDefinition")
 }
 
-#[test]
-fn test_language_server_goto_definition() {
-    let mut lsp = LanguageServerProcess::new().expect("Failed to spawn language server");
+#[tokio::test]
+async fn test_language_server_goto_definition() {
+    let (client, server) = tokio::io::duplex(64);
+    let mut lsp = LanguageServer::new(client);
+
+    // tower-lsp does not actually exit when receiving an "exit" notification
+    // https://github.com/ebkalderon/tower-lsp/issues/399
+    // Use a channel to end the server task instead once we're done with the test.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
+    let server_handle = tokio::spawn(async move {
+        let (mut server_reader, mut server_writer) = tokio::io::split(server);
+
+        let lsp_server = serve(
+            &mut server_reader,
+            &mut server_writer,
+            Ok(get_test_directory()),
+        );
+
+        tokio::select! {
+            _ = lsp_server => {},
+            _ = shutdown_rx => {}
+        }
+    });
 
     // 1. Send initialize request
     let init_id = lsp
@@ -188,11 +174,13 @@ fn test_language_server_goto_definition() {
                 "capabilities": {},
             }),
         )
+        .await
         .expect("Failed to send initialize request");
 
     // Wait for initialize response
     let init_response = lsp
         .wait_for_response(init_id, 30)
+        .await
         .expect("Failed to get initialize response");
 
     assert!(
@@ -202,14 +190,20 @@ fn test_language_server_goto_definition() {
 
     // 2. Send initialized notification
     lsp.send_notification("initialized", json!({}))
+        .await
         .expect("Failed to send initialized notification");
 
-    // Give the server time to perform initial analysis
-    std::thread::sleep(Duration::from_secs(5));
+    // 3. Wait for initialized notification
+    lsp.wait_for_response(0, 30)
+        .await
+        .expect("Failed to get initialize notification");
 
-    // 3. Send goto-definition request
+    // 4. Send goto-definition request
     // Position is at line 8, character 15 (the "MyClass" in "new MyClass()")
-    let test_file_uri = format!("file://{}", get_test_directory().join("input.hack").display());
+    let test_file_uri = format!(
+        "file://{}",
+        get_test_directory().join("input.hack").display()
+    );
 
     let goto_def_id = lsp
         .send_request(
@@ -224,14 +218,16 @@ fn test_language_server_goto_definition() {
                 }
             }),
         )
+        .await
         .expect("Failed to send goto-definition request");
 
     // Wait for goto-definition response
     let goto_def_response = lsp
         .wait_for_response(goto_def_id, 10)
+        .await
         .expect("Failed to get goto-definition response");
 
-    // 4. Verify the response
+    // 5. Verify the response
     let result = goto_def_response
         .get("result")
         .expect("Goto-definition response missing result");
@@ -244,19 +240,12 @@ fn test_language_server_goto_definition() {
 
     if let Some(location) = result.as_object() {
         // Verify we got a URI
-        assert!(
-            location.contains_key("uri"),
-            "Location missing uri field"
-        );
+        assert!(location.contains_key("uri"), "Location missing uri field");
 
         // Verify we got a range
-        let range = location
-            .get("range")
-            .expect("Location missing range field");
+        let range = location.get("range").expect("Location missing range field");
 
-        let start = range
-            .get("start")
-            .expect("Range missing start field");
+        let start = range.get("start").expect("Range missing start field");
 
         // The class definition is on line 1 (0-indexed = line 0)
         assert_eq!(
@@ -271,31 +260,18 @@ fn test_language_server_goto_definition() {
     // 5. Send shutdown request
     let shutdown_id = lsp
         .send_request("shutdown", json!(null))
+        .await
         .expect("Failed to send shutdown request");
 
     lsp.wait_for_response(shutdown_id, 5)
+        .await
         .expect("Failed to get shutdown response");
 
     // 6. Send exit notification
     lsp.send_notification("exit", json!(null))
+        .await
         .expect("Failed to send exit notification");
 
-    // Wait for the process to exit with a timeout
-    let start = std::time::Instant::now();
-    while start.elapsed() < Duration::from_secs(2) {
-        match lsp.process.try_wait() {
-            Ok(Some(_status)) => {
-                // Process exited successfully
-                return;
-            }
-            Ok(None) => {
-                // Process still running, wait a bit
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            Err(_) => break,
-        }
-    }
-
-    // If we get here, the process didn't exit cleanly, so kill it
-    let _ = lsp.process.kill();
+    shutdown_tx.send(true).ok();
+    server_handle.await.ok();
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,11 +1,6 @@
-use std::{env, io::Cursor};
-
-use hakana_language_server::{get_config, Backend};
-use hakana_str::Interner;
+use hakana_language_server::serve;
 use mimalloc::MiMalloc;
 
-use tokio::io::AsyncWriteExt;
-use tower_lsp::{LspService, Server};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -15,41 +10,7 @@ async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let mut stderr = tokio::io::stderr();
+    let current_dir = std::env::current_dir();
 
-    let cwd = if let Ok(current_dir) = env::current_dir() {
-        if let Some(str) = current_dir.to_str() {
-            str.to_string()
-        } else {
-            stderr
-                .write_all_buf(&mut Cursor::new(b"Passed current directory is malformed"))
-                .await
-                .ok();
-            return;
-        }
-    } else {
-        stderr
-            .write_all_buf(&mut Cursor::new(
-                b"Current working directory could not be determined",
-            ))
-            .await
-            .ok();
-        return;
-    };
-
-    let mut interner = Interner::default();
-
-    let config = match get_config(vec![], &cwd, &mut interner) {
-        Ok(config) => config,
-        Err(error) => {
-            stderr
-                .write_all_buf(&mut Cursor::new(format!("Config error: {error}")))
-                .await
-                .ok();
-            return;
-        }
-    };
-
-    let (service, socket) = LspService::new(|client| Backend::new(client, config, interner));
-    Server::new(stdin, stdout, socket).serve(service).await;
+    serve(stdin, stdout, current_dir).await;
 }


### PR DESCRIPTION
51cf750 added some Rust unit tests for the embedded language server, but these are not working in CI at the moment.
So, add them to the workflow definition and make relevant fixes:

* Hoist language server initialization into the hakana-language-server crate so that we can run the server as a tokio task instead of a subprocess.
* Rework tests to use tokio async I/O for communicating with the server.
* Wait for the initialization notification from the server as the signal that the initial analysis has completed, rather than a hardcoded timeout.
* Enable go-to definition functionality on Linux.