### PR TITLE
Add FunctionCouldBeMadeAsync issue for sync functions with Asio\join whose callers are all async

### DIFF
--- a/src/analyzer/config/mod.rs
+++ b/src/analyzer/config/mod.rs
@@ -184,14 +184,14 @@ impl Config {
         Ok(())
     }
 
-    pub fn can_add_issue(&self, issue: &Issue) -> bool {
-        if let Some(issue_filter) = &self.allowed_issues {
-            if !issue_filter.contains(&issue.kind) {
-                return false;
-            }
-        }
+    pub fn can_add_issue_kind(&self, kind: &IssueKind) -> bool {
+        self.allowed_issues
+            .as_ref()
+            .is_none_or(|issue_filter| issue_filter.contains(kind))
+    }
 
-        true
+    pub fn can_add_issue(&self, issue: &Issue) -> bool {
+        self.can_add_issue_kind(&issue.kind)
     }
 
     pub fn allow_issues_in_file(&self, file: &str) -> bool {

--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -32,6 +32,7 @@ pub enum IssueKind {
     FalsableReturnStatement,
     FalseArgument,
     ForLoopInvalidation,
+    FunctionCouldBeMadeAsync,
     ImmutablePropertyWrite,
     ImplicitAsioJoin,
     ImplicitStringCast,

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -30,6 +30,7 @@ indicatif = "0.17.0-rc.11"
 rustc-hash = "1.1.0"
 glob = "0.3.0"
 chrono = "0.4"
+rayon = "1.11.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tower-lsp = { version = "=0.20.0", features = ["proposed"] }

--- a/src/orchestrator/unused_symbols.rs
+++ b/src/orchestrator/unused_symbols.rs
@@ -11,9 +11,10 @@ use hakana_code_info::issue::{Issue, IssueKind};
 use hakana_code_info::member_visibility::MemberVisibility;
 use hakana_code_info::property_info::PropertyKind;
 use hakana_str::{Interner, StrId};
+use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, RwLock};
 
 use crate::file::VirtualFileSystem;
 
@@ -65,6 +66,7 @@ pub(crate) fn find_unused_definitions(
     }
 
     check_enum_exclusivity(analysis_result, codebase, interner, &config);
+    check_functions_could_be_async(analysis_result, codebase, interner, &config);
 
     let referenced_symbols_and_members = analysis_result.symbol_references.back_references();
     let mut test_symbols = codebase
@@ -890,6 +892,133 @@ fn get_trait_users(
     }
 
     base_set
+}
+
+fn check_functions_could_be_async(
+    analysis_result: &mut AnalysisResult,
+    codebase: &CodebaseInfo,
+    interner: &Interner,
+    config: &Config,
+) {
+    if !config.can_add_issue_kind(&IssueKind::FunctionCouldBeMadeAsync) {
+        return;
+    }
+
+    let analysis_result_mut = Arc::new(RwLock::new(analysis_result));
+    codebase.functionlike_infos.par_iter().for_each_with(
+        analysis_result_mut,
+        |analysis_result_mut, (functionlike_name, functionlike_info)| {
+            if functionlike_info.is_async
+                || !functionlike_info.has_asio_join
+                || !functionlike_info.user_defined
+                || functionlike_info.is_closure
+                || functionlike_info.dynamically_callable
+                || functionlike_name.1 == StrId::CONSTRUCT
+            {
+                return;
+            }
+
+            let Some(name_pos) = functionlike_info.name_location else {
+                return;
+            };
+
+            let file_path = interner.lookup(&name_pos.file_path.0);
+
+            if !config.allow_issue_kind_in_file(&IssueKind::FunctionCouldBeMadeAsync, file_path) {
+                return;
+            }
+
+            if functionlike_info
+                .suppressed_issues
+                .iter()
+                .any(|(i, _)| i == &IssueKind::FunctionCouldBeMadeAsync)
+            {
+                return;
+            }
+
+            // Skip methods that override a non-async base method
+            if !functionlike_name.1.is_empty() {
+                if let Some(classlike_info) = codebase.classlike_infos.get(&functionlike_name.0) {
+                    if let Some(parent_classes) = classlike_info
+                        .overridden_method_ids
+                        .get(&functionlike_name.1)
+                    {
+                        let has_non_async_parent = parent_classes.iter().any(|parent_class| {
+                            codebase
+                                .functionlike_infos
+                                .get(&(*parent_class, functionlike_name.1))
+                                .is_some_and(|info| !info.is_async)
+                        });
+                        if has_non_async_parent {
+                            return;
+                        }
+                    }
+                }
+            }
+
+            let all_callers_async = {
+                let analysis_result = analysis_result_mut.read().unwrap();
+
+                let callers = analysis_result
+                    .symbol_references
+                    .get_references_to_symbol(*functionlike_name);
+
+                if callers.is_empty() {
+                    return;
+                }
+
+                callers.iter().all(|caller| {
+                    codebase
+                        .functionlike_infos
+                        .get(caller)
+                        .is_some_and(|info| info.is_async)
+                })
+            };
+
+            if !all_callers_async {
+                return;
+            }
+
+            let display_name = if functionlike_name.1.is_empty() {
+                interner.lookup(&functionlike_name.0).to_string()
+            } else {
+                format!(
+                    "{}::{}",
+                    interner.lookup(&functionlike_name.0),
+                    interner.lookup(&functionlike_name.1)
+                )
+            };
+
+            let calling_functionlike_id = if functionlike_name.1.is_empty() {
+                FunctionLikeIdentifier::Function(functionlike_name.0)
+            } else {
+                FunctionLikeIdentifier::Method(functionlike_name.0, functionlike_name.1)
+            };
+
+            let issue = Issue::new(
+                IssueKind::FunctionCouldBeMadeAsync,
+                format!(
+                    "{} contains Asio\\join and all callers are async, so it could be made async",
+                    display_name,
+                ),
+                name_pos,
+                &Some(calling_functionlike_id),
+            );
+
+            if config.can_add_issue(&issue) {
+                let mut analysis_result = analysis_result_mut.write().unwrap();
+                *analysis_result
+                    .issue_counts
+                    .entry(issue.kind.clone())
+                    .or_insert(0) += 1;
+                analysis_result
+                    .emitted_definition_issues
+                    .entry(name_pos.file_path)
+                    .or_default()
+                    .push(issue);
+            }
+        },
+    );
 }
 
 fn check_enum_exclusivity(

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsync/input.hack
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsync/input.hack
@@ -1,0 +1,18 @@
+async function do_async_work(): Awaitable<int> {
+    return 42;
+}
+
+function get_data(): int {
+    $result = \HH\Asio\join(do_async_work());
+    return $result + 1;
+}
+
+async function caller1(): Awaitable<int> {
+    $x = await do_async_work();
+    return get_data() + $x;
+}
+
+async function caller2(): Awaitable<void> {
+    $x = await do_async_work();
+    echo get_data() + $x;
+}

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsync/output.txt
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsync/output.txt
@@ -1,0 +1,4 @@
+ERROR: UnnecessaryAsyncAnnotation - input.hack:1:16 - This function is marked async but has no async behaviour
+ERROR: FunctionCouldBeMadeAsync - input.hack:5:10 - get_data contains Asio\join and all callers are async, so it could be made async
+ERROR: UnusedFunction - input.hack:10:16 - Unused function caller1
+ERROR: UnusedFunction - input.hack:15:16 - Unused function caller2

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsyncConstructor/input.hack
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsyncConstructor/input.hack
@@ -1,0 +1,21 @@
+async function do_async_work(): Awaitable<int> {
+    return 42;
+}
+
+final class Foo {
+    private int $value;
+
+    public function __construct() {
+        $this->value = \HH\Asio\join(do_async_work());
+    }
+
+    public function get_value(): int {
+        return $this->value;
+    }
+}
+
+async function caller(): Awaitable<int> {
+    $foo = new Foo();
+    $x = await do_async_work();
+    return $foo->get_value() + $x;
+}

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsyncConstructor/output.txt
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsyncConstructor/output.txt
@@ -1,0 +1,2 @@
+ERROR: UnnecessaryAsyncAnnotation - input.hack:1:16 - This function is marked async but has no async behaviour
+ERROR: UnusedFunction - input.hack:17:16 - Unused function caller

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsyncDynamicallyCallable/input.hack
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsyncDynamicallyCallable/input.hack
@@ -1,0 +1,14 @@
+async function do_async_work(): Awaitable<int> {
+    return 42;
+}
+
+<<__DynamicallyCallable>>
+function get_data(): int {
+    $result = \HH\Asio\join(do_async_work());
+    return $result + 1;
+}
+
+async function caller(): Awaitable<int> {
+    $x = await do_async_work();
+    return get_data() + $x;
+}

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsyncDynamicallyCallable/output.txt
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsyncDynamicallyCallable/output.txt
@@ -1,0 +1,2 @@
+ERROR: UnnecessaryAsyncAnnotation - input.hack:1:16 - This function is marked async but has no async behaviour
+ERROR: UnusedFunction - input.hack:11:16 - Unused function caller

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsyncMixedCallers/input.hack
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsyncMixedCallers/input.hack
@@ -1,0 +1,17 @@
+async function do_async_work(): Awaitable<int> {
+    return 42;
+}
+
+function get_data(): int {
+    $result = \HH\Asio\join(do_async_work());
+    return $result + 1;
+}
+
+async function async_caller(): Awaitable<int> {
+    $x = await do_async_work();
+    return get_data() + $x;
+}
+
+function sync_caller(): int {
+    return get_data();
+}

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsyncMixedCallers/output.txt
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsyncMixedCallers/output.txt
@@ -1,0 +1,3 @@
+ERROR: UnnecessaryAsyncAnnotation - input.hack:1:16 - This function is marked async but has no async behaviour
+ERROR: UnusedFunction - input.hack:10:16 - Unused function async_caller
+ERROR: UnusedFunction - input.hack:15:10 - Unused function sync_caller

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsyncOverride/input.hack
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsyncOverride/input.hack
@@ -1,0 +1,20 @@
+async function do_async_work(): Awaitable<int> {
+    return 42;
+}
+
+abstract class Base {
+    abstract public function get_data(): int;
+}
+
+final class Child extends Base {
+    <<__Override>>
+    public function get_data(): int {
+        $result = \HH\Asio\join(do_async_work());
+        return $result + 1;
+    }
+}
+
+async function caller(Base $b): Awaitable<int> {
+    $x = await do_async_work();
+    return $b->get_data() + $x;
+}

--- a/tests/unused/UnusedCode/functionCouldBeMadeAsyncOverride/output.txt
+++ b/tests/unused/UnusedCode/functionCouldBeMadeAsyncOverride/output.txt
@@ -1,0 +1,3 @@
+ERROR: UnnecessaryAsyncAnnotation - input.hack:1:16 - This function is marked async but has no async behaviour
+ERROR: UnusedClass - input.hack:9:13 - Unused class, interface or enum Child
+ERROR: UnusedFunction - input.hack:17:16 - Unused function caller


### PR DESCRIPTION
Fires when a non-async function contains at least one Asio\join call and every caller of that function is itself async, suggesting the function could be converted to async with await instead.