### PR TITLE
Fix type inference for literals matching enum cases

### DIFF
--- a/src/algebra/clause.rs
+++ b/src/algebra/clause.rs
@@ -103,11 +103,7 @@ impl Clause {
         }
 
         Some(Clause {
-            hash: get_hash(
-                &possibilities,
-                self.wedge,
-                self.reconcilable,
-            ),
+            hash: get_hash(&possibilities, self.wedge, self.reconcilable),
             possibilities,
             creating_conditional_id: self.creating_conditional_id,
             creating_object_id: self.creating_object_id,
@@ -127,11 +123,7 @@ impl Clause {
         possibilities.insert(var_id, new_possibility);
 
         Clause {
-            hash: get_hash(
-                &possibilities,
-                self.wedge,
-                self.reconcilable,
-            ),
+            hash: get_hash(&possibilities, self.wedge, self.reconcilable),
             possibilities,
             creating_conditional_id: self.creating_conditional_id,
             creating_object_id: self.creating_object_id,

--- a/src/code_info/ttype/comparison/scalar_type_comparator.rs
+++ b/src/code_info/ttype/comparison/scalar_type_comparator.rs
@@ -1,9 +1,45 @@
 use super::{atomic_type_comparator, type_comparison_result::TypeComparisonResult};
 use crate::{
+    class_constant_info::ConstantInfo,
     code_location::FilePath,
     codebase_info::CodebaseInfo,
     t_atomic::{TAtomic, TNamedObject},
 };
+use hakana_str::StrId;
+
+/// Checks whether a literal int or string value matches a single case of an enum.
+fn literal_matches_enum_case(literal: &TAtomic, member_storage: &ConstantInfo) -> bool {
+    match (literal, &member_storage.inferred_type) {
+        (
+            TAtomic::TLiteralString { value: input_value },
+            Some(TAtomic::TLiteralString {
+                value: inferred_value,
+            }),
+        ) => inferred_value == input_value,
+        (
+            TAtomic::TLiteralInt { value: input_value },
+            Some(TAtomic::TLiteralInt {
+                value: inferred_value,
+            }),
+        ) => inferred_value == input_value,
+        _ => false,
+    }
+}
+
+/// Checks whether a literal int or string value matches any case of the given enum.
+fn literal_matches_enum_value(
+    codebase: &CodebaseInfo,
+    enum_name: &StrId,
+    literal: &TAtomic,
+) -> bool {
+    let Some(c) = codebase.classlike_infos.get(enum_name) else {
+        return false;
+    };
+
+    c.constants
+        .values()
+        .any(|member_storage| literal_matches_enum_case(literal, member_storage))
+}
 
 pub fn is_contained_by(
     codebase: &CodebaseInfo,
@@ -168,43 +204,32 @@ pub fn is_contained_by(
             return container_name == input_name;
         }
 
-        // check if a string matches an enum case
-        if let TAtomic::TLiteralString { value: input_value } = input_type_part {
-            if let Some(c) = codebase.classlike_infos.get(container_name) {
-                for (_, const_storage) in &c.constants {
-                    if let Some(TAtomic::TLiteralString {
-                        value: inferred_value,
-                    }) = &const_storage.inferred_type
-                    {
-                        if inferred_value == input_value {
-                            return true;
-                        }
-                    }
-                }
-            }
-        } else if let TAtomic::TLiteralInt { value: input_value } = input_type_part {
-            if let Some(c) = codebase.classlike_infos.get(container_name) {
-                for (_, const_storage) in &c.constants {
-                    if let Some(TAtomic::TLiteralInt {
-                        value: inferred_value,
-                    }) = &const_storage.inferred_type
-                    {
-                        if inferred_value == input_value {
-                            return true;
-                        }
-                    }
-                }
-            }
+        // Consider an enum to contain literal ints or strings matching one of its cases.
+        // This requires an `as EnumType` assertion to avoid a typechecker error,
+        // so only admit this if comparing types outside such an assertion so that we do not
+        // falsely raise a RedundantTypeComparison error.
+        if !inside_assertion
+            && literal_matches_enum_value(codebase, container_name, input_type_part)
+        {
+            return true;
         }
 
         return false;
     }
 
     if let TAtomic::TEnum {
+        name: container_name,
         as_type: input_as_type,
         ..
     } = input_type_part
     {
+        // Ensure an enum is considered compatible with literal ints or strings matching one of its cases
+        // for type assertion purposes.
+        if inside_assertion
+            && literal_matches_enum_value(codebase, container_name, container_type_part)
+        {
+            return true;
+        }
         let input_as_type = match input_as_type {
             Some(input_as_type) => input_as_type,
             _ => &TAtomic::TArraykey { from_any: false },
@@ -274,32 +299,14 @@ pub fn is_contained_by(
         ..
     } = container_type_part
     {
-        // check if a string matches an enum case
-        if let TAtomic::TLiteralString { value: input_value } = input_type_part {
-            if let Some(c) = codebase.classlike_infos.get(container_name) {
-                if let Some(TAtomic::TLiteralString {
-                    value: inferred_value,
-                }) = &c.constants.get(member_name).unwrap().inferred_type
-                {
-                    if inferred_value == input_value {
-                        return true;
-                    }
-                }
-            }
-        } else if let TAtomic::TLiteralInt { value: input_value } = input_type_part {
-            if let Some(c) = codebase.classlike_infos.get(container_name) {
-                if let Some(TAtomic::TLiteralInt {
-                    value: inferred_value,
-                }) = &c.constants.get(member_name).unwrap().inferred_type
-                {
-                    if inferred_value == input_value {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
+        return codebase
+            .classlike_infos
+            .get(container_name)
+            .and_then(|c| c.constants.get(member_name))
+            // check if a literal int or string matches an enum case
+            .is_some_and(|member_storage| {
+                literal_matches_enum_case(input_type_part, member_storage)
+            });
     }
 
     // compare non-identical types

--- a/tests/inference/Enum/enumValueAs/input.hack
+++ b/tests/inference/Enum/enumValueAs/input.hack
@@ -1,4 +1,4 @@
-function takesString(string $s) {}
+function takesString(string $s): void {}
 
 enum Foo: string {
     A = "a";
@@ -20,4 +20,22 @@ function callIt(): void {
     takesString(Foo::A as string);
     echo Bar::A as string;
     echo BarInt::A as int;
+    
+    takesFoo("c" as Bar);
+    takesBarInt(999 as BarInt);
+    takesFoo(Foo::A as Foo);
+
+    // valid
+    takesFoo(Foo::A);
+    takesFoo('a' as Foo);
+    takesBar(Bar::A);
+    takesBar("b" as Bar);
+    takesBarInt(BarInt::A);
+    takesBarInt(1 as BarInt);
 }
+
+function takesFoo(Foo $foo): void {}
+
+function takesBar(Bar $bar): void {}
+
+function takesBarInt(BarInt $bar): void {}

--- a/tests/inference/Enum/enumValueAs/output.txt
+++ b/tests/inference/Enum/enumValueAs/output.txt
@@ -1,3 +1,8 @@
 ERROR: LessSpecificArgument - input.hack:19:17 - Argument 1 of takesString expects string, parent type Foo::A provided
 ERROR: RedundantTypeComparison - input.hack:21:10 - Type Bar::A is always string
 ERROR: RedundantTypeComparison - input.hack:22:10 - Type BarInt::A is always int
+ERROR: ImpossibleTypeComparison - input.hack:24:14 - Type string(c) is never Bar
+ERROR: InvalidArgument - input.hack:24:14 - Argument 1 of takesFoo expects Foo, different type string(c) provided
+ERROR: ImpossibleTypeComparison - input.hack:25:17 - Type int(999) is never BarInt
+ERROR: InvalidArgument - input.hack:25:17 - Argument 1 of takesBarInt expects BarInt, different type int(999) provided
+ERROR: RedundantTypeComparison - input.hack:26:14 - Type Foo::A is always Foo


### PR DESCRIPTION
Given an `enum E: string { A = "a"; }`, it's valid Hack to cast a string literal matching one of its cases to `E`, i.e. `"a" as E`. However, this only works with an explicit `as`; trying to pass a literal to a function that expects an enum is a typechecker error even if the literal would match one of the enum's cases. Hakana wrongly raises a RedundantTypeComparison error here.

So special-case enum - literal comparisons depending on whether we're in a type assertion and deduplicate the comparison logic.