### PR TITLE
Fix module load on hakana.dev

### DIFF
--- a/src/js_interop/www/index.ts
+++ b/src/js_interop/www/index.ts
@@ -70,7 +70,8 @@ import { ScannerAndAnalyzer } from "../pkg/js_interop";
     // oniguruma is a low-level library and stock wasm-loader isn't equipped with advanced low-level API's to interact with libonig
     await loadWASM(require('onigasm/lib/onigasm.wasm').default);
     let languageId = 'source.hack';
-    addGrammar(languageId, () => import('./tm/grammars/hack.tmLanguage.json'));
+    const grammar = { ...(await import("./tm/grammars/hack.tmLanguage.json")) };
+    addGrammar(languageId, grammar);
     await activateLanguage(languageId, 'hack', 'asap');
     editor.setOption('mode', 'hack');
 

--- a/src/js_interop/www/package.json
+++ b/src/js_interop/www/package.json
@@ -12,17 +12,14 @@
   },
   "license": "(MIT OR Apache-2.0)",
   "devDependencies": {
-    "copy-webpack-plugin": "^5.0.0",
-    "css-loader": "^5.2.7",
+    "css-loader": "^7.1.4",
     "file-loader": "^6.2.0",
-    "html-webpack-plugin": "^4.5.2",
-    "sass": "^1.49.8",
-    "sass-loader": "^10.2.1",
+    "html-webpack-plugin": "^5.6.6",
     "style-loader": "^2.0.0",
-    "ts-loader": "^8.3.0",
+    "ts-loader": "^9.5.7",
     "webpack": "^5",
-    "webpack-cli": "^4",
-    "webpack-dev-server": "^3.1.5"
+    "webpack-cli": "^7",
+    "webpack-dev-server": "^5.2.3"
   },
   "dependencies": {
     "@codemirror/lint": "^0.19.3",

--- a/src/js_interop/www/tsconfig.json
+++ b/src/js_interop/www/tsconfig.json
@@ -1,4 +1,7 @@
 {
+    "compilerOptions": {
+        "target": "es2020"
+    },
     "jsRules": {},
     "rules": {
         "quotemark": [true, "single"],

--- a/src/js_interop/www/webpack.config.js
+++ b/src/js_interop/www/webpack.config.js
@@ -2,8 +2,6 @@ const path = require('path');
 const webpack = require('webpack');
 const HTMLWebpackPlugin = require('html-webpack-plugin')
 
-const CopyWebpackPlugin = require('copy-webpack-plugin')
-
 module.exports = {
   mode: 'development',
   devtool: 'source-map',
@@ -54,7 +52,6 @@ module.exports = {
     syncWebAssembly: true
   },
   plugins: [
-    new CopyWebpackPlugin(['index.html']),
     new HTMLWebpackPlugin({
       template: path.resolve('./index.html')
     }),


### PR DESCRIPTION
hakana.dev is failing to load because it tries to write properties on an ES module:
```
main.js:142 Uncaught (in promise) TypeError: Cannot set property scopeName of [object Module] which has only a getter
    at Registry.<anonymous> (main.js:142:1)
    at step (main.js:35:1)
    at Object.next (main.js:16:46)
    at fulfilled (main.js:7:43)
(anonymous) @ main.js:142
step @ main.js:35
(anonymous) @ main.js:16
fulfilled @ main.js:7
Promise.then
step @ main.js:9
(anonymous) @ main.js:10
(anonymous) @ main.js:6
(anonymous) @ main.js:120
(anonymous) @ main.js:120
step @ main.js:35
(anonymous) @ main.js:16
(anonymous) @ main.js:10
(anonymous) @ main.js:6
(anonymous) @ main.js:106
(anonymous) @ main.js:100
step @ main.js:35
(anonymous) @ main.js:16
(anonymous) @ main.js:10
(anonymous) @ main.js:6
(anonymous) @ main.js:98
loadLanguage @ Highlighter.js:127
(anonymous) @ Highlighter.js:113
fulfilled @ Highlighter.js:4
Promise.then
step @ Highlighter.js:6
(anonymous) @ Highlighter.js:7
(anonymous) @ Highlighter.js:3
activateLanguage @ Highlighter.js:98
(anonymous) @ index.ts:53
setTimeout
(anonymous) @ index.ts:47
(anonymous) @ index.ts:140
__webpack_require__ @ bootstrap:25
Promise.then
(anonymous) @ bootstrap.js:7
__webpack_require__ @ bootstrap:25
(anonymous) @ startup:4
(anonymous) @ startup:4
```

So clone the results before passing it to addGrammar() and update dependencies as we're here.