### PR TITLE
Replace `.map(...).flatten(...)` chains with `.and_then(...)`

### DIFF
--- a/src/analyzer/expr/call/arguments_analyzer.rs
+++ b/src/analyzer/expr/call/arguments_analyzer.rs
@@ -64,14 +64,12 @@ pub(crate) fn check_arguments_match(
     let functionlike_params = &functionlike_info.params;
     // todo handle map and filter
 
-    let calling_classlike_storage = calling_classlike
-        .map(|calling_classlike| {
-            statements_analyzer
-                .codebase
-                .classlike_infos
-                .get(&calling_classlike.0)
-        })
-        .flatten();
+    let calling_classlike_storage = calling_classlike.and_then(|calling_classlike| {
+        statements_analyzer
+            .codebase
+            .classlike_infos
+            .get(&calling_classlike.0)
+    });
 
     if !type_args.is_empty() {
         for (i, type_arg) in type_args.iter().enumerate() {

--- a/src/analyzer/expression_analyzer.rs
+++ b/src/analyzer/expression_analyzer.rs
@@ -487,13 +487,12 @@ pub(crate) fn analyze(
                 let calling_class = context.function_context.calling_class;
 
                 let calling_class_info = calling_class
-                    .map(|calling_class_id| {
+                    .and_then(|calling_class_id| {
                         statements_analyzer
                             .codebase
                             .classlike_infos
                             .get(&calling_class_id)
-                    })
-                    .flatten();
+                    });
 
                 // The RHS of a nameof expression always seems to be a CIexpr,
                 // even if a classname literal or a keyword like self/static/parent is passed.
@@ -519,8 +518,7 @@ pub(crate) fn analyze(
                                 // nameof parent in a class that has no parent is a typechecker error.
                                 if inner_class_id.name() == "parent" {
                                     calling_class_info
-                                        .map(|i| i.direct_parent_class)
-                                        .flatten()
+                                        .and_then(|i| i.direct_parent_class)
                                         .map(|id| statements_analyzer.interner.lookup(&id))
                                 } else {
                                     // self/static


### PR DESCRIPTION
This is a more concise way of transforming an `Option<T>` to an `Option<U>` when your mapper is a `T -> Option<U>`. I did not know about it at first and used the more verbose equivalent instead.