### PR TITLE
Add basic `upcast` expression support

### DIFF
--- a/src/analyzer/expression_analyzer.rs
+++ b/src/analyzer/expression_analyzer.rs
@@ -486,12 +486,23 @@ pub(crate) fn analyze(
             )?;
         }
 
+        aast::Expr_::Upcast(boxed) => {
+            as_analyzer::analyze(
+                statements_analyzer,
+                expr.pos(),
+                &boxed.0,
+                &boxed.1,
+                false,
+                analysis_data,
+                context,
+            )?;
+        }
+
         aast::Expr_::Collection(_)
         | aast::Expr_::This
         | aast::Expr_::Omitted
         | aast::Expr_::Dollardollar(_)
         | aast::Expr_::ReadonlyExpr(_)
-        | aast::Expr_::Upcast(_)
         | aast::Expr_::ExpressionTree(_)
         | aast::Expr_::Lplaceholder(_)
         | aast::Expr_::MethodCaller(_)

--- a/tests/inference/Upcast/basic/input.hack
+++ b/tests/inference/Upcast/basic/input.hack
@@ -1,0 +1,19 @@
+<<file:__EnableUnstableFeatures('like_type_hints')>>
+<<file:__EnableUnstableFeatures('upcast_expression')>>
+
+final class Foo {}
+
+function trust_me(vec<shape('type' => string, ...)> $blocks, Foo $foo): ~?dict<arraykey, mixed> {
+    foreach ($blocks as $block) {
+        $sections = Shapes::idx($block, 'elements') upcast ~?vec<dict<arraykey, mixed>>;
+        foreach ($sections ?? vec[] as $section) {
+            $leaf_elements = ($section['elements'] ?? null) upcast ~?vec<dict<arraykey, mixed>>;
+            foreach ($leaf_elements ?? vec[] as $el) {
+                if (($el['type'] ?? null) === $foo) {
+                    return $el;
+                }
+            }
+        }
+    }
+    return null;
+}


### PR DESCRIPTION
We don't currently distinguish between like types and non-dynamic types in Hakana, so treat `upcast` as if it was an `as` for now.