### PR TITLE
Have the LSP server receive diagnostics from the hakana server

### DIFF
--- a/src/cli/lib.rs
+++ b/src/cli/lib.rs
@@ -8,6 +8,7 @@ use hakana_code_info::data_flow::graph::{GraphKind, WholeProgramKind};
 use hakana_code_info::issue::IssueKind;
 use hakana_language_server::server_client::ServerConnection;
 use hakana_logger::{Logger, Verbosity};
+use hakana_protocol::ClientSocket;
 use hakana_str::Interner;
 use indexmap::IndexMap;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -37,7 +38,7 @@ macro_rules! tty_println {
     };
 }
 
-pub fn init(
+pub async fn init(
     analysis_hooks: Vec<Box<dyn CustomHook>>,
     migration_hooks: Vec<Box<dyn CustomHook>>,
     codegen_hooks: Vec<Box<dyn CustomHook>>,
@@ -699,7 +700,8 @@ pub fn init(
                 logger,
                 header,
                 &mut had_error,
-            );
+            )
+            .await;
         }
         Some(("security-check", sub_matches)) => {
             do_security_check(
@@ -849,7 +851,8 @@ pub fn init(
                 logger,
                 header,
                 analysis_hooks,
-            );
+            )
+            .await;
         }
         Some(("cyclomatic-complexity", sub_matches)) => {
             do_cyclomatic_complexity(
@@ -916,7 +919,7 @@ fn do_fix(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,
@@ -1017,7 +1020,7 @@ fn do_remove_unused_fixmes(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,
@@ -1094,7 +1097,7 @@ fn do_add_fixmes(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,
@@ -1186,7 +1189,7 @@ fn do_migrate(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,
@@ -1259,7 +1262,7 @@ fn do_migration_candidates(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,
@@ -1342,7 +1345,7 @@ fn do_codegen(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,
@@ -1478,7 +1481,7 @@ fn do_find_paths(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,
@@ -1548,7 +1551,7 @@ fn do_security_check(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,
@@ -1581,7 +1584,7 @@ fn do_security_check(
     }
 }
 
-fn do_analysis(
+async fn do_analysis(
     sub_matches: &clap::ArgMatches,
     all_custom_issues: FxHashSet<String>,
     root_dir: &str,
@@ -1594,7 +1597,7 @@ fn do_analysis(
     header: &str,
     had_error: &mut bool,
 ) {
-    use hakana_protocol::{ClientSocket, GetIssuesRequest, Message, SocketPath};
+    use hakana_protocol::{GetIssuesRequest, Message, SocketPath};
     use std::io::{self, Write};
     use std::time::Duration;
 
@@ -1611,6 +1614,7 @@ fn do_analysis(
         // --with-server: spawn server if not running
         if !socket_path.server_exists() {
             ServerConnection::connect_or_spawn(project_root, None)
+                .await
                 .inspect_err(|e| {
                     println!(
                         "Failed to spawn server: {}. Falling back to standalone analysis.",
@@ -1642,6 +1646,7 @@ fn do_analysis(
             filter: filter.clone(),
             find_unused_expressions,
             find_unused_definitions,
+            block_until_next_analysis: false,
         });
 
         // Poll for results, showing progress bar if analysis is in progress
@@ -1658,7 +1663,7 @@ fn do_analysis(
         };
 
         loop {
-            let mut client = match ClientSocket::connect(&socket_path) {
+            let mut client = match ClientSocket::connect(&socket_path).await {
                 Ok(c) => c,
                 Err(e) => {
                     pb.finish_and_clear();
@@ -1667,7 +1672,7 @@ fn do_analysis(
                 }
             };
 
-            match client.request(&request) {
+            match client.request(&request).await {
                 Ok(Message::GetIssuesResult(result)) => {
                     if result.analysis_complete {
                         pb.finish_and_clear();
@@ -1805,7 +1810,7 @@ fn do_analysis(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,
@@ -2620,7 +2625,7 @@ fn do_lint(
     }
 }
 
-fn do_server(
+async fn do_server(
     sub_matches: &clap::ArgMatches,
     root_dir: &str,
     threads: u8,
@@ -2628,7 +2633,7 @@ fn do_server(
     header: &str,
     analysis_hooks: Vec<Box<dyn CustomHook>>,
 ) {
-    use hakana_protocol::{ClientSocket, Message, ShutdownRequest, SocketPath, StatusRequest};
+    use hakana_protocol::{Message, ShutdownRequest, SocketPath, StatusRequest};
     use hakana_server::{Server, ServerConfig};
 
     let socket_path = SocketPath::for_project(Path::new(root_dir));
@@ -2640,9 +2645,9 @@ fn do_server(
             return;
         }
 
-        match ClientSocket::connect(&socket_path) {
+        match ClientSocket::connect(&socket_path).await {
             Ok(mut client) => {
-                let response = client.request(&Message::Status(StatusRequest));
+                let response = client.request(&Message::Status(StatusRequest)).await;
                 match response {
                     Ok(Message::StatusResult(status)) => {
                         println!("Server Status:");
@@ -2671,8 +2676,8 @@ fn do_server(
             return;
         }
 
-        match ClientSocket::connect(&socket_path) {
-            Ok(mut client) => match client.send(&Message::Shutdown(ShutdownRequest)) {
+        match ClientSocket::connect(&socket_path).await {
+            Ok(mut client) => match client.send(&Message::Shutdown(ShutdownRequest)).await {
                 Ok(_) => println!("Shutdown signal sent"),
                 Err(e) => println!("Error sending shutdown: {}", e),
             },
@@ -2704,7 +2709,7 @@ fn do_server(
         Ok(mut server) => {
             tty_println!("Starting hakana server...");
             tty_println!("Socket: {}", server.socket_path().path().display());
-            if let Err(e) = server.run() {
+            if let Err(e) = server.run().await {
                 println!("Server error: {}", e);
                 exit(1);
             }
@@ -2771,7 +2776,7 @@ fn do_cyclomatic_complexity(
         threads,
         Arc::new(logger),
         header,
-        interner,
+        Arc::new(interner),
         None,
         None,
         None,

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -61,7 +61,7 @@ pub fn parse_args() -> McpConfig {
 }
 
 /// Run the MCP server with the given plugins and header.
-pub fn run(plugins: Vec<Box<dyn CustomHook>>, header: String) {
+pub async fn run(plugins: Vec<Box<dyn CustomHook>>, header: String) {
     let config = parse_args();
 
     // Convert hooks to Arc for reuse
@@ -73,7 +73,9 @@ pub fn run(plugins: Vec<Box<dyn CustomHook>>, header: String) {
         Some(config.config_path),
         plugins,
         header,
-    ) {
+    )
+    .await
+    {
         eprintln!("MCP server error: {}", e);
         std::process::exit(1);
     }

--- a/src/cli/test_runners/tests/code_transform.rs
+++ b/src/cli/test_runners/tests/code_transform.rs
@@ -33,7 +33,7 @@ impl IntegrationTest for CodeTransformTest {
             stub_dirs.push(cwd.clone() + "/third-party/xhp-lib/src");
         }
 
-        let interner = Interner::default();
+        let interner = Arc::new(Interner::default());
 
         let result = hakana_orchestrator::scan_and_analyze(
             stub_dirs,

--- a/src/cli/test_runners/tests/cyclomatic_complexity.rs
+++ b/src/cli/test_runners/tests/cyclomatic_complexity.rs
@@ -28,7 +28,7 @@ impl IntegrationTest for CyclomaticComplexityTest {
 
         let stub_dirs = vec![cwd.clone() + "/tests/stubs"];
 
-        let interner = Interner::default();
+        let interner = Arc::new(Interner::default());
 
         let result = hakana_orchestrator::scan_and_analyze(
             stub_dirs,

--- a/src/cli/test_runners/tests/diff.rs
+++ b/src/cli/test_runners/tests/diff.rs
@@ -60,7 +60,7 @@ impl IntegrationTest for DiffTest {
 
         config.ast_diff = true;
         config.find_unused_definitions = true;
-        let interner = Interner::default();
+        let interner = Arc::new(Interner::default());
         let config = Arc::new(config);
         let mut stub_dirs = vec![cwd.clone() + "/tests/stubs"];
 

--- a/src/cli/test_runners/tests/goto_definition.rs
+++ b/src/cli/test_runners/tests/goto_definition.rs
@@ -31,7 +31,7 @@ impl IntegrationTest for GotoDefinitionTest {
             1,
             ctx.logger,
             ctx.build_checksum,
-            hakana_str::Interner::default(),
+            Arc::new(hakana_str::Interner::default()),
             ctx.previous_scan_data,
             ctx.previous_analysis_result,
             None,

--- a/src/cli/test_runners/tests/migration_candidates.rs
+++ b/src/cli/test_runners/tests/migration_candidates.rs
@@ -33,7 +33,7 @@ impl IntegrationTest for MigrationCandidatesTest {
             stub_dirs.push(cwd.clone() + "/third-party/xhp-lib/src");
         }
 
-        let interner = Interner::default();
+        let interner = Arc::new(Interner::default());
 
         let result = hakana_orchestrator::scan_and_analyze(
             stub_dirs,

--- a/src/cli/test_runners/tests/references.rs
+++ b/src/cli/test_runners/tests/references.rs
@@ -30,7 +30,7 @@ impl IntegrationTest for ReferencesTest {
             1,
             ctx.logger,
             ctx.build_checksum,
-            hakana_str::Interner::default(),
+            Arc::new(hakana_str::Interner::default()),
             ctx.previous_scan_data,
             ctx.previous_analysis_result,
             None,

--- a/src/cli/test_runners/tests/standard_analysis.rs
+++ b/src/cli/test_runners/tests/standard_analysis.rs
@@ -32,7 +32,7 @@ impl IntegrationTest for StandardAnalysisTest {
             stub_dirs.push(cwd.clone() + "/third-party/xhp-lib/src");
         }
 
-        let interner = Interner::default();
+        let interner = Arc::new(Interner::default());
 
         let result = hakana_orchestrator::scan_and_analyze(
             stub_dirs,

--- a/src/language_server/lib.rs
+++ b/src/language_server/lib.rs
@@ -1,32 +1,29 @@
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
 
 use hakana_analyzer::config::{self, Config};
 use hakana_analyzer::custom_hook::CustomHook;
 use hakana_code_info::analysis_result::AnalysisResult;
 use hakana_code_info::code_location::HPos;
-#[cfg(target_arch = "wasm32")]
-use hakana_orchestrator::SuccessfulScanData;
 use hakana_orchestrator::file::FileStatus;
-#[cfg(not(target_arch = "wasm32"))]
-use hakana_orchestrator::{SuccessfulScanData, scan_and_analyze_async};
+use hakana_orchestrator::{SuccessfulScanData, scan_and_analyze};
 use hakana_str::Interner;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use tokio::sync::{Mutex, RwLock};
-use tokio::time::sleep;
+use tokio::sync::RwLock;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
-#[cfg(not(target_arch = "wasm32"))]
+use crate::server_backend::ServerBasedBackend;
+
+pub mod server_backend;
 pub mod server_client;
 
 #[derive(Debug)]
 pub struct Backend {
-    client: Client,
+    client: Arc<Client>,
     analysis_config: Arc<Config>,
     starter_interner: Arc<Interner>,
     previous_scan_data: RwLock<Option<SuccessfulScanData>>,
@@ -34,15 +31,12 @@ pub struct Backend {
     all_diagnostics: RwLock<Option<FxHashMap<Url, Vec<Diagnostic>>>>,
     file_changes: RwLock<Option<FxHashMap<String, FileStatus>>>,
     files_with_errors: RwLock<FxHashSet<Url>>,
-    /// Connection to the hakana server (used when server mode is enabled)
-    #[cfg(not(target_arch = "wasm32"))]
-    server_connection: Option<Mutex<server_client::ServerConnection>>,
 }
 
 impl Backend {
     pub fn new(client: Client, analysis_config: Config, starter_interner: Interner) -> Self {
         Self {
-            client,
+            client: Arc::new(client),
             analysis_config: Arc::new(analysis_config),
             starter_interner: Arc::new(starter_interner),
             previous_scan_data: RwLock::new(None),
@@ -50,29 +44,6 @@ impl Backend {
             all_diagnostics: RwLock::new(None),
             file_changes: RwLock::new(None),
             files_with_errors: RwLock::new(FxHashSet::default()),
-            #[cfg(not(target_arch = "wasm32"))]
-            server_connection: None,
-        }
-    }
-
-    /// Create a Backend with a server connection.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn with_server_connection(
-        client: Client,
-        analysis_config: Config,
-        starter_interner: Interner,
-        server_connection: Option<Mutex<server_client::ServerConnection>>,
-    ) -> Self {
-        Self {
-            client,
-            analysis_config: Arc::new(analysis_config),
-            starter_interner: Arc::new(starter_interner),
-            previous_scan_data: RwLock::new(None),
-            previous_analysis_result: RwLock::new(None),
-            all_diagnostics: RwLock::new(None),
-            file_changes: RwLock::new(None),
-            files_with_errors: RwLock::new(FxHashSet::default()),
-            server_connection,
         }
     }
 
@@ -97,8 +68,6 @@ impl Backend {
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
-        self.do_analysis().await;
-
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 text_document_sync: Some(TextDocumentSyncCapability::Options(
@@ -118,6 +87,8 @@ impl LanguageServer for Backend {
     }
 
     async fn initialized(&self, _: InitializedParams) {
+        self.do_analysis().await;
+
         let registration = Registration {
             id: "watch-hack-files".to_string(),
             method: "workspace/didChangeWatchedFiles".to_string(),
@@ -237,14 +208,6 @@ impl LanguageServer for Backend {
         let uri = params.text_document_position_params.text_document.uri;
         let file_path = uri.path().to_string();
 
-        // If we have a server connection, forward the request to the server
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Some(ref server_conn) = self.server_connection {
-            return self
-                .goto_definition_via_server(server_conn, &file_path, position)
-                .await;
-        }
-
         let scan_data_guard = self.previous_scan_data.read().await;
         let analysis_result_guard = self.previous_analysis_result.read().await;
         if let Some(scan_data) = scan_data_guard.as_ref() {
@@ -324,245 +287,7 @@ fn pos_to_offset(def_pos: HPos, interner: &Interner) -> Option<GotoDefinitionRes
 }
 
 impl Backend {
-    #[cfg(not(target_arch = "wasm32"))]
     async fn do_analysis(&self) {
-        // If we have a server connection, use it instead of local analysis
-        if let Some(ref server_conn) = self.server_connection {
-            self.do_analysis_via_server(server_conn).await;
-            return;
-        }
-
-        // Fall back to local analysis (original behavior)
-        self.do_local_analysis().await;
-    }
-
-    /// Perform analysis by querying the hakana server.
-    #[cfg(not(target_arch = "wasm32"))]
-    async fn do_analysis_via_server(&self, server_conn: &Mutex<server_client::ServerConnection>) {
-        let mut all_diagnostics_guard = self.all_diagnostics.write().await;
-
-        // First, forward any pending file changes to the server
-        let file_changes = {
-            let mut file_changes_guard = self.file_changes.write().await;
-            file_changes_guard.take()
-        };
-
-        if let Some(changes) = file_changes {
-            if !changes.is_empty() {
-                self.client
-                    .log_message(
-                        MessageType::INFO,
-                        format!("Forwarding {} file change(s) to server", changes.len()),
-                    )
-                    .await;
-
-                let mut conn = server_conn.lock().await;
-                if let Err(e) = conn.notify_file_changes(changes) {
-                    self.client
-                        .log_message(
-                            MessageType::ERROR,
-                            format!("Failed to notify server of file changes: {}", e),
-                        )
-                        .await;
-                }
-            }
-        }
-
-        self.client
-            .log_message(MessageType::INFO, "Fetching issues from server")
-            .await;
-
-        // Get issues from the server
-        let result = {
-            let mut conn = server_conn.lock().await;
-            conn.get_issues(None, true, true)
-        };
-
-        match result {
-            Ok(response) => {
-                if !response.analysis_complete {
-                    self.client
-                        .log_message(
-                            MessageType::INFO,
-                            format!(
-                                "Server analysis in progress: {} ({}%)",
-                                response.phase, response.progress_percent
-                            ),
-                        )
-                        .await;
-                    // Don't update diagnostics while analysis is in progress
-                    return;
-                }
-
-                let mut all_diagnostics = FxHashMap::default();
-
-                for issue in response.issues {
-                    let file_path =
-                        format!("{}/{}", self.analysis_config.root_dir, issue.file_path);
-
-                    let diagnostic = Diagnostic::new(
-                        Range {
-                            start: Position {
-                                line: issue.start_line - 1,
-                                character: issue.start_column as u32 - 1,
-                            },
-                            end: Position {
-                                line: issue.end_line - 1,
-                                character: issue.end_column as u32 - 1,
-                            },
-                        },
-                        Some(DiagnosticSeverity::ERROR),
-                        Some(NumberOrString::String(issue.kind)),
-                        Some("Hakana".to_string()),
-                        issue.description,
-                        None,
-                        None,
-                    );
-
-                    match Url::from_file_path(&file_path) {
-                        Ok(url) => {
-                            all_diagnostics
-                                .entry(url)
-                                .or_insert_with(Vec::new)
-                                .push(diagnostic);
-                        }
-                        Err(_) => {
-                            self.client
-                                .log_message(
-                                    MessageType::ERROR,
-                                    format!("Failure to get url from file {}", file_path),
-                                )
-                                .await;
-                        }
-                    }
-                }
-
-                self.client
-                    .log_message(
-                        MessageType::INFO,
-                        format!(
-                            "Received {} file(s) with issues from server",
-                            all_diagnostics.len()
-                        ),
-                    )
-                    .await;
-
-                *all_diagnostics_guard = Some(all_diagnostics);
-            }
-            Err(e) => {
-                self.client
-                    .log_message(
-                        MessageType::ERROR,
-                        format!("Failed to get issues from server: {}", e),
-                    )
-                    .await;
-            }
-        }
-    }
-
-    /// Perform goto-definition via the hakana server.
-    #[cfg(not(target_arch = "wasm32"))]
-    async fn goto_definition_via_server(
-        &self,
-        server_conn: &Mutex<server_client::ServerConnection>,
-        file_path: &str,
-        position: Position,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        self.client
-            .log_message(
-                MessageType::INFO,
-                format!(
-                    "Forwarding goto-definition to server: {}:{}:{}",
-                    file_path,
-                    position.line + 1,
-                    position.character + 1
-                ),
-            )
-            .await;
-
-        // Convert absolute path to relative path for the server
-        let relative_path = if file_path.starts_with(&self.analysis_config.root_dir) {
-            file_path
-                .strip_prefix(&self.analysis_config.root_dir)
-                .and_then(|p| p.strip_prefix('/'))
-                .unwrap_or(file_path)
-                .to_string()
-        } else {
-            file_path.to_string()
-        };
-
-        let result = {
-            let mut conn = server_conn.lock().await;
-            conn.goto_definition(
-                relative_path,
-                position.line + 1, // LSP is 0-indexed, server expects 1-indexed
-                position.character + 1,
-            )
-        };
-
-        match result {
-            Ok(response) => {
-                if response.found {
-                    if let (
-                        Some(def_file_path),
-                        Some(start_line),
-                        Some(start_column),
-                        Some(end_line),
-                        Some(end_column),
-                    ) = (
-                        response.file_path,
-                        response.start_line,
-                        response.start_column,
-                        response.end_line,
-                        response.end_column,
-                    ) {
-                        self.client
-                            .log_message(
-                                MessageType::INFO,
-                                format!(
-                                    "Definition found: {}:{}:{}",
-                                    def_file_path, start_line, start_column
-                                ),
-                            )
-                            .await;
-
-                        if let Ok(def_uri) = Url::from_file_path(&def_file_path) {
-                            return Ok(Some(GotoDefinitionResponse::Scalar(Location {
-                                uri: def_uri,
-                                range: Range {
-                                    start: Position {
-                                        line: start_line - 1, // Convert back to 0-indexed for LSP
-                                        character: (start_column - 1) as u32,
-                                    },
-                                    end: Position {
-                                        line: end_line - 1,
-                                        character: (end_column - 1) as u32,
-                                    },
-                                },
-                            })));
-                        }
-                    }
-                }
-                self.client
-                    .log_message(MessageType::INFO, "Definition not found")
-                    .await;
-                Ok(None)
-            }
-            Err(e) => {
-                self.client
-                    .log_message(
-                        MessageType::ERROR,
-                        format!("Failed to get definition from server: {}", e),
-                    )
-                    .await;
-                Ok(None)
-            }
-        }
-    }
-
-    /// Perform local analysis (original behavior when no server is connected).
-    #[cfg(not(target_arch = "wasm32"))]
-    async fn do_local_analysis(&self) {
         let mut previous_scan_data_guard = self.previous_scan_data.write().await;
         let mut previous_analysis_result_guard = self.previous_analysis_result.write().await;
         let mut all_diagnostics_guard = self.all_diagnostics.write().await;
@@ -582,97 +307,111 @@ impl Backend {
             )
             .await;
 
-        sleep(Duration::from_millis(10)).await;
+        let analysis_config = self.analysis_config.clone();
+        let interner = self.starter_interner.clone();
+        let client = self.client.clone();
 
-        let result = scan_and_analyze_async(
-            Vec::new(),
-            None,
-            None,
-            self.analysis_config.clone(),
-            8,
-            Some(&self.client),
-            "",
-            self.starter_interner.clone(),
-            successful_scan_data,
-            analysis_result,
-            file_changes,
-            None::<fn(hakana_orchestrator::AnalysisProgress)>,
-            None,
-            None,
-            None,
-        )
-        .await;
+        let (log_tx, mut log_rx) = tokio::sync::mpsc::channel(1);
 
-        *file_changes_guard = None;
+        println!("analysiseee");
 
-        match result {
-            Ok((analysis_result, successful_scan_data)) => {
-                let mut all_diagnostics = FxHashMap::default();
+        let mut task_result = tokio::task::spawn_blocking(move || {
+            use hakana_logger::Logger;
 
-                for (file, emitted_issues) in analysis_result.get_all_issues(
-                    &successful_scan_data.interner,
-                    &self.analysis_config.root_dir,
-                    false,
-                ) {
-                    let mut diagnostics = vec![];
-                    for emitted_issue in emitted_issues {
-                        diagnostics.push(Diagnostic::new(
-                            Range {
-                                start: Position {
-                                    line: emitted_issue.pos.start_line - 1,
-                                    character: emitted_issue.pos.start_column as u32 - 1,
-                                },
-                                end: Position {
-                                    line: emitted_issue.pos.end_line - 1,
-                                    character: emitted_issue.pos.end_column as u32 - 1,
-                                },
-                            },
-                            Some(DiagnosticSeverity::ERROR),
-                            Some(NumberOrString::String(emitted_issue.kind.to_string())),
-                            Some("Hakana".to_string()),
-                            emitted_issue.description.clone(),
-                            None,
-                            None,
-                        ));
-                    }
+            scan_and_analyze(
+                Vec::new(),
+                None,
+                None,
+                analysis_config,
+                None,
+                8,
+                Arc::new(Logger::Channel(log_tx)),
+                "",
+                interner,
+                successful_scan_data,
+                analysis_result,
+                file_changes,
+                || {},
+            )
+        });
 
-                    match Url::from_file_path(&file) {
-                        Ok(url) => {
-                            all_diagnostics.insert(url, diagnostics);
+        loop {
+            tokio::select! {
+                Some(log_message) = log_rx.recv() => {
+                    client
+                        .log_message(MessageType::INFO, log_message)
+                        .await;
+                },
+                Ok(result) = (&mut task_result) => {
+                    match result {
+                        Ok((analysis_result, successful_scan_data)) => {
+                            let mut all_diagnostics = FxHashMap::default();
+
+                            for (file, emitted_issues) in analysis_result.get_all_issues(
+                                &successful_scan_data.interner,
+                                &self.analysis_config.root_dir,
+                                false,
+                            ) {
+                                let mut diagnostics = vec![];
+                                for emitted_issue in emitted_issues {
+                                    diagnostics.push(Diagnostic::new(
+                                        Range {
+                                            start: Position {
+                                                line: emitted_issue.pos.start_line - 1,
+                                                character: emitted_issue.pos.start_column as u32 - 1,
+                                            },
+                                            end: Position {
+                                                line: emitted_issue.pos.end_line - 1,
+                                                character: emitted_issue.pos.end_column as u32 - 1,
+                                            },
+                                        },
+                                        Some(DiagnosticSeverity::ERROR),
+                                        Some(NumberOrString::String(emitted_issue.kind.to_string())),
+                                        Some("Hakana".to_string()),
+                                        emitted_issue.description.clone(),
+                                        None,
+                                        None,
+                                    ));
+                                }
+
+                                match Url::from_file_path(&file) {
+                                    Ok(url) => {
+                                        all_diagnostics.insert(url, diagnostics);
+                                    }
+                                    Err(_) => {
+                                        self.client
+                                            .log_message(
+                                                MessageType::ERROR,
+                                                format!("Failure to get url from file {}", file),
+                                            )
+                                            .await;
+                                    }
+                                }
+                            }
+
+                            *all_diagnostics_guard = Some(all_diagnostics);
+                            *previous_scan_data_guard = Some(successful_scan_data);
+                            *previous_analysis_result_guard = Some(analysis_result);
                         }
-                        Err(_) => {
+                        Err(error) => {
+                            *previous_scan_data_guard = None;
+                            *previous_analysis_result_guard = None;
+                            *all_diagnostics_guard = None;
+
                             self.client
                                 .log_message(
                                     MessageType::ERROR,
-                                    format!("Failure to get url from file {}", file),
+                                    format!("Analysis failed with error {}", error),
                                 )
                                 .await;
                         }
                     }
+                    break;
                 }
-
-                *all_diagnostics_guard = Some(all_diagnostics);
-                *previous_scan_data_guard = Some(successful_scan_data);
-                *previous_analysis_result_guard = Some(analysis_result);
-            }
-            Err(error) => {
-                *previous_scan_data_guard = None;
-                *previous_analysis_result_guard = None;
-                *all_diagnostics_guard = None;
-
-                self.client
-                    .log_message(
-                        MessageType::ERROR,
-                        format!("Analysis failed with error {}", error),
-                    )
-                    .await;
             }
         }
-    }
 
-    #[cfg(target_arch = "wasm32")]
-    async fn do_analysis(&self) {
-        // WASM version doesn't support async analysis
+        *file_changes_guard = None;
     }
 
     async fn emit_issues(&self) {
@@ -758,7 +497,6 @@ pub async fn serve<Reader, Writer>(
 }
 
 /// Serve the language server with custom plugins.
-#[cfg(not(target_arch = "wasm32"))]
 pub async fn serve_with_plugins<Reader, Writer>(
     reader: Reader,
     writer: Writer,
@@ -804,76 +542,33 @@ pub async fn serve_with_plugins<Reader, Writer>(
 
     // Try to connect to an existing hakana server and use it for analysis. or start one.
     // Fall back to local analysis if we can't start the server.
-    let server_connection = match server_client::ServerConnection::connect_or_spawn(&cwd_path, None)
-    {
-        Ok(conn) => {
-            stderr
-                .write_all_buf(&mut Cursor::new(b"Connected to hakana server\n"))
-                .await
-                .ok();
-            Some(Mutex::new(conn))
-        }
-        Err(e) => {
-            stderr
-                .write_all_buf(&mut Cursor::new(format!(
-                    "Error starting hakana server: {} . Using local analysis.\n",
-                    e
-                )))
-                .await
-                .ok();
-            None
-        }
-    };
+    let server_connection =
+        match server_client::ServerConnection::connect_or_spawn(&cwd_path, None).await {
+            Ok(conn) => {
+                stderr
+                    .write_all_buf(&mut Cursor::new(b"Connected to hakana server\n"))
+                    .await
+                    .ok();
+                Some(conn)
+            }
+            Err(e) => {
+                stderr
+                    .write_all_buf(&mut Cursor::new(format!(
+                        "Error starting hakana server: {} . Using local analysis.\n",
+                        e
+                    )))
+                    .await
+                    .ok();
+                None
+            }
+        };
 
-    let (service, socket) = LspService::new(|client| {
-        Backend::with_server_connection(client, config, interner, server_connection)
-    });
-
-    Server::new(reader, writer, socket).serve(service).await;
-}
-
-/// WASM version
-#[cfg(target_arch = "wasm32")]
-pub async fn serve_with_plugins<Reader, Writer>(
-    reader: Reader,
-    writer: Writer,
-    current_dir: std::io::Result<PathBuf>,
-    _plugins: Vec<Box<dyn CustomHook>>,
-) where
-    Reader: AsyncRead + Unpin,
-    Writer: AsyncWrite,
-{
-    let mut stderr = tokio::io::stderr();
-
-    let cwd = if let Ok(current_dir) = current_dir {
-        if let Some(str) = current_dir.to_str() {
-            str.to_string()
-        } else {
-            stderr
-                .write_all_buf(&mut Cursor::new(b"Passed current directory is malformed"))
-                .await
-                .ok();
-            return;
-        }
-    } else {
-        stderr
-            .write_all_buf(&mut Cursor::new(
-                b"Current working directory could not be determined",
-            ))
-            .await
-            .ok();
+    if let Some(server_conn) = server_connection {
+        let (service, socket) =
+            LspService::new(|client| ServerBasedBackend::new(client, config, server_conn));
+        Server::new(reader, writer, socket).serve(service).await;
         return;
-    };
-
-    let mut interner = Interner::default();
-
-    let config = match get_config(vec![], &cwd, &mut interner) {
-        Ok(config) => config,
-        Err(msg) => {
-            stderr.write_all_buf(&mut Cursor::new(msg)).await.ok();
-            return;
-        }
-    };
+    }
 
     let (service, socket) = LspService::new(|client| Backend::new(client, config, interner));
 

--- a/src/language_server/server_backend.rs
+++ b/src/language_server/server_backend.rs
@@ -1,0 +1,326 @@
+use std::sync::{Arc, Mutex};
+
+use crate::server_client;
+use hakana_analyzer::config::Config;
+use rustc_hash::{FxHashMap, FxHashSet};
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer};
+
+#[derive(Debug)]
+pub struct ServerBasedBackend {
+    client: Arc<Client>,
+    analysis_config: Arc<Config>,
+    server_conn: Arc<server_client::ServerConnection>,
+    shutdown_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<bool>>>>,
+}
+
+impl ServerBasedBackend {
+    pub fn new(
+        client: Client,
+        analysis_config: Config,
+        server_conn: server_client::ServerConnection,
+    ) -> Self {
+        Self {
+            client: Arc::new(client),
+            analysis_config: Arc::new(analysis_config),
+            server_conn: Arc::new(server_conn),
+            shutdown_tx: Arc::new(Mutex::new(None)),
+        }
+    }
+    /// Perform analysis by querying the hakana server.
+    async fn do_analysis_via_server(
+        client: &Arc<Client>,
+        analysis_config: &Arc<Config>,
+        server_conn: &Arc<server_client::ServerConnection>,
+        block_until_next_analysis: bool,
+    ) -> FxHashMap<Url, Vec<Diagnostic>> {
+        client
+            .log_message(MessageType::INFO, "Fetching issues from server")
+            .await;
+
+        // Get issues from the server
+        let result = server_conn
+            .get_issues(None, true, true, block_until_next_analysis)
+            .await;
+
+        match result {
+            Ok(response) => {
+                if !response.analysis_complete {
+                    client
+                        .log_message(
+                            MessageType::INFO,
+                            format!(
+                                "Server analysis in progress: {} ({}%)",
+                                response.phase, response.progress_percent
+                            ),
+                        )
+                        .await;
+                    // Don't update diagnostics while analysis is in progress
+                    return FxHashMap::default();
+                }
+
+                let mut all_diagnostics = FxHashMap::default();
+
+                for issue in response.issues {
+                    let file_path = format!("{}/{}", analysis_config.root_dir, issue.file_path);
+
+                    let diagnostic = Diagnostic::new(
+                        Range {
+                            start: Position {
+                                line: issue.start_line - 1,
+                                character: issue.start_column as u32 - 1,
+                            },
+                            end: Position {
+                                line: issue.end_line - 1,
+                                character: issue.end_column as u32 - 1,
+                            },
+                        },
+                        Some(DiagnosticSeverity::ERROR),
+                        Some(NumberOrString::String(issue.kind)),
+                        Some("Hakana".to_string()),
+                        issue.description,
+                        None,
+                        None,
+                    );
+
+                    match Url::from_file_path(&file_path) {
+                        Ok(url) => {
+                            all_diagnostics
+                                .entry(url)
+                                .or_insert_with(Vec::new)
+                                .push(diagnostic);
+                        }
+                        Err(_) => {
+                            client
+                                .log_message(
+                                    MessageType::ERROR,
+                                    format!("Failure to get url from file {}", file_path),
+                                )
+                                .await;
+                        }
+                    }
+                }
+
+                client
+                    .log_message(
+                        MessageType::INFO,
+                        format!(
+                            "Received {} file(s) with issues from server",
+                            all_diagnostics.len()
+                        ),
+                    )
+                    .await;
+
+                return all_diagnostics;
+            }
+            Err(e) => {
+                client
+                    .log_message(
+                        MessageType::ERROR,
+                        format!("Failed to get issues from server: {}", e),
+                    )
+                    .await;
+
+                return FxHashMap::default();
+            }
+        }
+    }
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for ServerBasedBackend {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Options(
+                    TextDocumentSyncOptions {
+                        open_close: Some(true),
+                        change: Some(TextDocumentSyncKind::NONE),
+                        will_save: Some(false),
+                        will_save_wait_until: Some(false),
+                        save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+                    },
+                )),
+                definition_provider: Some(OneOf::Left(true)),
+                ..ServerCapabilities::default()
+            },
+            ..InitializeResult::default()
+        })
+    }
+
+    async fn did_save(&self, _params: DidSaveTextDocumentParams) {
+        // handled by the server
+    }
+
+    async fn hover(&self, _: HoverParams) -> Result<Option<Hover>> {
+        Ok(None)
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
+        let _ = self.shutdown_tx.lock().unwrap().insert(shutdown_tx);
+
+        let client = self.client.clone();
+        let config = self.analysis_config.clone();
+        let conn = self.server_conn.clone();
+
+        tokio::spawn(async move {
+            client
+                .log_message(MessageType::INFO, "started watching for diagnostics")
+                .await;
+
+            let mut files_with_errors: FxHashSet<Url> = FxHashSet::default();
+
+            // On startup, allow populating initial diagnostics from warm server state if exists,
+            // then block until subsequent analysis runs.
+            let mut block_until_next_analysis = false;
+
+            loop {
+                tokio::select! {
+                    all_diagnostics = Self::do_analysis_via_server(&client, &config, &conn, block_until_next_analysis) => {
+                        block_until_next_analysis = true;
+                        let mut new_files_with_errors = FxHashSet::default();
+
+                        for (uri, diagnostics) in all_diagnostics {
+                            client
+                                .publish_diagnostics(uri.clone(), diagnostics, None)
+                                .await;
+                            new_files_with_errors.insert(uri);
+                        }
+
+                        for old_uri in files_with_errors.iter() {
+                            if !new_files_with_errors.contains(old_uri) {
+                                client
+                                    .publish_diagnostics(old_uri.clone(), vec![], None)
+                                    .await;
+                            }
+                        }
+
+                        files_with_errors = new_files_with_errors;
+
+                        client
+                            .log_message(MessageType::INFO, "Diagnostics sent")
+                            .await;
+                    }
+                    _ = &mut shutdown_rx => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        self.client
+            .log_message(MessageType::INFO, "server initialized!")
+            .await;
+    }
+
+    async fn goto_definition(
+        &self,
+        params: GotoDefinitionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        let position = params.text_document_position_params.position;
+        let uri = params.text_document_position_params.text_document.uri;
+        let file_path = uri.path().to_string();
+
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!(
+                    "Forwarding goto-definition to server: {}:{}:{}",
+                    file_path,
+                    position.line + 1,
+                    position.character + 1
+                ),
+            )
+            .await;
+
+        // Convert absolute path to relative path for the server
+        let relative_path = if file_path.starts_with(&self.analysis_config.root_dir) {
+            file_path
+                .strip_prefix(&self.analysis_config.root_dir)
+                .and_then(|p| p.strip_prefix('/'))
+                .unwrap_or(&file_path)
+                .to_string()
+        } else {
+            file_path.to_string()
+        };
+
+        let result = {
+            self.server_conn
+                .goto_definition(
+                    relative_path,
+                    position.line + 1, // LSP is 0-indexed, server expects 1-indexed
+                    position.character + 1,
+                )
+                .await
+        };
+
+        match result {
+            Ok(response) => {
+                if response.found {
+                    if let (
+                        Some(def_file_path),
+                        Some(start_line),
+                        Some(start_column),
+                        Some(end_line),
+                        Some(end_column),
+                    ) = (
+                        response.file_path,
+                        response.start_line,
+                        response.start_column,
+                        response.end_line,
+                        response.end_column,
+                    ) {
+                        self.client
+                            .log_message(
+                                MessageType::INFO,
+                                format!(
+                                    "Definition found: {}:{}:{}",
+                                    def_file_path, start_line, start_column
+                                ),
+                            )
+                            .await;
+
+                        if let Ok(def_uri) = Url::from_file_path(&def_file_path) {
+                            return Ok(Some(GotoDefinitionResponse::Scalar(Location {
+                                uri: def_uri,
+                                range: Range {
+                                    start: Position {
+                                        line: start_line - 1, // Convert back to 0-indexed for LSP
+                                        character: (start_column - 1) as u32,
+                                    },
+                                    end: Position {
+                                        line: end_line - 1,
+                                        character: (end_column - 1) as u32,
+                                    },
+                                },
+                            })));
+                        }
+                    }
+                }
+                self.client
+                    .log_message(MessageType::INFO, "Definition not found")
+                    .await;
+                Ok(None)
+            }
+            Err(e) => {
+                self.client
+                    .log_message(
+                        MessageType::ERROR,
+                        format!("Failed to get definition from server: {}", e),
+                    )
+                    .await;
+                Ok(None)
+            }
+        }
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        if let Some(shutdown_tx) = self.shutdown_tx.lock().ok().and_then(|mut o| o.take()) {
+            let _ = shutdown_tx.send(true);
+        }
+
+        Ok(())
+    }
+}

--- a/src/language_server/server_client.rs
+++ b/src/language_server/server_client.rs
@@ -1,16 +1,5 @@
-//! Client for connecting to the hakana server from the language server.
-//!
-//! This module provides functionality to:
-//! - Connect to an existing hakana server
-//! - Spawn a new server if one isn't running
-//! - Forward file changes and analysis requests
-//!
-//! Note: The server handles one request per connection, so the client
-//! reconnects for each request.
-
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::thread;
 use std::time::Duration;
 use std::{env, io};
 
@@ -20,36 +9,25 @@ use hakana_protocol::{
 };
 use rustc_hash::FxHashMap;
 
-/// Connection to the hakana server.
-///
-/// The server handles one request per connection, so each method
-/// creates a fresh connection to the server. If the server dies,
-/// it will be automatically respawned on the next request.
 #[derive(Debug)]
 pub struct ServerConnection {
     socket_path: SocketPath,
     project_root: PathBuf,
-    /// Child process handle if we spawned the server
-    server_process: Option<Child>,
-    /// Binary path used to spawn the server
     hakana_binary: Option<String>,
 }
 
 impl ServerConnection {
-    /// Connect to an existing server, returning None if no server is running.
-    pub fn try_connect(project_root: &Path) -> Option<Self> {
+    pub async fn try_connect(project_root: &Path) -> Option<Self> {
         let socket_path = SocketPath::for_project(project_root);
 
         if !socket_path.server_exists() {
             return None;
         }
 
-        // Verify we can actually connect
-        if ClientSocket::connect(&socket_path).is_ok() {
+        if ClientSocket::connect(&socket_path).await.is_ok() {
             Some(Self {
                 socket_path,
                 project_root: project_root.to_path_buf(),
-                server_process: None,
                 hakana_binary: None,
             })
         } else {
@@ -57,72 +35,56 @@ impl ServerConnection {
         }
     }
 
-    /// Connect to an existing server or spawn a new one.
-    /// This is a blocking operation.
-    pub fn connect_or_spawn(project_root: &Path, hakana_binary: Option<&str>) -> io::Result<Self> {
+    pub async fn connect_or_spawn(
+        project_root: &Path,
+        hakana_binary: Option<&str>,
+    ) -> io::Result<Self> {
         let socket_path = SocketPath::for_project(project_root);
 
-        // Try to connect to existing server
         if socket_path.server_exists() {
-            if ClientSocket::connect(&socket_path).is_ok() {
+            if ClientSocket::connect(&socket_path).await.is_ok() {
                 return Ok(Self {
                     socket_path,
                     project_root: project_root.to_path_buf(),
-                    server_process: None,
                     hakana_binary: hakana_binary.map(|s| s.to_string()),
                 });
             }
         }
 
-        // Spawn a new server
         let mut server_process = Self::spawn_server(project_root, hakana_binary)?;
 
-        // Wait for server to be ready (also checks if process died during startup)
-        Self::wait_for_server(&socket_path, &mut server_process, Duration::from_secs(120))?;
+        Self::wait_for_server(&socket_path, &mut server_process, Duration::from_secs(120)).await?;
 
         Ok(Self {
             socket_path,
             project_root: project_root.to_path_buf(),
-            server_process: Some(server_process),
             hakana_binary: hakana_binary.map(|s| s.to_string()),
         })
     }
 
-    /// Create a fresh connection to the server for a single request.
-    /// If the connection fails, attempts to respawn the server.
-    fn connect(&mut self) -> io::Result<ClientSocket> {
-        // First, try to connect directly
-        if let Ok(socket) = ClientSocket::connect(&self.socket_path) {
+    async fn connect(&self) -> io::Result<ClientSocket> {
+        if let Ok(socket) = ClientSocket::connect(&self.socket_path).await {
             return Ok(socket);
         }
 
-        // Connection failed - server may have died. Try to respawn.
         eprintln!("Server connection failed, attempting to respawn...");
 
-        // Clean up old process handle if any
-        self.server_process = None;
-
-        // Spawn a new server
         let mut server_process =
             Self::spawn_server(&self.project_root, self.hakana_binary.as_deref())?;
 
-        // Wait for it to be ready (also checks if process died during startup)
         Self::wait_for_server(
             &self.socket_path,
             &mut server_process,
             Duration::from_secs(120),
-        )?;
+        )
+        .await?;
 
-        self.server_process = Some(server_process);
-
-        // Try to connect again
         ClientSocket::connect(&self.socket_path)
+            .await
             .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, format!("{}", e)))
     }
 
-    /// Spawn a new hakana server process.
     fn spawn_server(project_root: &Path, hakana_binary: Option<&str>) -> io::Result<Child> {
-        // Find the hakana binary
         let binary = if let Some(bin) = hakana_binary {
             PathBuf::from(bin)
         } else {
@@ -135,7 +97,6 @@ impl ServerConnection {
             project_root.display()
         );
 
-        // Create a log file for server output so we can see errors
         let log_path = std::env::temp_dir().join("hakana-server.log");
         let log_file = std::fs::File::create(&log_path).ok();
         let log_file2 = std::fs::OpenOptions::new()
@@ -145,9 +106,6 @@ impl ServerConnection {
 
         eprintln!("Server log file: {}", log_path.display());
 
-        // Capture both stdout and stderr to the log file
-        // Set current_dir to project_root to ensure consistent behavior
-        // Environment (including PATH) is inherited by default from the parent process
         let child = Command::new(&binary)
             .arg("server")
             .arg("--root")
@@ -171,8 +129,6 @@ impl ServerConnection {
         Ok(child)
     }
 
-    /// Find the hakana binary.
-    /// The hakana binary is always in the same directory as hakana-language-server.
     fn find_hakana_binary() -> io::Result<PathBuf> {
         let current_exe = std::env::current_exe().map_err(|e| {
             io::Error::new(
@@ -188,7 +144,6 @@ impl ServerConnection {
             )
         })?;
 
-        // hakana binary is in the same directory as hakana-language-server
         let hakana_path = exe_dir.join("hakana");
         if hakana_path.exists() {
             return Ok(hakana_path);
@@ -196,11 +151,7 @@ impl ServerConnection {
 
         env::var_os("PATH")
             .map(|path| env::split_paths(&path).collect::<Vec<_>>())
-            .and_then(|paths| paths.iter()
-                .map(|p| p.join("hakana"))
-                .filter(|p| p.exists())
-                .next()
-            )
+            .and_then(|paths| paths.iter().map(|p| p.join("hakana")).find(|p| p.exists()))
             .ok_or(io::Error::new(
                 io::ErrorKind::NotFound,
                 format!(
@@ -210,9 +161,7 @@ impl ServerConnection {
             ))
     }
 
-    /// Wait for the server to be ready.
-    /// Also checks if the child process has died during startup.
-    fn wait_for_server(
+    async fn wait_for_server(
         socket_path: &SocketPath,
         child: &mut Child,
         timeout: Duration,
@@ -221,10 +170,8 @@ impl ServerConnection {
         let poll_interval = Duration::from_millis(100);
 
         loop {
-            // Check if child process has exited (died)
             match child.try_wait() {
                 Ok(Some(status)) => {
-                    // Try to read the server log file to see what went wrong
                     let log_path = std::env::temp_dir().join("hakana-server.log");
                     let log_contents = std::fs::read_to_string(&log_path)
                         .unwrap_or_else(|_| "<no log available>".to_string());
@@ -238,9 +185,7 @@ impl ServerConnection {
                         ),
                     ));
                 }
-                Ok(None) => {
-                    // Process still running, continue waiting
-                }
+                Ok(None) => {}
                 Err(e) => {
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
@@ -250,7 +195,6 @@ impl ServerConnection {
             }
 
             if start.elapsed() > timeout {
-                // Kill the child process since we're giving up
                 let _ = child.kill();
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
@@ -259,22 +203,20 @@ impl ServerConnection {
             }
 
             if socket_path.server_exists() {
-                if ClientSocket::connect(socket_path).is_ok() {
+                if ClientSocket::connect(socket_path).await.is_ok() {
                     return Ok(());
                 }
-                // Server socket exists but not ready yet
-                thread::sleep(poll_interval);
+                tokio::time::sleep(poll_interval).await;
             } else {
-                thread::sleep(poll_interval);
+                tokio::time::sleep(poll_interval).await;
             }
         }
     }
 
-    /// Check server status.
-    pub fn status(&mut self) -> io::Result<StatusResponse> {
-        let mut socket = self.connect()?;
+    pub async fn status(&self) -> io::Result<StatusResponse> {
+        let mut socket = self.connect().await?;
         let request = Message::Status(StatusRequest);
-        match socket.request(&request) {
+        match socket.request(&request).await {
             Ok(Message::StatusResult(response)) => Ok(response),
             Ok(Message::Error(e)) => Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -288,21 +230,22 @@ impl ServerConnection {
         }
     }
 
-    /// Get current issues from the server.
-    pub fn get_issues(
-        &mut self,
+    pub async fn get_issues(
+        &self,
         filter: Option<String>,
         find_unused_expressions: bool,
         find_unused_definitions: bool,
+        block_until_next_analysis: bool,
     ) -> io::Result<GetIssuesResponse> {
-        let mut socket = self.connect()?;
+        let mut socket = self.connect().await?;
         let request = Message::GetIssues(GetIssuesRequest {
             filter,
             find_unused_expressions,
             find_unused_definitions,
+            block_until_next_analysis,
         });
 
-        match socket.request(&request) {
+        match socket.request(&request).await {
             Ok(Message::GetIssuesResult(response)) => Ok(response),
             Ok(Message::Error(e)) => Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -316,12 +259,11 @@ impl ServerConnection {
         }
     }
 
-    /// Send file changes to the server.
-    pub fn notify_file_changes(
-        &mut self,
+    pub async fn notify_file_changes(
+        &self,
         changes: FxHashMap<String, hakana_orchestrator::file::FileStatus>,
     ) -> io::Result<()> {
-        let mut socket = self.connect()?;
+        let mut socket = self.connect().await?;
         let file_changes: Vec<FileChange> = changes
             .into_iter()
             .map(|(path, status)| FileChange {
@@ -332,7 +274,7 @@ impl ServerConnection {
 
         let request = Message::FileChanged(file_changes);
 
-        match socket.request(&request) {
+        match socket.request(&request).await {
             Ok(Message::Ack(_)) => Ok(()),
             Ok(Message::Error(e)) => Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -346,21 +288,20 @@ impl ServerConnection {
         }
     }
 
-    /// Request goto-definition.
-    pub fn goto_definition(
-        &mut self,
+    pub async fn goto_definition(
+        &self,
         file_path: String,
         line: u32,
         column: u32,
     ) -> io::Result<GotoDefinitionResponse> {
-        let mut socket = self.connect()?;
+        let mut socket = self.connect().await?;
         let request = Message::GotoDefinition(GotoDefinitionRequest {
             file_path,
             line,
             column,
         });
 
-        match socket.request(&request) {
+        match socket.request(&request).await {
             Ok(Message::GotoDefinitionResult(response)) => Ok(response),
             Ok(Message::Error(e)) => Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -374,14 +315,13 @@ impl ServerConnection {
         }
     }
 
-    /// Shutdown the server.
-    pub fn shutdown(&mut self) -> io::Result<()> {
-        let mut socket = self.connect()?;
+    pub async fn shutdown(&self) -> io::Result<()> {
+        let mut socket = self.connect().await?;
         let request = Message::Shutdown(ShutdownRequest);
 
-        match socket.request(&request) {
+        match socket.request(&request).await {
             Ok(Message::Ack(_)) => Ok(()),
-            Ok(_) => Ok(()), // Any response is fine for shutdown
+            Ok(_) => Ok(()),
             Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))),
         }
     }
@@ -390,17 +330,12 @@ impl ServerConnection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
     use tempfile::tempdir;
 
-    /// Test that find_hakana_binary returns a proper error when binary doesn't exist
     #[test]
     fn test_find_hakana_binary_error_message() {
-        // This test verifies the error message is helpful
-        // In a real scenario, the binary should exist next to hakana-language-server
         let result = ServerConnection::find_hakana_binary();
 
-        // Either it finds the binary (in dev environment) or gives a clear error
         match result {
             Ok(path) => {
                 assert!(path.exists(), "Found binary path should exist");
@@ -420,13 +355,11 @@ mod tests {
         }
     }
 
-    /// Test that wait_for_server detects when a process dies
-    #[test]
-    fn test_wait_for_server_detects_dead_process() {
+    #[tokio::test]
+    async fn test_wait_for_server_detects_dead_process() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let socket_path = SocketPath::for_project(temp_dir.path());
 
-        // Spawn a process that immediately exits
         let mut child = Command::new("sh")
             .arg("-c")
             .arg("exit 1")
@@ -436,12 +369,11 @@ mod tests {
             .spawn()
             .expect("Failed to spawn test process");
 
-        // Give it a moment to exit
-        thread::sleep(Duration::from_millis(100));
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
-        // wait_for_server should detect the process died
         let result =
-            ServerConnection::wait_for_server(&socket_path, &mut child, Duration::from_secs(1));
+            ServerConnection::wait_for_server(&socket_path, &mut child, Duration::from_secs(1))
+                .await;
 
         assert!(result.is_err(), "Should return error when process dies");
         let err = result.unwrap_err();
@@ -452,13 +384,11 @@ mod tests {
         );
     }
 
-    /// Test that wait_for_server times out appropriately
-    #[test]
-    fn test_wait_for_server_timeout() {
+    #[tokio::test]
+    async fn test_wait_for_server_timeout() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let socket_path = SocketPath::for_project(temp_dir.path());
 
-        // Spawn a process that sleeps (stays alive but doesn't create socket)
         let mut child = Command::new("sleep")
             .arg("10")
             .stdin(Stdio::null())
@@ -467,11 +397,10 @@ mod tests {
             .spawn()
             .expect("Failed to spawn test process");
 
-        // wait_for_server should timeout since no socket is created
         let result =
-            ServerConnection::wait_for_server(&socket_path, &mut child, Duration::from_millis(200));
+            ServerConnection::wait_for_server(&socket_path, &mut child, Duration::from_millis(200))
+                .await;
 
-        // Clean up the sleep process
         let _ = child.kill();
         let _ = child.wait();
 
@@ -484,53 +413,15 @@ mod tests {
         );
     }
 
-    /// Test that try_connect returns None when no server exists
-    #[test]
-    fn test_try_connect_no_server() {
+    #[tokio::test]
+    async fn test_try_connect_no_server() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
 
-        let result = ServerConnection::try_connect(temp_dir.path());
+        let result = ServerConnection::try_connect(temp_dir.path()).await;
 
         assert!(
             result.is_none(),
             "Should return None when no server is running"
         );
-    }
-
-    /// Test ServerConnection respawn behavior (integration test)
-    /// This test requires the hakana binary to be built
-    #[test]
-    #[ignore] // Run with --ignored flag, requires built hakana binary
-    fn test_server_respawn_on_death() {
-        let temp_dir = tempdir().expect("Failed to create temp dir");
-
-        // Create a minimal hakana.json
-        let config_path = temp_dir.path().join("hakana.json");
-        fs::write(&config_path, r#"{"ignore_files": []}"#).expect("Failed to write config");
-
-        // Connect or spawn should work
-        let mut conn = ServerConnection::connect_or_spawn(temp_dir.path(), None)
-            .expect("Should be able to spawn server");
-
-        // Get status to verify server is working
-        let status = conn.status().expect("Should get status");
-        assert!(status.ready || !status.analysis_in_progress);
-
-        // Kill the server process
-        if let Some(ref mut child) = conn.server_process {
-            child.kill().expect("Should kill server");
-            child.wait().expect("Should wait for server");
-        }
-        conn.server_process = None;
-
-        // Give it a moment
-        thread::sleep(Duration::from_millis(100));
-
-        // Next request should respawn the server
-        let status = conn.status().expect("Should respawn and get status");
-        assert!(status.ready || !status.analysis_in_progress);
-
-        // Clean up
-        let _ = conn.shutdown();
     }
 }

--- a/src/language_server/tests.rs
+++ b/src/language_server/tests.rs
@@ -56,8 +56,7 @@ impl LanguageServer {
     }
 
     /// Read a single response from the language server
-    async fn read_response(&mut self) -> std::io::Result<Value> {
-        let mut reader = BufReader::new(&mut self.client);
+    async fn read_response(reader: &mut BufReader<&mut DuplexStream>) -> std::io::Result<Value> {
         let mut headers = Vec::new();
 
         // Read headers
@@ -101,6 +100,8 @@ impl LanguageServer {
         let start = std::time::Instant::now();
         let timeout_duration = Duration::from_secs(timeout_secs);
 
+        let mut reader = BufReader::new(&mut self.client);
+
         loop {
             if start.elapsed() > timeout_duration {
                 return Err(std::io::Error::new(
@@ -109,7 +110,7 @@ impl LanguageServer {
                 ));
             }
 
-            let result = timeout(timeout_duration, self.read_response()).await?;
+            let result = timeout(timeout_duration, Self::read_response(&mut reader)).await?;
             let response = result?;
 
             // Check if this is the response we're waiting for

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [lib]
 path = "lib.rs"
+
+[dependencies]
+tokio = { version = "1.26.0", features = ["sync"] }

--- a/src/logger/lib.rs
+++ b/src/logger/lib.rs
@@ -1,15 +1,25 @@
+use tokio::sync::mpsc::Sender;
+
 pub enum Logger {
     DevNull,
     CommandLine(Verbosity),
+    Channel(tokio::sync::mpsc::Sender<String>),
 }
 
 impl Logger {
+    fn try_send(tx: &Sender<String>, message: &str) {
+        if let Err(e) = tx.blocking_send(message.to_string()) {
+            eprintln!("error reporting event {}", e);
+        }
+    }
+
     pub async fn log(&self, message: &str) {
         match self {
             Logger::DevNull => {}
             Logger::CommandLine(_) => {
                 println!("{}", message);
             }
+            Logger::Channel(tx) => Logger::try_send(tx, message),
         }
     }
 
@@ -19,12 +29,13 @@ impl Logger {
             Logger::CommandLine(_) => {
                 println!("{}", message);
             }
+            Logger::Channel(tx) => Logger::try_send(tx, message),
         }
     }
 
     pub async fn log_debug(&self, message: &str) {
         match self {
-            Logger::DevNull => {}
+            Logger::DevNull | Logger::Channel(_) => {}
             Logger::CommandLine(verbosity) => {
                 if matches!(verbosity, Verbosity::Debugging | Verbosity::DebuggingByLine) {
                     println!("{}", message);
@@ -43,7 +54,7 @@ impl Logger {
 
     pub fn can_log_timing(&self) -> bool {
         match self {
-            Logger::DevNull => false,
+            Logger::DevNull | Logger::Channel(_) => false,
             Logger::CommandLine(verbosity) => {
                 matches!(verbosity, Verbosity::Debugging | Verbosity::Timing)
             }
@@ -52,7 +63,7 @@ impl Logger {
 
     pub fn get_verbosity(&self) -> Verbosity {
         match self {
-            Logger::DevNull => Verbosity::Simple,
+            Logger::DevNull | Logger::Channel(_) => Verbosity::Simple,
             Logger::CommandLine(verbosity) => *verbosity,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@ use mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let build_timestamp = env!("VERGEN_BUILD_TIMESTAMP");
     let header = "\nCommit:    ".to_string()
         + &env!("VERGEN_GIT_SHA")[0..7]
@@ -18,5 +19,6 @@ fn main() {
         header.as_str(),
         &TestRunner(Box::new(CoreHooksProvider {})),
         vec![],
-    );
+    )
+    .await;
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3,12 +3,13 @@ use mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let header = format!(
         "Hakana\n\nCommit:    {}\nTimestamp: {}",
         &env!("VERGEN_GIT_SHA")[0..7],
         env!("VERGEN_BUILD_TIMESTAMP")
     );
 
-    hakana_cli::mcp::run(vec![], header);
+    hakana_cli::mcp::run(vec![], header).await;
 }

--- a/src/mcp_server/Cargo.toml
+++ b/src/mcp_server/Cargo.toml
@@ -11,6 +11,7 @@ hakana-analyzer = { path = "../analyzer" }
 hakana-code-info = { path = "../code_info" }
 hakana-orchestrator = { path = "../orchestrator" }
 hakana-protocol = { path = "../protocol" }
+tokio = { version = "1.28", features = ["rt-multi-thread", "net", "time", "io-util"] }
 hakana-server = { path = "../server" }
 hakana-str = { path = "../str" }
 hakana-logger = { path = "../logger" }

--- a/src/mcp_server/protocol.rs
+++ b/src/mcp_server/protocol.rs
@@ -1,5 +1,3 @@
-//! MCP protocol implementation using JSON-RPC over stdio.
-
 use crate::tools::Tool;
 use hakana_analyzer::custom_hook::CustomHook;
 use hakana_protocol::{
@@ -12,16 +10,15 @@ use std::io;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::time::Instant;
 
-/// MCP protocol version
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
-/// Server information
 const SERVER_NAME: &str = "hakana-mcp";
 const SERVER_VERSION: &str = "0.1.0";
 
-/// JSON-RPC request structure
 #[derive(Debug, Deserialize)]
 struct JsonRpcRequest {
     #[allow(dead_code)]
@@ -32,7 +29,6 @@ struct JsonRpcRequest {
     params: Value,
 }
 
-/// JSON-RPC response structure
 #[derive(Debug, Serialize)]
 struct JsonRpcResponse {
     jsonrpc: String,
@@ -44,7 +40,6 @@ struct JsonRpcResponse {
     error: Option<JsonRpcError>,
 }
 
-/// JSON-RPC error structure
 #[derive(Debug, Serialize)]
 struct JsonRpcError {
     code: i32,
@@ -77,27 +72,18 @@ impl JsonRpcResponse {
     }
 }
 
-/// MCP Server state
 pub struct McpServer {
-    /// Root directory of the project
     root_dir: String,
-    /// Number of threads for analysis
     threads: u8,
-    /// Analysis config path
     config_path: Option<String>,
-    /// Analysis plugins (unused but kept for API compatibility)
     #[allow(dead_code)]
     plugins: Vec<Arc<dyn CustomHook>>,
-    /// Socket path for connecting to hakana server
     socket_path: SocketPath,
-    /// Whether server is ready
     server_ready: bool,
-    /// Whether the server has been initialized
     initialized: bool,
 }
 
 impl McpServer {
-    /// Create a new MCP server
     pub fn new(
         root_dir: String,
         threads: u8,
@@ -117,21 +103,18 @@ impl McpServer {
         }
     }
 
-    /// Try to connect to existing hakana server, or spawn one and wait for it
-    fn ensure_server_ready(&mut self) -> Result<(), String> {
+    async fn ensure_server_ready(&mut self) -> Result<(), String> {
         if self.server_ready {
             return Ok(());
         }
 
         if !self.socket_path.server_exists() {
-            // Spawn a new server
             eprintln!("Spawning hakana server...");
             self.spawn_server()?;
 
-            // Wait for server socket to appear
             eprintln!("Waiting for server to start...");
             let start = Instant::now();
-            let timeout = Duration::from_secs(300); // 5 minutes for initial analysis
+            let timeout = Duration::from_secs(300);
 
             loop {
                 if self.socket_path.server_exists() {
@@ -140,21 +123,18 @@ impl McpServer {
                 if start.elapsed() > timeout {
                     return Err("Timed out waiting for hakana server to start".to_string());
                 }
-                std::thread::sleep(Duration::from_millis(100));
+                tokio::time::sleep(Duration::from_millis(100)).await;
             }
             eprintln!("Server socket appeared, waiting for analysis to complete...");
         }
 
-        // Poll server until analysis is complete
-        self.wait_for_server_ready()?;
+        self.wait_for_server_ready().await?;
         self.server_ready = true;
 
         Ok(())
     }
 
-    /// Spawn a hakana server in the background
     fn spawn_server(&self) -> Result<(), String> {
-        // Find the hakana binary (should be in the same directory as hakana-mcp)
         let current_exe = std::env::current_exe()
             .map_err(|e| format!("Could not determine current executable: {}", e))?;
 
@@ -174,7 +154,6 @@ impl McpServer {
             self.root_dir
         );
 
-        // Spawn the server as a background process
         let child = Command::new(&hakana_exe)
             .arg("server")
             .arg("--root")
@@ -189,59 +168,43 @@ impl McpServer {
             .spawn()
             .map_err(|e| format!("Failed to spawn server: {}", e))?;
 
-        // Don't wait for the child - let it run in the background
         std::mem::forget(child);
 
         Ok(())
     }
 
-    /// Wait for the server to complete its initial analysis
-    fn wait_for_server_ready(&self) -> Result<(), String> {
+    async fn wait_for_server_ready(&self) -> Result<(), String> {
         let start = Instant::now();
-        let timeout = Duration::from_secs(300); // 5 minutes
+        let timeout = Duration::from_secs(300);
 
         loop {
             if start.elapsed() > timeout {
                 return Err("Timed out waiting for server to complete analysis".to_string());
             }
 
-            match ClientSocket::connect(&self.socket_path) {
-                Ok(mut client) => {
-                    match client.request(&Message::Status(StatusRequest)) {
-                        Ok(Message::StatusResult(status)) => {
-                            if status.ready && !status.analysis_in_progress {
-                                eprintln!(
-                                    "\nServer analysis complete: {} files, {} symbols",
-                                    status.files_count, status.symbols_count
-                                );
-                                return Ok(());
-                            }
-                            // Still analyzing, show progress
-                            let elapsed = start.elapsed().as_secs();
-                            eprint!(
-                                "\rAnalysis in progress... {}s (files: {})",
-                                elapsed, status.files_count
-                            );
-                        }
-                        Ok(_) => {
-                            // Unexpected response, wait and retry
-                        }
-                        Err(_) => {
-                            // Connection error, wait and retry
-                        }
-                    }
+            if let Ok(mut client) = ClientSocket::connect(&self.socket_path).await
+                && let Ok(Message::StatusResult(status)) =
+                    client.request(&Message::Status(StatusRequest)).await
+            {
+                if status.ready && !status.analysis_in_progress {
+                    eprintln!(
+                        "\nServer analysis complete: {} files, {} symbols",
+                        status.files_count, status.symbols_count
+                    );
+                    return Ok(());
                 }
-                Err(_) => {
-                    // Server not ready yet, wait and retry
-                }
+                let elapsed = start.elapsed().as_secs();
+                eprint!(
+                    "\rAnalysis in progress... {}s (files: {})",
+                    elapsed, status.files_count
+                );
             }
 
-            std::thread::sleep(Duration::from_millis(500));
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
     }
 
-    /// Handle an incoming JSON-RPC request
-    fn handle_request(&mut self, request: JsonRpcRequest) -> JsonRpcResponse {
+    async fn handle_request(&mut self, request: JsonRpcRequest) -> JsonRpcResponse {
         match request.method.as_str() {
             "initialize" => self.handle_initialize(request.id, request.params),
             "initialized" | "notifications/initialized" => {
@@ -249,7 +212,7 @@ impl McpServer {
                 JsonRpcResponse::success(request.id, json!({}))
             }
             "tools/list" => self.handle_tools_list(request.id),
-            "tools/call" => self.handle_tools_call(request.id, request.params),
+            "tools/call" => self.handle_tools_call(request.id, request.params).await,
             "shutdown" => JsonRpcResponse::success(request.id, json!({})),
             _ => JsonRpcResponse::error(
                 request.id,
@@ -259,7 +222,6 @@ impl McpServer {
         }
     }
 
-    /// Handle initialize request
     fn handle_initialize(&mut self, id: Option<Value>, _params: Value) -> JsonRpcResponse {
         self.initialized = true;
 
@@ -280,7 +242,6 @@ impl McpServer {
         )
     }
 
-    /// Handle tools/list request
     fn handle_tools_list(&self, id: Option<Value>) -> JsonRpcResponse {
         let tools = vec![
             Tool::find_symbol_usages_definition(),
@@ -295,8 +256,7 @@ impl McpServer {
         )
     }
 
-    /// Handle tools/call request
-    fn handle_tools_call(&mut self, id: Option<Value>, params: Value) -> JsonRpcResponse {
+    async fn handle_tools_call(&mut self, id: Option<Value>, params: Value) -> JsonRpcResponse {
         #[derive(Deserialize)]
         struct ToolCallParams {
             name: String,
@@ -312,20 +272,21 @@ impl McpServer {
         };
 
         match call_params.name.as_str() {
-            "find_symbol_usages" => self.handle_find_symbol_usages(id, call_params.arguments),
-            "goto_definition" => self.handle_goto_definition(id, call_params.arguments),
+            "find_symbol_usages" => {
+                self.handle_find_symbol_usages(id, call_params.arguments)
+                    .await
+            }
+            "goto_definition" => self.handle_goto_definition(id, call_params.arguments).await,
             _ => JsonRpcResponse::error(id, -32602, format!("Unknown tool: {}", call_params.name)),
         }
     }
 
-    /// Handle find_symbol_usages tool call
-    fn handle_find_symbol_usages(
+    async fn handle_find_symbol_usages(
         &mut self,
         id: Option<Value>,
         arguments: Value,
     ) -> JsonRpcResponse {
-        // Ensure server is running
-        if let Err(e) = self.ensure_server_ready() {
+        if let Err(e) = self.ensure_server_ready().await {
             return JsonRpcResponse::error(id, -32603, e);
         }
 
@@ -341,8 +302,7 @@ impl McpServer {
             }
         };
 
-        // Connect to server and make the request
-        let mut client = match ClientSocket::connect(&self.socket_path) {
+        let mut client = match ClientSocket::connect(&self.socket_path).await {
             Ok(c) => c,
             Err(e) => {
                 return JsonRpcResponse::error(
@@ -357,7 +317,7 @@ impl McpServer {
             symbol_name: params.symbol_name.clone(),
         });
 
-        match client.request(&request) {
+        match client.request(&request).await {
             Ok(Message::FindSymbolReferencesResult(response)) => {
                 let content = if !response.symbol_found {
                     format!("Symbol not found: {}", params.symbol_name)
@@ -411,10 +371,12 @@ impl McpServer {
         }
     }
 
-    /// Handle goto_definition tool call
-    fn handle_goto_definition(&mut self, id: Option<Value>, arguments: Value) -> JsonRpcResponse {
-        // Ensure server is running
-        if let Err(e) = self.ensure_server_ready() {
+    async fn handle_goto_definition(
+        &mut self,
+        id: Option<Value>,
+        arguments: Value,
+    ) -> JsonRpcResponse {
+        if let Err(e) = self.ensure_server_ready().await {
             return JsonRpcResponse::error(id, -32603, e);
         }
 
@@ -432,8 +394,7 @@ impl McpServer {
             }
         };
 
-        // Connect to server and make the request
-        let mut client = match ClientSocket::connect(&self.socket_path) {
+        let mut client = match ClientSocket::connect(&self.socket_path).await {
             Ok(c) => c,
             Err(e) => {
                 return JsonRpcResponse::error(
@@ -450,7 +411,7 @@ impl McpServer {
             column: params.column,
         });
 
-        match client.request(&request) {
+        match client.request(&request).await {
             Ok(Message::GotoDefinitionResult(response)) => {
                 let content = if !response.found {
                     format!(
@@ -507,14 +468,14 @@ impl McpServer {
     }
 }
 
-/// Run the MCP server message loop over the given reader/writer.
-fn run_mcp_server_io(
+async fn run_mcp_server_io(
     server: &mut McpServer,
-    reader: impl io::BufRead,
-    writer: &mut impl io::Write,
+    reader: impl tokio::io::AsyncBufRead + Unpin,
+    writer: &mut (impl tokio::io::AsyncWrite + Unpin),
 ) -> io::Result<()> {
-    for line in reader.lines() {
-        let line = line?;
+    let mut lines = reader.lines();
+
+    while let Some(line) = lines.next_line().await? {
         if line.trim().is_empty() {
             continue;
         }
@@ -525,40 +486,43 @@ fn run_mcp_server_io(
                 let error_response =
                     JsonRpcResponse::error(None, -32700, format!("Parse error: {}", e));
                 let response_json = serde_json::to_string(&error_response)?;
-                writeln!(writer, "{}", response_json)?;
-                writer.flush()?;
+                writer
+                    .write_all(format!("{}\n", response_json).as_bytes())
+                    .await?;
+                writer.flush().await?;
                 continue;
             }
         };
 
         let is_notification = request.id.is_none();
 
-        // Handle shutdown specially
         if request.method == "shutdown" {
-            let response = server.handle_request(request);
+            let response = server.handle_request(request).await;
             let response_json = serde_json::to_string(&response)?;
-            writeln!(writer, "{}", response_json)?;
-            writer.flush()?;
+            writer
+                .write_all(format!("{}\n", response_json).as_bytes())
+                .await?;
+            writer.flush().await?;
             break;
         }
 
-        let response = server.handle_request(request);
+        let response = server.handle_request(request).await;
 
-        // Per JSON-RPC 2.0, notifications (no "id") must not receive a response
         if is_notification {
             continue;
         }
 
         let response_json = serde_json::to_string(&response)?;
-        writeln!(writer, "{}", response_json)?;
-        writer.flush()?;
+        writer
+            .write_all(format!("{}\n", response_json).as_bytes())
+            .await?;
+        writer.flush().await?;
     }
 
     Ok(())
 }
 
-/// Run the MCP server, reading from stdin and writing to stdout
-pub fn run_mcp_server(
+pub async fn run_mcp_server(
     root_dir: String,
     threads: u8,
     config_path: Option<String>,
@@ -566,10 +530,10 @@ pub fn run_mcp_server(
     header: String,
 ) -> io::Result<()> {
     let mut server = McpServer::new(root_dir, threads, config_path, plugins, header);
-    let stdin = io::stdin();
-    let mut stdout = io::stdout();
+    let stdin = BufReader::new(tokio::io::stdin());
+    let mut stdout = tokio::io::stdout();
 
-    run_mcp_server_io(&mut server, stdin.lock(), &mut stdout)?;
+    run_mcp_server_io(&mut server, stdin, &mut stdout).await?;
 
     eprintln!("Hakana MCP server shutting down");
     Ok(())
@@ -578,21 +542,16 @@ pub fn run_mcp_server(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::BufReader;
 
-    fn run_session(messages: &[&str]) -> Vec<serde_json::Value> {
+    async fn run_session(messages: &[&str]) -> Vec<serde_json::Value> {
         let input = messages.join("\n") + "\n";
         let reader = BufReader::new(input.as_bytes());
         let mut output = Vec::new();
 
-        let mut server = McpServer::new(
-            "/tmp/fake".to_string(),
-            1,
-            None,
-            vec![],
-            String::new(),
-        );
-        run_mcp_server_io(&mut server, reader, &mut output).unwrap();
+        let mut server = McpServer::new("/tmp/fake".to_string(), 1, None, vec![], String::new());
+        run_mcp_server_io(&mut server, reader, &mut output)
+            .await
+            .unwrap();
 
         String::from_utf8(output)
             .unwrap()
@@ -601,44 +560,46 @@ mod tests {
             .collect()
     }
 
-    /// Repro from https://gist.slack-github.com/juno-suarez/445e9b74e09d3c8bf44ffa125eab7649
-    ///
-    /// Sends the initialize request followed by a notifications/initialized
-    /// notification (no "id"). The server must respond to the request but
-    /// must NOT respond to the notification per JSON-RPC 2.0.
-    #[test]
-    fn notifications_initialized_gets_no_response() {
+    #[tokio::test]
+    async fn notifications_initialized_gets_no_response() {
         let initialize = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}"#;
         let notification = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
 
-        let responses = run_session(&[initialize, notification]);
+        let responses = run_session(&[initialize, notification]).await;
 
-        // Exactly one response: the initialize result for id=1
-        assert_eq!(responses.len(), 1, "expected 1 response, got: {responses:?}");
+        assert_eq!(
+            responses.len(),
+            1,
+            "expected 1 response, got: {responses:?}"
+        );
         assert_eq!(responses[0]["id"], 1);
         assert!(responses[0]["result"].is_object());
         assert!(responses[0]["error"].is_null());
     }
 
-    #[test]
-    fn unknown_method_with_id_gets_error_response() {
+    #[tokio::test]
+    async fn unknown_method_with_id_gets_error_response() {
         let request = r#"{"jsonrpc":"2.0","id":42,"method":"bogus/method"}"#;
-        let responses = run_session(&[request]);
+        let responses = run_session(&[request]).await;
 
         assert_eq!(responses.len(), 1);
         assert_eq!(responses[0]["id"], 42);
         assert_eq!(responses[0]["error"]["code"], -32601);
     }
 
-    #[test]
-    fn unknown_notification_is_silently_ignored() {
+    #[tokio::test]
+    async fn unknown_notification_is_silently_ignored() {
         let initialize = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}"#;
-        let notification = r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":99}}"#;
+        let notification =
+            r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":99}}"#;
 
-        let responses = run_session(&[initialize, notification]);
+        let responses = run_session(&[initialize, notification]).await;
 
-        // Only the initialize response, no response for the notification
-        assert_eq!(responses.len(), 1, "expected 1 response, got: {responses:?}");
+        assert_eq!(
+            responses.len(),
+            1,
+            "expected 1 response, got: {responses:?}"
+        );
         assert_eq!(responses[0]["id"], 1);
     }
 }

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -31,10 +31,6 @@ rustc-hash = "1.1.0"
 glob = "0.3.0"
 chrono = "0.4"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tower-lsp = { version = "=0.20.0", features = ["proposed"] }
-tokio = { version = "1.26.0", features = ["full"] }
-
 [lib]
 path = "lib.rs"
 

--- a/src/orchestrator/lib.rs
+++ b/src/orchestrator/lib.rs
@@ -26,10 +26,6 @@ use std::fs;
 use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-#[cfg(not(target_arch = "wasm32"))]
-use tower_lsp::Client;
-#[cfg(not(target_arch = "wasm32"))]
-use tower_lsp::lsp_types::MessageType;
 use unused_symbols::find_unused_definitions;
 
 mod analyzer;
@@ -78,245 +74,6 @@ impl Default for SuccessfulScanData {
 
 use std::sync::atomic::AtomicU32;
 
-#[cfg(not(target_arch = "wasm32"))]
-pub async fn scan_and_analyze_async<P>(
-    stubs_dirs: Vec<String>,
-    filter: Option<String>,
-    ignored_paths: Option<FxHashSet<String>>,
-    config: Arc<Config>,
-    threads: u8,
-    lsp_client: Option<&Client>,
-    header: &str,
-    interner: Arc<Interner>,
-    previous_scan_data: Option<SuccessfulScanData>,
-    previous_analysis_result: Option<AnalysisResult>,
-    language_server_changes: Option<FxHashMap<String, FileStatus>>,
-    mut progress_callback: Option<P>,
-    files_scanned: Option<Arc<AtomicU32>>,
-    total_files_to_scan: Option<Arc<AtomicU32>>,
-    files_analyzed: Option<Arc<AtomicU32>>,
-) -> io::Result<(AnalysisResult, SuccessfulScanData)>
-where
-    P: FnMut(AnalysisProgress),
-{
-    let mut all_scanned_dirs = stubs_dirs.clone();
-    all_scanned_dirs.push(config.root_dir.clone());
-
-    if let Some(client) = lsp_client {
-        client
-            .log_message(MessageType::INFO, "Scanning files")
-            .await;
-    }
-
-    if let Some(ref mut cb) = progress_callback {
-        cb(AnalysisProgress {
-            phase: "Scanning".to_string(),
-            files_analyzed: 0,
-            total_files: 0,
-        });
-    }
-
-    tokio::time::sleep(Duration::from_millis(10)).await;
-
-    let ScanFilesResult {
-        mut codebase,
-        mut interner,
-        resolved_names,
-        codebase_diff,
-        file_system,
-        mut files_to_analyze,
-        invalid_files,
-    } = scan_files(
-        &all_scanned_dirs,
-        None,
-        &config,
-        threads,
-        Arc::new(Logger::DevNull),
-        header,
-        &interner,
-        previous_scan_data,
-        language_server_changes,
-        files_scanned,
-        total_files_to_scan,
-    )?;
-
-    let total_files = codebase.files.len() as u32;
-    if let Some(ref mut cb) = progress_callback {
-        cb(AnalysisProgress {
-            phase: "Scanning complete".to_string(),
-            files_analyzed: 0,
-            total_files,
-        });
-    }
-
-    let mut cached_analysis = if config.ast_diff {
-        mark_safe_symbols_from_diff(
-            &Arc::new(Logger::DevNull),
-            codebase_diff,
-            &codebase,
-            &mut interner,
-            invalid_files,
-            &mut files_to_analyze,
-            &None,
-            &None,
-            previous_analysis_result,
-            config.max_changes_allowed,
-        )
-    } else {
-        CachedAnalysis::default()
-    };
-
-    if let Some(client) = lsp_client {
-        client
-            .log_message(MessageType::INFO, "Calculating symbol inheritance")
-            .await;
-    }
-
-    if let Some(ref mut cb) = progress_callback {
-        cb(AnalysisProgress {
-            phase: "Calculating inheritance".to_string(),
-            files_analyzed: 0,
-            total_files,
-        });
-    }
-
-    tokio::time::sleep(Duration::from_millis(10)).await;
-
-    populate_codebase(
-        &mut codebase,
-        &interner,
-        &mut cached_analysis.symbol_references,
-        cached_analysis.safe_symbols,
-        cached_analysis.safe_symbol_members,
-        &config,
-    );
-
-    for hook in &config.hooks {
-        hook.after_populate(&codebase, &interner, &config);
-    }
-
-    // Check for duplicate definitions and skip analysis if found
-    if codebase.has_duplicates() {
-        if let Some(client) = lsp_client {
-            client
-                .log_message(
-                    MessageType::ERROR,
-                    "ERROR: Duplicate definitions found in codebase. Skipping analysis.",
-                )
-                .await;
-        }
-
-        let duplicate_issues = emit_duplicate_definition_issues(&codebase, &interner);
-
-        let (analysis_result, arc_scan_data) = get_analysis_ready(
-            &config,
-            codebase,
-            interner,
-            file_system,
-            resolved_names,
-            cached_analysis.symbol_references,
-            cached_analysis.existing_issues,
-            cached_analysis.definition_locations,
-        );
-
-        // Add duplicate issues to the result
-        {
-            let mut result = analysis_result.lock().unwrap();
-            for (file_path, issues) in duplicate_issues {
-                result
-                    .emitted_issues
-                    .entry(file_path)
-                    .or_default()
-                    .extend(issues);
-            }
-            result.has_invalid_hack_files = true;
-        }
-
-        let scan_data = Arc::try_unwrap(arc_scan_data).unwrap();
-        let analysis_result = (*analysis_result.lock().unwrap()).clone();
-        return Ok((analysis_result, scan_data));
-    }
-
-    let (analysis_result, arc_scan_data) = get_analysis_ready(
-        &config,
-        codebase,
-        interner,
-        file_system,
-        resolved_names,
-        cached_analysis.symbol_references,
-        cached_analysis.existing_issues,
-        cached_analysis.definition_locations,
-    );
-
-    let files_to_analyze_count = files_to_analyze.len() as u32;
-
-    if let Some(client) = lsp_client {
-        client
-            .log_message(
-                MessageType::INFO,
-                &format!("Analyzing {} files", files_to_analyze_count),
-            )
-            .await;
-    }
-
-    if let Some(ref mut cb) = progress_callback {
-        cb(AnalysisProgress {
-            phase: "Analyzing".to_string(),
-            files_analyzed: 0,
-            total_files: files_to_analyze_count,
-        });
-    }
-
-    tokio::time::sleep(Duration::from_millis(10)).await;
-
-    analyze_files(
-        files_to_analyze,
-        arc_scan_data.clone(),
-        config.clone(),
-        &analysis_result,
-        filter,
-        &ignored_paths,
-        threads,
-        Arc::new(Logger::DevNull),
-        &mut Duration::default(),
-        files_analyzed,
-    )?;
-
-    let mut analysis_result = (*analysis_result.lock().unwrap()).clone();
-
-    let mut scan_data = Arc::try_unwrap(arc_scan_data).unwrap();
-
-    add_invalid_files(&scan_data, &mut analysis_result);
-
-    if config.find_unused_definitions {
-        if let Some(ref mut cb) = progress_callback {
-            cb(AnalysisProgress {
-                phase: "Finding unused definitions".to_string(),
-                files_analyzed: files_to_analyze_count,
-                total_files: files_to_analyze_count,
-            });
-        }
-        find_unused_definitions(
-            &mut analysis_result,
-            &config,
-            &mut scan_data.codebase,
-            &scan_data.interner,
-            &ignored_paths,
-            &mut scan_data.file_system,
-        );
-    }
-
-    if let Some(ref mut cb) = progress_callback {
-        cb(AnalysisProgress {
-            phase: "Complete".to_string(),
-            files_analyzed: files_to_analyze_count,
-            total_files: files_to_analyze_count,
-        });
-    }
-
-    Ok((analysis_result, scan_data))
-}
-
 pub fn scan_and_analyze<F: FnOnce()>(
     stubs_dirs: Vec<String>,
     filter: Option<String>,
@@ -326,11 +83,49 @@ pub fn scan_and_analyze<F: FnOnce()>(
     threads: u8,
     logger: Arc<Logger>,
     header: &str,
-    interner: Interner,
+    interner: Arc<Interner>,
     previous_scan_data: Option<SuccessfulScanData>,
     previous_analysis_result: Option<AnalysisResult>,
     language_server_changes: Option<FxHashMap<String, FileStatus>>,
     chaos_monkey: F,
+) -> io::Result<(AnalysisResult, SuccessfulScanData)> {
+    scan_and_analyze_with_progress(
+        stubs_dirs,
+        filter,
+        ignored_paths,
+        config,
+        cache_dir,
+        threads,
+        logger,
+        header,
+        interner,
+        previous_scan_data,
+        previous_analysis_result,
+        language_server_changes,
+        chaos_monkey,
+        None,
+        None,
+        None,
+    )
+}
+
+pub fn scan_and_analyze_with_progress<F: FnOnce()>(
+    stubs_dirs: Vec<String>,
+    filter: Option<String>,
+    ignored_paths: Option<FxHashSet<String>>,
+    config: Arc<Config>,
+    cache_dir: Option<&String>,
+    threads: u8,
+    logger: Arc<Logger>,
+    header: &str,
+    interner: Arc<Interner>,
+    previous_scan_data: Option<SuccessfulScanData>,
+    previous_analysis_result: Option<AnalysisResult>,
+    language_server_changes: Option<FxHashMap<String, FileStatus>>,
+    chaos_monkey: F,
+    files_scanned: Option<Arc<AtomicU32>>,
+    total_files_to_scan: Option<Arc<AtomicU32>>,
+    files_analyzed: Option<Arc<AtomicU32>>,
 ) -> io::Result<(AnalysisResult, SuccessfulScanData)> {
     let mut all_scanned_dirs = stubs_dirs.clone();
     all_scanned_dirs.push(config.root_dir.clone());
@@ -354,11 +149,11 @@ pub fn scan_and_analyze<F: FnOnce()>(
         threads,
         logger.clone(),
         header,
-        &Arc::new(interner),
+        &interner,
         previous_scan_data,
         language_server_changes,
-        None,
-        None,
+        files_scanned,
+        total_files_to_scan,
     )?;
 
     let file_discovery_and_scanning_elapsed = file_discovery_and_scanning_now.elapsed();
@@ -487,7 +282,7 @@ pub fn scan_and_analyze<F: FnOnce()>(
         threads,
         logger.clone(),
         &mut pure_file_analysis_time,
-        None,
+        files_analyzed,
     )?;
 
     if logger.can_log_timing() {

--- a/src/protocol/Cargo.toml
+++ b/src/protocol/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "hakana-protocol"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 hakana-code-info = { path = "../code_info" }
 hakana-orchestrator = { path = "../orchestrator" }
 rustc-hash = "1.1.0"
+tokio = { version = "1.28", features = ["net", "io-util"] }
+
+[dev-dependencies]
+tokio = { version = "1.28", features = ["rt", "macros", "time"] }
 
 [lib]
 path = "lib.rs"

--- a/src/protocol/serialize.rs
+++ b/src/protocol/serialize.rs
@@ -7,7 +7,9 @@
 //! └──────────────┴──────────────┴─────────────────┘
 //! ```
 
-use std::io::{self, Read, Write};
+use std::io;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::types::*;
 
@@ -669,6 +671,7 @@ impl Serialize for GetIssuesRequest {
         write_option_string(buf, &self.filter);
         write_bool(buf, self.find_unused_expressions);
         write_bool(buf, self.find_unused_definitions);
+        write_bool(buf, self.block_until_next_analysis);
     }
 }
 
@@ -677,11 +680,13 @@ impl Deserialize for GetIssuesRequest {
         let (filter, rest) = read_option_string(data)?;
         let (find_unused_expressions, rest) = read_bool(rest)?;
         let (find_unused_definitions, rest) = read_bool(rest)?;
+        let (block_until_next_analysis, rest) = read_bool(rest)?;
         Ok((
             Self {
                 filter,
                 find_unused_expressions,
                 find_unused_definitions,
+                block_until_next_analysis,
             },
             rest,
         ))
@@ -1014,22 +1019,26 @@ pub fn decode_message(data: &[u8]) -> Result<(Message, &[u8]), ProtocolError> {
     Ok((msg, &data[4 + frame_len..]))
 }
 
-/// Read a complete message from a reader.
-pub fn read_message<R: Read>(reader: &mut R) -> Result<Message, ProtocolError> {
-    // Read length prefix
+pub async fn read_message<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut R,
+) -> Result<Message, ProtocolError> {
     let mut len_buf = [0u8; 4];
-    reader.read_exact(&mut len_buf)?;
+    reader
+        .read_exact(&mut len_buf)
+        .await
+        .map_err(|e| ProtocolError::Io(e))?;
     let len = u32::from_le_bytes(len_buf);
 
     if len > MAX_MESSAGE_SIZE {
         return Err(ProtocolError::MessageTooLarge(len));
     }
 
-    // Read the rest of the frame
     let mut frame = vec![0u8; len as usize];
-    reader.read_exact(&mut frame)?;
+    reader
+        .read_exact(&mut frame)
+        .await
+        .map_err(|e| ProtocolError::Io(e))?;
 
-    // Parse message type
     if frame.is_empty() {
         return Err(ProtocolError::UnexpectedEof);
     }
@@ -1037,16 +1046,20 @@ pub fn read_message<R: Read>(reader: &mut R) -> Result<Message, ProtocolError> {
     let msg_type =
         MessageType::try_from(msg_type_byte).map_err(ProtocolError::InvalidMessageType)?;
 
-    // Parse payload
     let payload = &frame[1..];
     Message::deserialize_with_type(msg_type, payload)
 }
 
-/// Write a message to a writer.
-pub fn write_message<W: Write>(writer: &mut W, msg: &Message) -> Result<(), ProtocolError> {
+pub async fn write_message<W: tokio::io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    msg: &Message,
+) -> Result<(), ProtocolError> {
     let frame = encode_message(msg);
-    writer.write_all(&frame)?;
-    writer.flush()?;
+    writer
+        .write_all(&frame)
+        .await
+        .map_err(|e| ProtocolError::Io(e))?;
+    writer.flush().await.map_err(|e| ProtocolError::Io(e))?;
     Ok(())
 }
 

--- a/src/protocol/socket.rs
+++ b/src/protocol/socket.rs
@@ -1,12 +1,10 @@
 //! Unix socket utilities for hakana client-server communication.
 
 use std::fs;
-use std::io::{self, BufReader, BufWriter};
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::io;
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
-use crate::serialize::{ProtocolError, read_message, write_message};
 use crate::types::Message;
 
 /// Socket path configuration.
@@ -61,21 +59,17 @@ impl SocketPath {
     }
 }
 
-/// Server-side socket wrapper.
 pub struct ServerSocket {
-    listener: UnixListener,
+    listener: tokio::net::UnixListener,
     socket_path: SocketPath,
 }
 
 impl ServerSocket {
-    /// Create and bind a new server socket.
     pub fn bind(socket_path: SocketPath) -> io::Result<Self> {
-        // Clean up any stale socket file
         socket_path.cleanup()?;
 
-        let listener = UnixListener::bind(socket_path.path())?;
+        let listener = tokio::net::UnixListener::bind(socket_path.path())?;
 
-        // Set socket permissions to owner-only
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -89,21 +83,11 @@ impl ServerSocket {
         })
     }
 
-    /// Accept a new client connection.
-    pub fn accept(&self) -> io::Result<ClientConnection> {
-        let (stream, _addr) = self.listener.accept()?;
-        // Ensure the connection stream is in blocking mode
-        stream.set_nonblocking(false)?;
+    pub async fn accept(&self) -> io::Result<ClientConnection> {
+        let (stream, _addr) = self.listener.accept().await?;
         Ok(ClientConnection::new(stream))
     }
 
-    /// Set the accept timeout.
-    pub fn set_accept_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
-        self.listener.set_nonblocking(timeout.is_some())?;
-        Ok(())
-    }
-
-    /// Get the socket path.
     pub fn socket_path(&self) -> &SocketPath {
         &self.socket_path
     }
@@ -115,96 +99,55 @@ impl Drop for ServerSocket {
     }
 }
 
-/// A connection to a client (server-side).
 pub struct ClientConnection {
-    reader: BufReader<UnixStream>,
-    writer: BufWriter<UnixStream>,
+    reader: tokio::io::BufReader<tokio::net::unix::OwnedReadHalf>,
+    writer: tokio::io::BufWriter<tokio::net::unix::OwnedWriteHalf>,
 }
 
 impl ClientConnection {
-    fn new(stream: UnixStream) -> Self {
-        // Set a generous write timeout for large responses
-        let _ = stream.set_write_timeout(Some(Duration::from_secs(300)));
-        let reader = BufReader::new(stream.try_clone().expect("Failed to clone stream"));
-        let writer = BufWriter::new(stream);
+    fn new(stream: tokio::net::UnixStream) -> Self {
+        let (read_half, write_half) = stream.into_split();
+        let reader = tokio::io::BufReader::new(read_half);
+        let writer = tokio::io::BufWriter::new(write_half);
         Self { reader, writer }
     }
 
-    /// Read a message from the client.
-    pub fn read_message(&mut self) -> Result<Message, ProtocolError> {
-        read_message(&mut self.reader)
+    pub async fn read_message(&mut self) -> Result<Message, crate::serialize::ProtocolError> {
+        crate::serialize::read_message(&mut self.reader).await
     }
 
-    /// Write a message to the client.
-    pub fn write_message(&mut self, msg: &Message) -> Result<(), ProtocolError> {
-        write_message(&mut self.writer, msg)
-    }
-
-    /// Set read timeout.
-    pub fn set_read_timeout(&mut self, timeout: Option<Duration>) -> io::Result<()> {
-        self.reader.get_ref().set_read_timeout(timeout)
-    }
-
-    /// Set write timeout.
-    pub fn set_write_timeout(&mut self, timeout: Option<Duration>) -> io::Result<()> {
-        self.writer.get_ref().set_write_timeout(timeout)
+    pub async fn write_message(
+        &mut self,
+        msg: &Message,
+    ) -> Result<(), crate::serialize::ProtocolError> {
+        crate::serialize::write_message(&mut self.writer, msg).await
     }
 }
 
-/// Client-side socket wrapper.
 pub struct ClientSocket {
-    reader: BufReader<UnixStream>,
-    writer: BufWriter<UnixStream>,
+    reader: tokio::io::BufReader<tokio::net::unix::OwnedReadHalf>,
+    writer: tokio::io::BufWriter<tokio::net::unix::OwnedWriteHalf>,
 }
 
 impl ClientSocket {
-    /// Connect to a server.
-    pub fn connect(socket_path: &SocketPath) -> io::Result<Self> {
-        let stream = UnixStream::connect(socket_path.path())?;
-        // Set generous timeouts for large responses
-        stream.set_read_timeout(Some(Duration::from_secs(300)))?;
-        stream.set_write_timeout(Some(Duration::from_secs(60)))?;
-        let reader = BufReader::new(stream.try_clone()?);
-        let writer = BufWriter::new(stream);
+    pub async fn connect(socket_path: &SocketPath) -> io::Result<Self> {
+        let stream = tokio::net::UnixStream::connect(socket_path.path()).await?;
+        let (read_half, write_half) = stream.into_split();
+        let reader = tokio::io::BufReader::new(read_half);
+        let writer = tokio::io::BufWriter::new(write_half);
         Ok(Self { reader, writer })
     }
 
-    /// Connect with a timeout.
-    pub fn connect_timeout(socket_path: &SocketPath, timeout: Duration) -> io::Result<Self> {
-        // Unix sockets don't have a direct connect_timeout, so we use non-blocking connect
-        // For simplicity, we'll just use regular connect with a read/write timeout
-        let stream = UnixStream::connect(socket_path.path())?;
-        stream.set_read_timeout(Some(timeout))?;
-        stream.set_write_timeout(Some(timeout))?;
-        let reader = BufReader::new(stream.try_clone()?);
-        let writer = BufWriter::new(stream);
-        Ok(Self { reader, writer })
+    pub async fn request(
+        &mut self,
+        msg: &Message,
+    ) -> Result<Message, crate::serialize::ProtocolError> {
+        crate::serialize::write_message(&mut self.writer, msg).await?;
+        crate::serialize::read_message(&mut self.reader).await
     }
 
-    /// Send a request and wait for a response.
-    pub fn request(&mut self, msg: &Message) -> Result<Message, ProtocolError> {
-        write_message(&mut self.writer, msg)?;
-        read_message(&mut self.reader)
-    }
-
-    /// Send a message without waiting for a response (for notifications).
-    pub fn send(&mut self, msg: &Message) -> Result<(), ProtocolError> {
-        write_message(&mut self.writer, msg)
-    }
-
-    /// Read a message from the server.
-    pub fn read_message(&mut self) -> Result<Message, ProtocolError> {
-        read_message(&mut self.reader)
-    }
-
-    /// Set read timeout.
-    pub fn set_read_timeout(&mut self, timeout: Option<Duration>) -> io::Result<()> {
-        self.reader.get_ref().set_read_timeout(timeout)
-    }
-
-    /// Set write timeout.
-    pub fn set_write_timeout(&mut self, timeout: Option<Duration>) -> io::Result<()> {
-        self.writer.get_ref().set_write_timeout(timeout)
+    pub async fn send(&mut self, msg: &Message) -> Result<(), crate::serialize::ProtocolError> {
+        crate::serialize::write_message(&mut self.writer, msg).await
     }
 }
 
@@ -212,7 +155,6 @@ impl ClientSocket {
 mod tests {
     use super::*;
     use crate::types::*;
-    use std::thread;
 
     #[test]
     fn test_socket_path_hash() {
@@ -226,23 +168,19 @@ mod tests {
         assert_ne!(path1.path(), path3.path());
     }
 
-    #[test]
-    fn test_client_server_roundtrip() {
+    #[tokio::test]
+    async fn test_client_server_roundtrip() {
         let socket_path = SocketPath::from_path(PathBuf::from("/tmp/hakana-test-roundtrip.sock"));
 
-        // Clean up any stale socket
         let _ = socket_path.cleanup();
 
-        // Start server in a thread
         let server_socket_path = socket_path.clone();
-        let server_handle = thread::spawn(move || {
+        let server_handle = tokio::spawn(async move {
             let server = ServerSocket::bind(server_socket_path).expect("Failed to bind");
-            let mut conn = server.accept().expect("Failed to accept");
+            let mut conn = server.accept().await.expect("Failed to accept");
 
-            // Read request
-            let msg = conn.read_message().expect("Failed to read");
+            let msg = conn.read_message().await.expect("Failed to read");
             if let Message::Status(_) = msg {
-                // Send response
                 let response = Message::StatusResult(StatusResponse {
                     ready: true,
                     files_count: 100,
@@ -252,19 +190,20 @@ mod tests {
                     pending_requests: 0,
                     project_root: "/home/user/project".to_string(),
                 });
-                conn.write_message(&response).expect("Failed to write");
+                conn.write_message(&response)
+                    .await
+                    .expect("Failed to write");
             }
         });
 
-        // Give server time to start
-        thread::sleep(Duration::from_millis(100));
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        // Connect client
-        let mut client = ClientSocket::connect(&socket_path).expect("Failed to connect");
+        let mut client = ClientSocket::connect(&socket_path)
+            .await
+            .expect("Failed to connect");
 
-        // Send request and get response
         let request = Message::Status(StatusRequest);
-        let response = client.request(&request).expect("Failed to request");
+        let response = client.request(&request).await.expect("Failed to request");
 
         if let Message::StatusResult(status) = response {
             assert!(status.ready);
@@ -273,6 +212,6 @@ mod tests {
             panic!("Expected StatusResponse");
         }
 
-        server_handle.join().unwrap();
+        server_handle.await.unwrap();
     }
 }

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -234,6 +234,8 @@ pub struct GetIssuesRequest {
     pub find_unused_expressions: bool,
     /// Find unused definitions (dead code).
     pub find_unused_definitions: bool,
+    /// Whether to wait until the next analysis run.
+    pub block_until_next_analysis: bool,
 }
 
 /// Response with current issues.

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hakana-server"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 hakana-protocol = { path = "../protocol" }
@@ -16,6 +16,7 @@ tokio = { version = "1.28", features = ["rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
 hakana-protocol = { path = "../protocol" }
+tokio = { version = "1.28", features = ["rt", "macros", "time"] }
 
 [lib]
 path = "lib.rs"

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -2,291 +2,67 @@
 
 use crate::{ServerConfig, ServerState};
 use hakana_analyzer::config::Config;
+use hakana_code_info::analysis_result::{self, AnalysisResult};
 use hakana_code_info::data_flow::graph::{GraphKind, WholeProgramKind};
 use hakana_logger::Logger;
+use hakana_orchestrator::SuccessfulScanData;
 use hakana_orchestrator::file::FileStatus;
-use hakana_protocol::FileChangeStatus;
 use hakana_protocol::{
     AckResponse, AnalyzeRequest, AnalyzeResponse, ErrorCode, ErrorResponse, FileChange,
     FindReferencesRequest, FindReferencesResponse, FindSymbolReferencesRequest,
     FindSymbolReferencesResponse, GotoDefinitionRequest, GotoDefinitionResponse, Message,
     ProtocolIssue, ReferenceLocation, SecurityCheckRequest, SecurityCheckResponse, StatusResponse,
 };
+use hakana_protocol::{FileChangeStatus, GetIssuesResponse};
 use hakana_str::Interner;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use tokio::sync::mpsc::Sender;
 
 /// Handles incoming requests.
-pub struct RequestHandler<'a> {
-    config: &'a ServerConfig,
-    state: &'a mut ServerState,
-    logger: &'a Arc<Logger>,
+pub struct RequestHandler {
+    config: Arc<ServerConfig>,
+    state: Arc<Mutex<ServerState>>,
+    logger: Arc<Logger>,
+    shutdown_tx: Sender<bool>,
     start_time: Instant,
 }
 
-impl<'a> RequestHandler<'a> {
+impl RequestHandler {
     pub fn new(
-        config: &'a ServerConfig,
-        state: &'a mut ServerState,
-        logger: &'a Arc<Logger>,
+        config: Arc<ServerConfig>,
+        state: Arc<Mutex<ServerState>>,
+        logger: Arc<Logger>,
+        shutdown_tx: Sender<bool>,
         start_time: Instant,
     ) -> Self {
         Self {
             config,
             state,
             logger,
+            shutdown_tx,
             start_time,
         }
     }
 
-    /// Handle an analyze request.
-    pub fn handle_analyze(mut self, req: AnalyzeRequest) -> Message {
-        if self.state.is_analysis_in_progress() {
-            return Message::Error(ErrorResponse {
-                code: ErrorCode::ServerBusy,
-                message: "Analysis already in progress".to_string(),
-            });
-        }
-
-        self.state.set_analysis_in_progress(true);
-
-        let result = self.do_analyze(req);
-
-        self.state.set_analysis_in_progress(false);
-
-        result
-    }
-
-    fn do_analyze(&mut self, req: AnalyzeRequest) -> Message {
-        let scan_start = Instant::now();
-
-        // Build config
-        let mut analysis_config = Config::new(self.config.root_dir.clone(), FxHashSet::default());
-        analysis_config.find_unused_expressions = req.find_unused_expressions;
-        analysis_config.find_unused_definitions = req.find_unused_definitions;
-
-        // Apply allowed issues filter
-        if let Some(allowed) = req.allowed_issues {
-            let mut issue_filter = FxHashSet::default();
-            for issue_name in allowed {
-                if let Ok(issue_kind) = hakana_code_info::issue::IssueKind::from_str_custom(
-                    &issue_name,
-                    &FxHashSet::default(),
-                ) {
-                    issue_filter.insert(issue_kind);
-                }
-            }
-            if !issue_filter.is_empty() {
-                analysis_config.allowed_issues = Some(issue_filter);
-            }
-        }
-
-        // Load config from file if specified
-        let mut interner = Interner::default();
-        if let Some(config_path) = &self.config.config_path {
-            let path = Path::new(config_path);
-            if path.exists() {
-                let _ =
-                    analysis_config.update_from_file(&self.config.root_dir, path, &mut interner);
-            }
-        }
-
-        // Note: Plugins are currently not supported in server mode
-        // due to the Config using Box<dyn CustomHook> rather than Arc
-        // TODO: Refactor Config to use Arc<dyn CustomHook> for server support
-
-        // Convert file changes to the expected format
-        let language_server_changes = if !req.file_changes.is_empty() {
-            let mut changes = FxHashMap::default();
-            for change in req.file_changes {
-                let status = match change.status {
-                    FileChangeStatus::Added => FileStatus::Added(0, 0),
-                    FileChangeStatus::Modified => FileStatus::Modified(0, 0),
-                    FileChangeStatus::Deleted => FileStatus::Deleted,
-                };
-                changes.insert(change.path, status);
-            }
-            Some(changes)
-        } else {
-            None
-        };
-
-        // Get previous state if available and not forcing full rescan
-        let (previous_scan_data, previous_analysis_result) = if !req.full_rescan {
-            (
-                self.state.scan_data.take(),
-                self.state.analysis_result.take(),
-            )
-        } else {
-            (None, None)
-        };
-
-        let scan_elapsed = scan_start.elapsed();
-
-        let analysis_start = Instant::now();
-
-        // Run analysis
-        let result = hakana_orchestrator::scan_and_analyze(
-            Vec::new(),
-            req.filter,
-            None,
-            Arc::new(analysis_config),
-            None, // No cache dir for server mode
-            self.config.threads,
-            self.logger.clone(),
-            &self.config.header,
-            interner,
-            previous_scan_data,
-            previous_analysis_result,
-            language_server_changes,
-            || {},
-        );
-
-        let analysis_elapsed = analysis_start.elapsed();
-
-        match result {
-            Ok((analysis_result, scan_data)) => {
-                // Collect issues
-                let mut issues = Vec::new();
-                let mut files_with_issues = FxHashSet::default();
-
-                for (file_path, file_issues) in &analysis_result.emitted_issues {
-                    let file_path_str =
-                        file_path.get_relative_path(&scan_data.interner, &self.config.root_dir);
-                    files_with_issues.insert(file_path_str.clone());
-
-                    for issue in file_issues {
-                        issues.push(ProtocolIssue::from_issue(issue, &file_path_str));
-                    }
-                }
-
-                let files_analyzed = scan_data.codebase.files.len() as u32;
-
-                // Update server state
-                self.state.update_state(scan_data, analysis_result);
-
-                Message::AnalyzeResult(AnalyzeResponse {
-                    success: true,
-                    issues,
-                    scan_time_ms: scan_elapsed.as_millis() as u64,
-                    analysis_time_ms: analysis_elapsed.as_millis() as u64,
-                    files_analyzed,
-                    files_with_issues: files_with_issues.len() as u32,
-                })
-            }
-            Err(e) => Message::Error(ErrorResponse {
-                code: ErrorCode::AnalysisFailed,
-                message: format!("Analysis failed: {}", e),
-            }),
-        }
-    }
-
-    /// Handle a security check request.
-    pub fn handle_security_check(mut self, req: SecurityCheckRequest) -> Message {
-        if self.state.is_analysis_in_progress() {
-            return Message::Error(ErrorResponse {
-                code: ErrorCode::ServerBusy,
-                message: "Analysis already in progress".to_string(),
-            });
-        }
-
-        self.state.set_analysis_in_progress(true);
-
-        let result = self.do_security_check(req);
-
-        self.state.set_analysis_in_progress(false);
-
-        result
-    }
-
-    fn do_security_check(&mut self, req: SecurityCheckRequest) -> Message {
-        let analysis_start = Instant::now();
-
-        // Build config for taint analysis
-        let mut analysis_config = Config::new(self.config.root_dir.clone(), FxHashSet::default());
-        analysis_config.graph_kind = GraphKind::WholeProgram(WholeProgramKind::Taint);
-
-        if let Some(max_depth) = req.max_depth {
-            analysis_config.security_config.max_depth = max_depth as u8;
-        }
-
-        // Load config from file if specified
-        let mut interner = Interner::default();
-        if let Some(config_path) = &self.config.config_path {
-            let path = Path::new(config_path);
-            if path.exists() {
-                let _ =
-                    analysis_config.update_from_file(&self.config.root_dir, path, &mut interner);
-            }
-        }
-
-        // Run security analysis
-        let result = hakana_orchestrator::scan_and_analyze(
-            Vec::new(),
-            req.filter,
-            None,
-            Arc::new(analysis_config),
-            None,
-            self.config.threads,
-            self.logger.clone(),
-            &self.config.header,
-            interner,
-            None,
-            None,
-            None,
-            || {},
-        );
-
-        let analysis_elapsed = analysis_start.elapsed();
-
-        match result {
-            Ok((analysis_result, scan_data)) => {
-                let mut issues = Vec::new();
-                let mut taint_flows = 0u32;
-
-                for (file_path, file_issues) in &analysis_result.emitted_issues {
-                    let file_path_str =
-                        file_path.get_relative_path(&scan_data.interner, &self.config.root_dir);
-
-                    for issue in file_issues {
-                        // In taint analysis mode, all issues are security-related
-                        taint_flows += 1;
-                        issues.push(ProtocolIssue::from_issue(issue, &file_path_str));
-                    }
-                }
-
-                Message::SecurityCheckResult(SecurityCheckResponse {
-                    success: true,
-                    issues,
-                    taint_flows_found: taint_flows,
-                    analysis_time_ms: analysis_elapsed.as_millis() as u64,
-                })
-            }
-            Err(e) => Message::Error(ErrorResponse {
-                code: ErrorCode::AnalysisFailed,
-                message: format!("Security check failed: {}", e),
-            }),
-        }
-    }
-
     /// Handle a goto-definition request.
-    pub fn handle_goto_definition(self, req: GotoDefinitionRequest) -> Message {
-        let (scan_data, analysis_result) =
-            match (self.state.scan_data(), self.state.analysis_result()) {
-                (Some(sd), Some(ar)) => (sd, ar),
-                _ => {
-                    return Message::GotoDefinitionResult(GotoDefinitionResponse {
-                        found: false,
-                        file_path: None,
-                        start_line: None,
-                        start_column: None,
-                        end_line: None,
-                        end_column: None,
-                    });
-                }
-            };
+    pub fn handle_goto_definition(&self, req: GotoDefinitionRequest) -> Message {
+        let state = self.state.lock().unwrap();
+        let (scan_data, analysis_result) = match (state.scan_data(), state.analysis_result()) {
+            (Some(sd), Some(ar)) => (sd, ar),
+            _ => {
+                return Message::GotoDefinitionResult(GotoDefinitionResponse {
+                    found: false,
+                    file_path: None,
+                    start_line: None,
+                    start_column: None,
+                    end_line: None,
+                    end_column: None,
+                });
+            }
+        };
 
         // Build the full file path
         let full_path = format!("{}/{}", self.config.root_dir, req.file_path);
@@ -373,7 +149,7 @@ impl<'a> RequestHandler<'a> {
     }
 
     /// Handle a find-references request.
-    pub fn handle_find_references(self, req: FindReferencesRequest) -> Message {
+    pub fn handle_find_references(&self, req: FindReferencesRequest) -> Message {
         // TODO: Implement using cached scan data
         // For now, return empty list
         let _ = req;
@@ -384,20 +160,20 @@ impl<'a> RequestHandler<'a> {
     }
 
     /// Handle a find-symbol-references request (by symbol name).
-    pub fn handle_find_symbol_references(self, req: FindSymbolReferencesRequest) -> Message {
+    pub fn handle_find_symbol_references(&self, req: FindSymbolReferencesRequest) -> Message {
         use hakana_code_info::symbol_references_utils::get_references_for_symbol;
+        let state = self.state.lock().unwrap();
 
         // Check if analysis is ready
-        let (scan_data, analysis_result) =
-            match (self.state.scan_data(), self.state.analysis_result()) {
-                (Some(sd), Some(ar)) => (sd, ar),
-                _ => {
-                    return Message::FindSymbolReferencesResult(FindSymbolReferencesResponse {
-                        symbol_found: false,
-                        references: Vec::new(),
-                    });
-                }
-            };
+        let (scan_data, analysis_result) = match (state.scan_data(), state.analysis_result()) {
+            (Some(sd), Some(ar)) => (sd, ar),
+            _ => {
+                return Message::FindSymbolReferencesResult(FindSymbolReferencesResponse {
+                    symbol_found: false,
+                    references: Vec::new(),
+                });
+            }
+        };
 
         let interner = &scan_data.interner;
         let symbol_name = &req.symbol_name;
@@ -460,36 +236,123 @@ impl<'a> RequestHandler<'a> {
         }
     }
 
-    /// Handle file changed notifications.
-    pub fn handle_file_changed(self, changes: Vec<FileChange>) -> Message {
-        // TODO: Track changes for incremental analysis
-        self.logger.log_sync(&format!(
-            "Received {} file change notification(s)",
-            changes.len()
-        ));
-
-        Message::Ack(AckResponse)
-    }
-
     /// Handle status request.
-    pub fn handle_status(self) -> Message {
+    pub fn handle_status(&self) -> Message {
         let uptime = self.start_time.elapsed();
+        let state = self.state.lock().unwrap();
 
         Message::StatusResult(StatusResponse {
-            ready: !self.state.is_analysis_in_progress(),
-            files_count: self.state.files_count(),
-            symbols_count: self.state.symbols_count(),
+            ready: !state.is_analysis_in_progress(),
+            files_count: state.files_count(),
+            symbols_count: state.symbols_count(),
             uptime_secs: uptime.as_secs(),
-            analysis_in_progress: self.state.is_analysis_in_progress(),
-            pending_requests: self.state.pending_requests(),
+            analysis_in_progress: state.is_analysis_in_progress(),
+            pending_requests: state.pending_requests(),
             project_root: self.config.root_dir.clone(),
         })
     }
 
     /// Handle shutdown request.
-    pub fn handle_shutdown(self) -> Message {
+    pub async fn handle_shutdown(&self) -> Message {
         self.logger.log_sync("Shutdown requested");
-        self.state.set_shutting_down();
+        if let Err(e) = self.shutdown_tx.send(true).await {
+            let msg = format!("error requesting shutdown: {}", e);
+            self.logger.log_sync(msg.as_str());
+        }
+        Message::Ack(AckResponse)
+    }
+
+    pub async fn handle_get_issues(
+        &self,
+        analysis_rx: &mut tokio::sync::broadcast::Receiver<
+            Result<Arc<(AnalysisResult, SuccessfulScanData)>, String>,
+        >,
+        req: hakana_protocol::GetIssuesRequest,
+    ) -> Message {
+        if !req.block_until_next_analysis {
+            let state = self.state.lock().unwrap();
+            let analysis_complete = !state.is_analysis_in_progress();
+
+            if analysis_complete && let Some(analysis_result) = &state.analysis_data {
+                return self.create_get_issues_response(req, analysis_result);
+            }
+        }
+
+        if let Ok(result) = analysis_rx.recv().await
+            && let Ok(result) = result.as_ref()
+        {
+            return self.create_get_issues_response(req, result);
+        }
+        Message::GetIssuesResult(GetIssuesResponse {
+            analysis_complete: false,
+            issues: vec![],
+            files_analyzed: 0,
+            total_files: 0,
+            phase: "Complete".to_string(),
+            progress_percent: 100,
+        })
+    }
+
+    fn create_get_issues_response(
+        &self,
+        req: hakana_protocol::GetIssuesRequest,
+        result: &Arc<(AnalysisResult, SuccessfulScanData)>,
+    ) -> Message {
+        let (analysis_result, scan_data) = result.as_ref();
+        let mut issues = Vec::new();
+        for (file_path, file_issues) in &analysis_result.emitted_issues {
+            let file_path_str =
+                file_path.get_relative_path(&scan_data.interner, &self.config.root_dir);
+
+            if let Some(ref filter) = req.filter {
+                if !file_path_str.starts_with(filter) {
+                    continue;
+                }
+            }
+
+            for issue in file_issues {
+                issues.push(ProtocolIssue::from_issue(issue, &file_path_str));
+            }
+        }
+
+        self.logger
+            .log_sync(&format!("Returning {} issues", issues.len()));
+
+        return Message::GetIssuesResult(GetIssuesResponse {
+            analysis_complete: true,
+            issues,
+            files_analyzed: 0,
+            total_files: 0,
+            phase: "Complete".to_string(),
+            progress_percent: 100,
+        });
+    }
+
+    pub fn handle_file_changed(&self, changes: Vec<hakana_protocol::FileChange>) -> Message {
+        use hakana_protocol::FileChangeStatus;
+
+        let change_count = changes.len();
+        self.logger.log_sync(&format!(
+            "Received {} file change notification(s) from client",
+            change_count
+        ));
+
+        let mut state = self.state.lock().unwrap();
+
+        for change in changes {
+            let status = match change.status {
+                FileChangeStatus::Added => FileStatus::Added(0, 0),
+                FileChangeStatus::Modified => FileStatus::Modified(0, 0),
+                FileChangeStatus::Deleted => FileStatus::Deleted,
+            };
+            state.pending_changes.insert(change.path, status);
+        }
+
+        self.logger.log_sync(&format!(
+            "Total pending changes: {}",
+            state.pending_changes.len()
+        ));
+
         Message::Ack(AckResponse)
     }
 }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -1,8 +1,3 @@
-//! Hakana server for handling analysis requests.
-//!
-//! The server maintains warm codebase state and handles requests from CLI and LSP clients.
-//! It performs initial analysis on startup and uses watchman to watch for file changes.
-
 mod handler;
 mod state;
 mod watchman;
@@ -17,29 +12,21 @@ use hakana_logger::Logger;
 use hakana_orchestrator::SuccessfulScanData;
 use hakana_orchestrator::file::FileStatus;
 use hakana_protocol::{
-    AckResponse, ClientConnection, ErrorCode, ErrorResponse, GetIssuesResponse, Message,
-    ProtocolIssue, ServerSocket, SocketPath,
+    ClientConnection, ErrorCode, ErrorResponse, Message, ServerSocket, SocketPath,
 };
 use hakana_str::Interner;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::thread;
-use std::time::{Duration, Instant};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Instant;
 
-/// Server configuration.
 #[derive(Clone)]
 pub struct ServerConfig {
-    /// Project root directory.
     pub root_dir: String,
-    /// Number of threads for analysis.
     pub threads: u8,
-    /// Path to hakana.json config file.
     pub config_path: Option<String>,
-    /// Analysis plugins.
     pub plugins: Vec<Arc<dyn CustomHook>>,
-    /// Build header for cache validation.
     pub header: String,
 }
 
@@ -55,30 +42,28 @@ impl ServerConfig {
     }
 }
 
-/// Check if watchman is available.
 pub fn check_watchman_available() -> Result<(), String> {
     watchman::check_available()
 }
 
-/// The hakana server.
 pub struct Server {
-    config: ServerConfig,
+    config: Arc<ServerConfig>,
     socket: ServerSocket,
-    state: ServerState,
+    state: Arc<Mutex<ServerState>>,
     logger: Arc<Logger>,
     start_time: Instant,
-    /// Pending file changes from watchman
-    pending_changes: FxHashMap<String, FileStatus>,
-    /// Handle for receiving file changes from watchman
     watchman_handle: Option<watchman::WatchmanHandle>,
-    /// Whether a config change triggered full re-analysis is pending
     config_changed: bool,
+    analysis_rx:
+        tokio::sync::broadcast::Receiver<Result<Arc<(AnalysisResult, SuccessfulScanData)>, String>>,
+    analysis_tx:
+        tokio::sync::broadcast::Sender<Result<Arc<(AnalysisResult, SuccessfulScanData)>, String>>,
+    shutdown_tx: tokio::sync::mpsc::Sender<bool>,
+    shutdown_rx: tokio::sync::mpsc::Receiver<bool>,
 }
 
 impl Server {
-    /// Create a new server. Requires watchman to be available.
     pub fn new(config: ServerConfig, logger: Arc<Logger>) -> io::Result<Self> {
-        // Check watchman is available
         if let Err(e) = watchman::check_available() {
             return Err(io::Error::new(
                 io::ErrorKind::NotFound,
@@ -88,7 +73,6 @@ impl Server {
 
         let socket_path = SocketPath::for_project(Path::new(&config.root_dir));
 
-        // Check if a server is already running
         if socket_path.server_exists() {
             return Err(io::Error::new(
                 io::ErrorKind::AddrInUse,
@@ -106,59 +90,36 @@ impl Server {
             socket.socket_path().path().display()
         ));
 
+        let (analysis_tx, analysis_rx) = tokio::sync::broadcast::channel(8);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
+
         Ok(Self {
-            config,
+            config: Arc::new(config),
             socket,
-            state: ServerState::new(),
+            state: Arc::new(Mutex::new(ServerState::new())),
             logger,
             start_time: Instant::now(),
-            pending_changes: FxHashMap::default(),
             watchman_handle: None,
             config_changed: false,
+            analysis_rx,
+            analysis_tx,
+            shutdown_tx,
+            shutdown_rx,
         })
     }
 
-    /// Get the socket path.
     pub fn socket_path(&self) -> &SocketPath {
         self.socket.socket_path()
     }
 
-    /// Run the server main loop.
-    /// This performs initial analysis while accepting connections, then watches for file changes.
-    pub fn run(&mut self) -> io::Result<()> {
-        // Load config to get ignore_files before starting watchman
+    pub async fn run(&mut self) -> io::Result<()> {
         let ignore_files = self.load_ignore_files();
 
-        // Get watchman clock BEFORE initial analysis to avoid race conditions
-        // Any file changes during analysis will be captured
         self.logger.log_sync("Getting watchman clock...");
-        let watchman_clock = watchman::get_clock(Path::new(&self.config.root_dir))?;
+        let watchman_clock = watchman::get_clock(Path::new(&self.config.root_dir)).await?;
         self.logger
             .log_sync(&format!("Watchman clock: {:?}", watchman_clock));
 
-        // Set socket to non-blocking so we can accept connections during analysis
-        self.socket
-            .set_accept_timeout(Some(Duration::from_millis(10)))?;
-
-        self.logger.log_sync("Performing initial analysis...");
-
-        // Set state to analyzing
-        self.state.set_analysis_in_progress(true);
-        self.state.set_phase("Scanning".to_string());
-
-        // Perform initial analysis while accepting connections
-        if let Err(e) = self.do_initial_analysis_with_connections() {
-            self.logger
-                .log_sync(&format!("Initial analysis failed: {}", e));
-            return Err(io::Error::new(io::ErrorKind::Other, e));
-        }
-
-        self.state.set_analysis_in_progress(false);
-        self.state.set_phase("Ready".to_string());
-        self.logger
-            .log_sync("Initial analysis complete. Waiting for connections...");
-
-        // Start watchman subscription with the clock we got before analysis
         self.logger.log_sync(&format!(
             "Starting watchman subscription for: {}",
             self.config.root_dir
@@ -172,383 +133,149 @@ impl Server {
         );
         self.watchman_handle = Some(handle);
 
-        // Set socket to non-blocking for the main loop
-        self.socket
-            .set_accept_timeout(Some(Duration::from_millis(100)))?;
-
-        // Main loop
-        loop {
-            // Poll for file changes from watchman
-            self.poll_watchman_events();
-
-            // Check for config changes (triggers full re-analysis)
-            if self.config_changed && !self.state.is_analysis_in_progress() {
-                self.do_config_reload_analysis();
-            }
-            // Check for pending file changes and re-analyze if needed
-            else if !self.pending_changes.is_empty() && !self.state.is_analysis_in_progress() {
-                self.do_incremental_analysis();
-            }
-
-            match self.socket.accept() {
-                Ok(mut conn) => {
-                    if let Err(e) = self.handle_connection(&mut conn) {
-                        self.logger.log_sync(&format!("Connection error: {}", e));
-                    }
-                }
-                Err(e) => {
-                    if e.kind() == io::ErrorKind::WouldBlock {
-                        // Non-blocking accept, no connection available
-                        std::thread::sleep(Duration::from_millis(10));
-                        continue;
-                    }
-                    self.logger.log_sync(&format!("Accept error: {}", e));
-                }
-            }
-
-            // Check for shutdown
-            if self.state.is_shutting_down() {
-                self.logger.log_sync("Server shutting down...");
-                break;
-            }
-        }
-
-        Ok(())
+        self.main_loop().await
     }
 
-    /// Perform initial analysis while accepting connections.
-    /// This runs analysis in a background thread while the main thread handles client connections.
-    fn do_initial_analysis_with_connections(&mut self) -> Result<(), String> {
-        use std::sync::Arc as StdArc;
-        use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    async fn main_loop(&mut self) -> io::Result<()> {
+        self.logger.log_sync("Performing initial analysis...");
 
-        // Shared state for communicating between threads
-        let analysis_done = StdArc::new(AtomicBool::new(false));
-        let analysis_error: StdArc<std::sync::Mutex<Option<String>>> =
-            StdArc::new(std::sync::Mutex::new(None));
+        {
+            let mut state = self.state.lock().unwrap();
+            state.set_analysis_in_progress(true);
+            state.set_phase("Scanning".to_string());
+            self.spawn_analysis(&mut state, None);
+        }
 
-        // Shared progress counters for real-time progress updates
-        let progress_phase: StdArc<std::sync::Mutex<String>> =
-            StdArc::new(std::sync::Mutex::new("Starting".to_string()));
-        let progress_files_analyzed = StdArc::new(AtomicU32::new(0));
-        let progress_total_files = StdArc::new(AtomicU32::new(0));
+        loop {
+            {
+                let mut state = self.state.lock().unwrap();
 
-        // Clone what we need for the analysis thread
+                if !state.is_analysis_in_progress() {
+                    // Kick off re-analysis if needed and not already running
+                    if self.config_changed {
+                        self.config_changed = false;
+                        state.pending_changes.clear();
+                        state.set_analysis_in_progress(true);
+                        state.set_phase("Reloading config".to_string());
+                        self.logger
+                            .log_sync("Config file changed, performing full re-analysis...");
+                        state.analysis_data = None;
+                        self.spawn_analysis(&mut state, None);
+                    } else if !state.pending_changes.is_empty() {
+                        let changes = std::mem::take(&mut state.pending_changes);
+                        let change_count = changes.len();
+                        state.set_analysis_in_progress(true);
+                        state.set_phase("Analyzing changes".to_string());
+                        self.logger
+                            .log_sync(&format!("Re-analyzing {} changed files...", change_count));
+                        self.spawn_analysis(&mut state, Some(changes));
+                    }
+                }
+            }
+
+            tokio::select! {
+                accept_result = self.socket.accept() => {
+                    match accept_result {
+                        Ok(conn) => {
+                            self.handle_connection(conn);
+                        }
+                        Err(e) => {
+                            self.logger.log_sync(&format!("Accept error: {}", e));
+                        }
+                    }
+                }
+                Some(event) = async {
+                    match self.watchman_handle.as_mut() {
+                        Some(handle) => handle.recv().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    self.handle_watchman_event(event);
+                }
+                result = self.analysis_rx.recv() => {
+                    self.handle_analysis_result(result);
+                }
+                _ = self.shutdown_rx.recv() => {
+                    self.logger.log_sync("Server shutting down...");
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    fn spawn_analysis(
+        &self,
+        state: &mut MutexGuard<ServerState>,
+        changes: Option<FxHashMap<String, FileStatus>>,
+    ) {
         let config = self.config.clone();
         let logger = self.logger.clone();
-        let analysis_done_clone = StdArc::clone(&analysis_done);
-        let analysis_error_clone = StdArc::clone(&analysis_error);
-        let progress_phase_clone = StdArc::clone(&progress_phase);
-        let progress_files_analyzed_clone = StdArc::clone(&progress_files_analyzed);
-        let progress_total_files_clone = StdArc::clone(&progress_total_files);
+        let previous_analysis_data = state.analysis_data.take();
 
-        // Channel to send back the results
-        let (tx, rx) = std::sync::mpsc::channel();
+        let tx = self.analysis_tx.clone();
 
-        // Spawn analysis thread
-        let analysis_thread = thread::spawn(move || {
-            let result = Self::run_analysis(
-                &config,
-                &logger,
-                &progress_phase_clone,
-                &progress_files_analyzed_clone,
-                &progress_total_files_clone,
-                None, // No previous scan data for initial analysis
-                None, // No previous analysis result
-                None, // No changes - full analysis
-            );
-            match result {
-                Ok((analysis_result, scan_data)) => {
-                    let _ = tx.send(Some((analysis_result, scan_data)));
-                }
-                Err(e) => {
-                    *analysis_error_clone.lock().unwrap() = Some(e);
-                    let _ = tx.send(None);
-                }
-            }
-            analysis_done_clone.store(true, Ordering::SeqCst);
+        tokio::task::spawn_blocking(move || {
+            let result =
+                run_analysis(&config, &logger, previous_analysis_data, changes).map(&Arc::new);
+            let _ = tx.send(result);
         });
-
-        // While analysis is running, accept and handle connections
-        while !analysis_done.load(Ordering::SeqCst) {
-            // Update state from shared progress counters
-            if let Ok(phase) = progress_phase.lock() {
-                self.state.set_phase(phase.clone());
-            }
-            self.state.set_progress(
-                progress_files_analyzed.load(Ordering::Relaxed),
-                progress_total_files.load(Ordering::Relaxed),
-            );
-
-            // Try to accept a connection (non-blocking due to timeout set earlier)
-            match self.socket.accept() {
-                Ok(mut conn) => {
-                    if let Err(e) = self.handle_connection(&mut conn) {
-                        self.logger
-                            .log_sync(&format!("Connection error during init: {}", e));
-                    }
-                }
-                Err(e) => {
-                    if e.kind() != io::ErrorKind::WouldBlock {
-                        self.logger
-                            .log_sync(&format!("Accept error during init: {}", e));
-                    }
-                }
-            }
-            // Small sleep to avoid busy-waiting
-            thread::sleep(Duration::from_millis(10));
-        }
-
-        // Wait for analysis thread to finish
-        analysis_thread
-            .join()
-            .map_err(|_| "Analysis thread panicked".to_string())?;
-
-        // Check for errors
-        if let Some(err) = analysis_error.lock().unwrap().take() {
-            return Err(err);
-        }
-
-        // Get the results
-        let received: Result<Option<(AnalysisResult, SuccessfulScanData)>, _> = rx.recv();
-        match received {
-            Ok(Some((analysis_result, scan_data))) => {
-                let issue_count: usize = analysis_result
-                    .emitted_issues
-                    .values()
-                    .map(|v: &Vec<_>| v.len())
-                    .sum();
-                self.logger.log_sync(&format!(
-                    "Analysis complete: {} files, {} issues",
-                    scan_data.codebase.files.len(),
-                    issue_count
-                ));
-                self.state.update_state(scan_data, analysis_result);
-                Ok(())
-            }
-            Ok(None) => Err("Analysis failed".to_string()),
-            Err(_) => Err("Failed to receive analysis results".to_string()),
-        }
     }
 
-    /// Run analysis with progress updates.
-    ///
-    /// This is the unified analysis method used for both initial and incremental analysis.
-    /// Progress is reported via the provided Arc counters which can be polled from other threads.
-    fn run_analysis(
-        config: &ServerConfig,
-        logger: &Arc<Logger>,
-        progress_phase: &std::sync::Arc<std::sync::Mutex<String>>,
-        progress_files_analyzed: &std::sync::Arc<std::sync::atomic::AtomicU32>,
-        progress_total_files: &std::sync::Arc<std::sync::atomic::AtomicU32>,
-        previous_scan_data: Option<SuccessfulScanData>,
-        previous_analysis_result: Option<AnalysisResult>,
-        changes: Option<FxHashMap<String, FileStatus>>,
-    ) -> Result<(AnalysisResult, SuccessfulScanData), String> {
-        use std::sync::atomic::Ordering;
-
-        // Collect custom issue names from plugins
-        let all_custom_issues: FxHashSet<String> = config
-            .plugins
-            .iter()
-            .flat_map(|h| h.get_custom_issue_names())
-            .map(|s| s.to_string())
-            .collect();
-
-        let mut analysis_config = Config::new(config.root_dir.clone(), all_custom_issues);
-        analysis_config.find_unused_expressions = true;
-        analysis_config.find_unused_definitions = true;
-        analysis_config.ast_diff = true;
-        analysis_config.collect_goto_definition_locations = true;
-        analysis_config.hooks = config.plugins.clone();
-
-        let mut interner = Interner::default();
-
-        // Load config from file if specified
-        if let Some(config_path) = &config.config_path {
-            let path = Path::new(config_path);
-            if path.exists() {
-                logger.log_sync(&format!("Loading config from: {}", config_path));
-                let _ = analysis_config.update_from_file(&config.root_dir, path, &mut interner);
-                if let Some(ref allowed) = analysis_config.allowed_issues {
-                    logger.log_sync(&format!("Allowed issues: {} types", allowed.len()));
-                } else {
-                    logger.log_sync("No allowed_issues filter (all issues enabled)");
-                }
-            } else {
-                logger.log_sync(&format!("Config file not found: {}", config_path));
-            }
-        } else {
-            logger.log_sync("No config path specified");
-        }
-
-        // Clone the Arc references for the progress callback closure
-        let phase_ref = std::sync::Arc::clone(progress_phase);
-        let total_files_ref = std::sync::Arc::clone(progress_total_files);
-        // Clone for total_files_to_scan parameter
-        let total_files_to_scan_ref = std::sync::Arc::clone(progress_total_files);
-
-        // Create separate counters for scanning and analysis phases
-        let files_scanned_counter = std::sync::Arc::clone(progress_files_analyzed);
-        let files_analyzed_counter = std::sync::Arc::clone(progress_files_analyzed);
-        // Clone for the callback to reset the counter when phase changes
-        let files_counter_for_callback = std::sync::Arc::clone(progress_files_analyzed);
-
-        // Create a tokio runtime to run the async analysis
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| format!("Failed to build tokio runtime: {}", e))?;
-
-        rt.block_on(hakana_orchestrator::scan_and_analyze_async(
-            Vec::new(),
-            None,
-            None,
-            Arc::new(analysis_config),
-            config.threads,
-            None,
-            &config.header,
-            Arc::new(interner),
-            previous_scan_data,
-            previous_analysis_result,
-            changes,
-            Some(move |progress: hakana_orchestrator::AnalysisProgress| {
-                // Reset counter when phase changes to Analyzing
-                if progress.phase == "Analyzing" {
-                    files_counter_for_callback.store(0, Ordering::Relaxed);
-                }
-                // Update shared progress state
-                if let Ok(mut phase) = phase_ref.lock() {
-                    *phase = progress.phase;
-                }
-                total_files_ref.store(progress.total_files, Ordering::Relaxed);
-            }),
-            // Pass files_scanned counter for real-time polling during scanning
-            Some(files_scanned_counter),
-            // Pass total_files_to_scan counter - set by scan_files when it knows how many files to scan
-            Some(total_files_to_scan_ref),
-            // Pass files_analyzed counter for real-time polling during analysis
-            Some(files_analyzed_counter),
-        ))
-        .map_err(|e| e.to_string())
-    }
-
-    /// Perform incremental analysis with pending changes.
-    fn do_incremental_analysis(&mut self) {
-        if self.pending_changes.is_empty() {
-            return;
-        }
-
-        self.state.set_analysis_in_progress(true);
-        self.state.set_phase("Analyzing changes".to_string());
-
-        let changes = std::mem::take(&mut self.pending_changes);
-        let change_count = changes.len();
-        self.logger
-            .log_sync(&format!("Re-analyzing {} changed files...", change_count));
-
-        let (previous_scan_data, previous_analysis_result) = (
-            self.state.scan_data.take(),
-            self.state.analysis_result.take(),
-        );
-
-        // Create progress counters for this analysis
-        let progress_phase = std::sync::Arc::new(std::sync::Mutex::new("Analyzing".to_string()));
-        let progress_files_analyzed = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let progress_total_files = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
-
-        let result = Self::run_analysis(
-            &self.config,
-            &self.logger,
-            &progress_phase,
-            &progress_files_analyzed,
-            &progress_total_files,
-            previous_scan_data,
-            previous_analysis_result,
-            Some(changes),
-        );
-
+    fn handle_analysis_result(
+        &mut self,
+        result: Result<
+            Result<Arc<(AnalysisResult, SuccessfulScanData)>, String>,
+            tokio::sync::broadcast::error::RecvError,
+        >,
+    ) {
+        let mut state = self.state.lock().unwrap();
         match result {
-            Ok((analysis_result, scan_data)) => {
+            Ok(Ok(result)) => {
+                let (analysis_result, _) = result.as_ref();
                 let issue_count: usize = analysis_result
                     .emitted_issues
                     .values()
                     .map(|v| v.len())
                     .sum();
-                self.logger.log_sync(&format!(
-                    "Incremental analysis complete: {} issues",
-                    issue_count
-                ));
-                self.state.update_state(scan_data, analysis_result);
-            }
-            Err(e) => {
                 self.logger
-                    .log_sync(&format!("Incremental analysis failed: {}", e));
+                    .log_sync(&format!("Analysis complete: {} issues", issue_count));
+                state.update_state(result.clone());
+            }
+            Ok(Err(e)) => {
+                self.logger.log_sync(&format!("Analysis failed: {}", e));
+            }
+            Err(_) => {
+                self.logger.log_sync("Analysis task was cancelled");
             }
         }
-
-        self.state.set_analysis_in_progress(false);
-        self.state.set_phase("Ready".to_string());
+        state.set_analysis_in_progress(false);
+        state.set_phase("Ready".to_string());
     }
 
-    /// Perform full re-analysis after config file change.
-    /// This discards all cached state and re-analyzes from scratch.
-    fn do_config_reload_analysis(&mut self) {
-        self.config_changed = false;
-        self.pending_changes.clear();
-
-        self.state.set_analysis_in_progress(true);
-        self.state.set_phase("Reloading config".to_string());
-
-        self.logger
-            .log_sync("Config file changed, performing full re-analysis...");
-
-        // Discard previous state - we need to re-analyze everything
-        self.state.scan_data = None;
-        self.state.analysis_result = None;
-
-        // Create progress counters for this analysis
-        let progress_phase = std::sync::Arc::new(std::sync::Mutex::new("Scanning".to_string()));
-        let progress_files_analyzed = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let progress_total_files = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
-
-        // Run full analysis with no previous state and no changes (triggers full scan)
-        let result = Self::run_analysis(
-            &self.config,
-            &self.logger,
-            &progress_phase,
-            &progress_files_analyzed,
-            &progress_total_files,
-            None, // No previous scan data - triggers full scan
-            None, // No previous analysis result
-            None, // No changes - full analysis
-        );
-
-        match result {
-            Ok((analysis_result, scan_data)) => {
-                let issue_count: usize = analysis_result
-                    .emitted_issues
-                    .values()
-                    .map(|v| v.len())
-                    .sum();
-                self.logger.log_sync(&format!(
-                    "Config reload analysis complete: {} files, {} issues",
-                    scan_data.codebase.files.len(),
-                    issue_count
-                ));
-                self.state.update_state(scan_data, analysis_result);
-            }
-            Err(e) => {
+    fn handle_watchman_event(&mut self, event: watchman::WatchmanEvent) {
+        match event {
+            watchman::WatchmanEvent::ConfigChanged => {
                 self.logger
-                    .log_sync(&format!("Config reload analysis failed: {}", e));
+                    .log_sync("Config file changed, scheduling full re-analysis");
+                self.config_changed = true;
+                let mut state = self.state.lock().unwrap();
+                state.pending_changes.clear();
+            }
+            watchman::WatchmanEvent::FileChanges(changes) => {
+                if !self.config_changed {
+                    let mut state = self.state.lock().unwrap();
+                    let change_count = changes.len();
+                    state.pending_changes.extend(changes);
+                    self.logger.log_sync(&format!(
+                        "Received {} file change(s) from watchman ({} pending)",
+                        change_count,
+                        state.pending_changes.len()
+                    ));
+                }
             }
         }
-
-        self.state.set_analysis_in_progress(false);
-        self.state.set_phase("Ready".to_string());
     }
 
-    /// Load ignore_files from config file.
     fn load_ignore_files(&self) -> Vec<String> {
         use hakana_analyzer::config::json_config;
 
@@ -574,203 +301,117 @@ impl Server {
         Vec::new()
     }
 
-    /// Poll for events from the watchman thread.
-    fn poll_watchman_events(&mut self) {
-        if let Some(handle) = &self.watchman_handle {
-            let events = handle.poll_events();
-            for event in events {
-                match event {
-                    watchman::WatchmanEvent::ConfigChanged => {
-                        self.logger
-                            .log_sync("Config file changed, scheduling full re-analysis");
-                        self.config_changed = true;
-                        // Clear pending changes since we'll do a full re-analysis anyway
-                        self.pending_changes.clear();
+    fn handle_connection(&self, mut conn: ClientConnection) {
+        let logger = self.logger.clone();
+        let handler = RequestHandler::new(
+            self.config.clone(),
+            self.state.clone(),
+            self.logger.clone(),
+            self.shutdown_tx.clone(),
+            self.start_time,
+        );
+        let mut analysis_rx = self.analysis_tx.subscribe();
+
+        tokio::spawn(async move {
+            loop {
+                let msg = match conn.read_message().await {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        logger.log_sync(&format!("Read error: {}", e));
+                        return;
                     }
-                    watchman::WatchmanEvent::FileChanges(changes) => {
-                        // Only queue file changes if we're not already doing a config reload
-                        if !self.config_changed {
-                            let change_count = changes.len();
-                            self.pending_changes.extend(changes);
-                            self.logger.log_sync(&format!(
-                                "Received {} file change(s) from watchman ({} pending)",
-                                change_count,
-                                self.pending_changes.len()
-                            ));
-                        }
+                };
+
+                logger.log_sync(&format!("Received: {:?}", msg.message_type()));
+
+                let response = match msg {
+                    Message::GetIssues(req) => {
+                        handler.handle_get_issues(&mut analysis_rx, req).await
                     }
+                    Message::Status(_) => handler.handle_status(),
+                    Message::Shutdown(_) => handler.handle_shutdown().await,
+                    Message::GotoDefinition(req) => handler.handle_goto_definition(req),
+                    Message::FindReferences(req) => handler.handle_find_references(req),
+                    Message::FindSymbolReferences(req) => {
+                        handler.handle_find_symbol_references(req)
+                    }
+                    Message::FileChanged(changes) => handler.handle_file_changed(changes),
+                    _ => Message::Error(ErrorResponse {
+                        code: ErrorCode::UnsupportedMessage,
+                        message: "Use GetIssues to retrieve analysis results".to_string(),
+                    }),
+                };
+
+                logger.log_sync(&format!("Sending response: {:?}", response.message_type()));
+
+                if let Err(e) = conn.write_message(&response).await {
+                    logger.log_sync(&format!("Write error: {}", e));
+                    return;
                 }
+
+                logger.log_sync("Response sent successfully");
             }
+        });
+    }
+}
+
+fn run_analysis(
+    config: &ServerConfig,
+    logger: &Arc<Logger>,
+    previous_analysis_data: Option<Arc<(AnalysisResult, SuccessfulScanData)>>,
+    changes: Option<FxHashMap<String, FileStatus>>,
+) -> Result<(AnalysisResult, SuccessfulScanData), String> {
+    let all_custom_issues: FxHashSet<String> = config
+        .plugins
+        .iter()
+        .flat_map(|h| h.get_custom_issue_names())
+        .map(|s| s.to_string())
+        .collect();
+
+    let mut analysis_config = Config::new(config.root_dir.clone(), all_custom_issues);
+    analysis_config.find_unused_expressions = true;
+    analysis_config.find_unused_definitions = true;
+    analysis_config.ast_diff = true;
+    analysis_config.collect_goto_definition_locations = true;
+    analysis_config.hooks = config.plugins.clone();
+
+    let mut interner = Interner::default();
+
+    if let Some(config_path) = &config.config_path {
+        let path = Path::new(config_path);
+        if path.exists() {
+            logger.log_sync(&format!("Loading config from: {}", config_path));
+            let _ = analysis_config.update_from_file(&config.root_dir, path, &mut interner);
+            if let Some(ref allowed) = analysis_config.allowed_issues {
+                logger.log_sync(&format!("Allowed issues: {} types", allowed.len()));
+            } else {
+                logger.log_sync("No allowed_issues filter (all issues enabled)");
+            }
+        } else {
+            logger.log_sync(&format!("Config file not found: {}", config_path));
         }
+    } else {
+        logger.log_sync("No config path specified");
     }
 
-    /// Handle a single client connection.
-    fn handle_connection(&mut self, conn: &mut ClientConnection) -> io::Result<()> {
-        // Set read timeout to detect dead connections
-        conn.set_read_timeout(Some(Duration::from_secs(300)))?;
+    let (previous_scan_data, previous_analysis_result) = previous_analysis_data
+        .map(|d| (Some(d.1.clone()), Some(d.0.clone())))
+        .unwrap_or((None, None));
 
-        // Handle one request per connection (simpler, avoids issues with client disconnects)
-        let msg = match conn.read_message() {
-            Ok(msg) => msg,
-            Err(e) => {
-                // Connection closed or error
-                self.logger.log_sync(&format!("Read error: {}", e));
-                return Ok(());
-            }
-        };
-
-        self.logger
-            .log_sync(&format!("Received: {:?}", msg.message_type()));
-
-        let response = self.handle_message(msg);
-
-        self.logger
-            .log_sync(&format!("Sending response: {:?}", response.message_type()));
-
-        if let Err(e) = conn.write_message(&response) {
-            self.logger.log_sync(&format!("Write error: {}", e));
-            return Err(io::Error::new(io::ErrorKind::BrokenPipe, e.to_string()));
-        }
-
-        self.logger.log_sync("Response sent successfully");
-
-        Ok(())
-    }
-
-    /// Handle a single message and return a response.
-    fn handle_message(&mut self, msg: Message) -> Message {
-        match msg {
-            Message::GetIssues(req) => self.handle_get_issues(req),
-            Message::Status(_) => {
-                let handler = RequestHandler::new(
-                    &self.config,
-                    &mut self.state,
-                    &self.logger,
-                    self.start_time,
-                );
-                handler.handle_status()
-            }
-            Message::Shutdown(_) => {
-                let handler = RequestHandler::new(
-                    &self.config,
-                    &mut self.state,
-                    &self.logger,
-                    self.start_time,
-                );
-                handler.handle_shutdown()
-            }
-            Message::GotoDefinition(req) => {
-                let handler = RequestHandler::new(
-                    &self.config,
-                    &mut self.state,
-                    &self.logger,
-                    self.start_time,
-                );
-                handler.handle_goto_definition(req)
-            }
-            Message::FindReferences(req) => {
-                let handler = RequestHandler::new(
-                    &self.config,
-                    &mut self.state,
-                    &self.logger,
-                    self.start_time,
-                );
-                handler.handle_find_references(req)
-            }
-            Message::FindSymbolReferences(req) => {
-                let handler = RequestHandler::new(
-                    &self.config,
-                    &mut self.state,
-                    &self.logger,
-                    self.start_time,
-                );
-                handler.handle_find_symbol_references(req)
-            }
-            Message::FileChanged(changes) => self.handle_file_changed(changes),
-            _ => Message::Error(ErrorResponse {
-                code: ErrorCode::UnsupportedMessage,
-                message: "Use GetIssues to retrieve analysis results".to_string(),
-            }),
-        }
-    }
-
-    /// Handle GetIssues request - returns current issues or progress info.
-    fn handle_get_issues(&self, req: hakana_protocol::GetIssuesRequest) -> Message {
-        let analysis_complete = !self.state.is_analysis_in_progress();
-
-        if !analysis_complete {
-            // Return progress information
-            return Message::GetIssuesResult(GetIssuesResponse {
-                analysis_complete: false,
-                issues: Vec::new(),
-                files_analyzed: self.state.files_analyzed(),
-                total_files: self.state.total_files(),
-                phase: self.state.phase().to_string(),
-                progress_percent: self.state.progress_percent(),
-            });
-        }
-
-        // Return all issues
-        let mut issues = Vec::new();
-
-        if let Some(ref analysis_result) = self.state.analysis_result {
-            if let Some(ref scan_data) = self.state.scan_data {
-                for (file_path, file_issues) in &analysis_result.emitted_issues {
-                    let file_path_str =
-                        file_path.get_relative_path(&scan_data.interner, &self.config.root_dir);
-
-                    // Apply filter if specified
-                    if let Some(ref filter) = req.filter {
-                        if !file_path_str.starts_with(filter) {
-                            continue;
-                        }
-                    }
-
-                    for issue in file_issues {
-                        issues.push(ProtocolIssue::from_issue(issue, &file_path_str));
-                    }
-                }
-            }
-        }
-
-        self.logger
-            .log_sync(&format!("Returning {} issues", issues.len()));
-
-        Message::GetIssuesResult(GetIssuesResponse {
-            analysis_complete: true,
-            issues,
-            files_analyzed: self.state.files_count(),
-            total_files: self.state.files_count(),
-            phase: "Complete".to_string(),
-            progress_percent: 100,
-        })
-    }
-
-    /// Handle file changed notifications from clients (e.g., LSP forwarding VS Code events).
-    fn handle_file_changed(&mut self, changes: Vec<hakana_protocol::FileChange>) -> Message {
-        use hakana_protocol::FileChangeStatus;
-
-        let change_count = changes.len();
-        self.logger.log_sync(&format!(
-            "Received {} file change notification(s) from client",
-            change_count
-        ));
-
-        // Convert protocol changes to FileStatus and add to pending changes
-        for change in changes {
-            let status = match change.status {
-                FileChangeStatus::Added => FileStatus::Added(0, 0),
-                FileChangeStatus::Modified => FileStatus::Modified(0, 0),
-                FileChangeStatus::Deleted => FileStatus::Deleted,
-            };
-            self.pending_changes.insert(change.path, status);
-        }
-
-        self.logger.log_sync(&format!(
-            "Total pending changes: {}",
-            self.pending_changes.len()
-        ));
-
-        Message::Ack(AckResponse)
-    }
+    hakana_orchestrator::scan_and_analyze(
+        Vec::new(),
+        None,
+        None,
+        Arc::new(analysis_config),
+        None,
+        config.threads,
+        logger.clone(),
+        &config.header,
+        Arc::new(interner),
+        previous_scan_data,
+        previous_analysis_result,
+        changes,
+        || {},
+    )
+    .map_err(|e| e.to_string())
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,14 +1,15 @@
 //! Server state management.
 
+use std::sync::Arc;
+
 use hakana_code_info::analysis_result::AnalysisResult;
 use hakana_orchestrator::SuccessfulScanData;
+use hakana_orchestrator::file::FileStatus;
+use rustc_hash::FxHashMap;
 
 /// Warm state maintained by the server.
 pub struct ServerState {
-    /// Cached scan data from last successful scan.
-    pub scan_data: Option<SuccessfulScanData>,
-    /// Cached analysis result.
-    pub analysis_result: Option<AnalysisResult>,
+    pub analysis_data: Option<Arc<(AnalysisResult, SuccessfulScanData)>>,
     /// Whether server is shutting down.
     shutting_down: bool,
     /// Whether an analysis is currently running.
@@ -21,19 +22,21 @@ pub struct ServerState {
     files_analyzed: u32,
     /// Total files to analyze.
     total_files: u32,
+    /// Pending file changes.
+    pub pending_changes: FxHashMap<String, FileStatus>,
 }
 
 impl ServerState {
     pub fn new() -> Self {
         Self {
-            scan_data: None,
-            analysis_result: None,
+            analysis_data: None,
             shutting_down: false,
             analysis_in_progress: false,
             pending_requests: 0,
             phase: "Initializing".to_string(),
             files_analyzed: 0,
             total_files: 0,
+            pending_changes: FxHashMap::default(),
         }
     }
 
@@ -98,26 +101,25 @@ impl ServerState {
     }
 
     /// Update scan data and analysis result.
-    pub fn update_state(&mut self, scan_data: SuccessfulScanData, analysis_result: AnalysisResult) {
-        self.total_files = scan_data.codebase.files.len() as u32;
-        self.files_analyzed = self.total_files;
-        self.scan_data = Some(scan_data);
-        self.analysis_result = Some(analysis_result);
+    pub fn update_state(&mut self, result: Arc<(AnalysisResult, SuccessfulScanData)>) {
+        self.analysis_data = Some(result);
     }
 
     /// Get files count if available.
     pub fn files_count(&self) -> u32 {
-        self.scan_data
+        self.analysis_data
             .as_ref()
-            .map(|d| d.codebase.files.len() as u32)
+            .map(&Arc::as_ref)
+            .map(|(_, d)| d.codebase.files.len() as u32)
             .unwrap_or(0)
     }
 
     /// Get symbols count if available.
     pub fn symbols_count(&self) -> u32 {
-        self.scan_data
+        self.analysis_data
             .as_ref()
-            .map(|d| {
+            .map(&Arc::as_ref)
+            .map(|(_, d)| {
                 d.codebase.classlike_infos.len() as u32 + d.codebase.functionlike_infos.len() as u32
             })
             .unwrap_or(0)
@@ -125,12 +127,18 @@ impl ServerState {
 
     /// Get scan data reference.
     pub fn scan_data(&self) -> Option<&SuccessfulScanData> {
-        self.scan_data.as_ref()
+        self.analysis_data
+            .as_ref()
+            .map(&Arc::as_ref)
+            .map(|(_, d)| d)
     }
 
     /// Get analysis result reference.
     pub fn analysis_result(&self) -> Option<&AnalysisResult> {
-        self.analysis_result.as_ref()
+        self.analysis_data
+            .as_ref()
+            .map(&Arc::as_ref)
+            .map(|(r, _)| r)
     }
 }
 

--- a/src/server/tests/integration_test.rs
+++ b/src/server/tests/integration_test.rs
@@ -1,34 +1,23 @@
-//! Integration tests for hakana server-client interaction.
-//!
-//! These tests verify that the server starts correctly and clients can connect
-//! to retrieve analysis results.
-
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::thread;
 use std::time::Duration;
 
 use hakana_protocol::{ClientSocket, GetIssuesRequest, Message, SocketPath, StatusRequest};
 
-/// Helper struct to manage server process lifecycle
 struct TestServer {
     process: Child,
     socket_path: SocketPath,
 }
 
 impl TestServer {
-    /// Start a test server for the given directory
-    fn start(test_dir: &str) -> Result<Self, String> {
+    async fn start(test_dir: &str) -> Result<Self, String> {
         let test_dir = PathBuf::from(test_dir);
         let socket_path = SocketPath::for_project(&test_dir);
 
-        // Clean up any stale socket
-        let _ = socket_path.cleanup();
+        socket_path.cleanup().ok();
 
-        // Find the hakana binary
         let hakana_bin = find_hakana_binary()?;
 
-        // Start server process
         let process = Command::new(&hakana_bin)
             .args(["server", "--root", test_dir.to_str().unwrap()])
             .stdout(Stdio::piped())
@@ -41,63 +30,51 @@ impl TestServer {
             socket_path,
         };
 
-        // Wait for server to be ready
-        server.wait_for_ready(Duration::from_secs(60))?;
+        server.wait_for_ready(Duration::from_secs(15)).await?;
 
         Ok(server)
     }
 
-    /// Wait for the server to be ready to accept connections
-    fn wait_for_ready(&self, timeout: Duration) -> Result<(), String> {
+    async fn wait_for_ready(&self, timeout: Duration) -> Result<(), String> {
         let start = std::time::Instant::now();
 
         while start.elapsed() < timeout {
             if self.socket_path.server_exists() {
-                // Try to connect and check status
-                if let Ok(mut client) = ClientSocket::connect(&self.socket_path) {
-                    let request = Message::Status(StatusRequest);
-                    if let Ok(Message::StatusResult(status)) = client.request(&request) {
-                        if status.ready {
-                            return Ok(());
+                match ClientSocket::connect(&self.socket_path).await {
+                    Ok(mut client) => {
+                        let request = Message::Status(StatusRequest);
+                        let x = client.request(&request).await;
+                        if let Ok(Message::StatusResult(status)) = x {
+                            if status.ready {
+                                return Ok(());
+                            }
                         }
                     }
+                    Err(e) => println!("{:?}", e),
                 }
             }
-            thread::sleep(Duration::from_millis(500));
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
 
         Err(format!("Server did not become ready within {:?}", timeout))
     }
 
-    /// Get a client connection to this server
-    fn connect(&self) -> Result<ClientSocket, String> {
+    async fn connect(&self) -> Result<ClientSocket, String> {
         ClientSocket::connect(&self.socket_path)
+            .await
             .map_err(|e| format!("Failed to connect to server: {}", e))
     }
 }
 
 impl Drop for TestServer {
     fn drop(&mut self) {
-        // Send shutdown signal
-        if let Ok(mut client) = ClientSocket::connect(&self.socket_path) {
-            let _ = client.send(&Message::Shutdown(hakana_protocol::ShutdownRequest));
-        }
-
-        // Give it a moment to shut down gracefully
-        thread::sleep(Duration::from_millis(100));
-
-        // Force kill if still running
         let _ = self.process.kill();
         let _ = self.process.wait();
-
-        // Clean up socket
         let _ = self.socket_path.cleanup();
     }
 }
 
-/// Find the hakana binary
 fn find_hakana_binary() -> Result<PathBuf, String> {
-    // Try release build first
     let release_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
@@ -109,7 +86,6 @@ fn find_hakana_binary() -> Result<PathBuf, String> {
         return Ok(release_path);
     }
 
-    // Try debug build
     let debug_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
@@ -124,36 +100,31 @@ fn find_hakana_binary() -> Result<PathBuf, String> {
     Err("Could not find hakana binary. Run 'cargo build' first.".to_string())
 }
 
-#[test]
-fn test_server_client_status() {
-    // Use a test directory with some Hack files
+#[tokio::test]
+async fn test_server_client_status() {
     let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
         .parent()
         .unwrap()
-        .join("tests/server");
+        .join("tests/server/1");
 
-    // Skip if watchman is not available
     if Command::new("watchman").arg("version").output().is_err() {
         eprintln!("Skipping test: watchman not available");
         return;
     }
 
-    // Start the server
-    let server = match TestServer::start(test_dir.to_str().unwrap()) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("Failed to start server: {}", e);
-            return;
-        }
-    };
+    let server = TestServer::start(test_dir.to_str().unwrap())
+        .await
+        .expect("Failed to start server");
 
-    // Connect and check status
-    let mut client = server.connect().expect("Failed to connect");
+    let mut client = server.connect().await.expect("Failed to connect");
 
     let request = Message::Status(StatusRequest);
-    let response = client.request(&request).expect("Failed to send request");
+    let response = client
+        .request(&request)
+        .await
+        .expect("Failed to send request");
 
     if let Message::StatusResult(status) = response {
         assert!(status.ready, "Server should be ready");
@@ -167,41 +138,37 @@ fn test_server_client_status() {
     }
 }
 
-#[test]
-fn test_server_client_get_issues() {
-    // Use a test directory with some Hack files
+#[tokio::test]
+async fn test_server_client_get_issues() {
     let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
         .parent()
         .unwrap()
-        .join("tests/server");
+        .join("tests/server/2");
 
-    // Skip if watchman is not available
     if Command::new("watchman").arg("version").output().is_err() {
         eprintln!("Skipping test: watchman not available");
         return;
     }
 
-    // Start the server
-    let server = match TestServer::start(test_dir.to_str().unwrap()) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("Failed to start server: {}", e);
-            return;
-        }
-    };
+    let server = TestServer::start(test_dir.to_str().unwrap())
+        .await
+        .expect("Failed to start server");
 
-    // Connect and get issues
-    let mut client = server.connect().expect("Failed to connect");
+    let mut client = server.connect().await.expect("Failed to connect");
 
     let request = Message::GetIssues(GetIssuesRequest {
         filter: None,
         find_unused_expressions: false,
         find_unused_definitions: false,
+        block_until_next_analysis: false,
     });
 
-    let response = client.request(&request).expect("Failed to send request");
+    let response = client
+        .request(&request)
+        .await
+        .expect("Failed to send request");
 
     if let Message::GetIssuesResult(result) = response {
         assert!(
@@ -218,37 +185,29 @@ fn test_server_client_get_issues() {
     }
 }
 
-#[test]
-fn test_cli_client_connects_to_server() {
-    // Use a test directory with some Hack files
+#[tokio::test]
+async fn test_cli_client_connects_to_server() {
     let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
         .parent()
         .unwrap()
-        .join("tests/server");
+        .join("tests/server/3");
 
-    // Skip if watchman is not available
     if Command::new("watchman").arg("version").output().is_err() {
         eprintln!("Skipping test: watchman not available");
         return;
     }
 
-    // Start the server
-    let _server = match TestServer::start(test_dir.to_str().unwrap()) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("Failed to start server: {}", e);
-            return;
-        }
-    };
+    TestServer::start(test_dir.to_str().unwrap())
+        .await
+        .expect("Failed to start server");
 
-    // Find hakana binary
     let hakana_bin = find_hakana_binary().expect("hakana binary not found");
 
-    // Run hakana analyze (should connect to the running server)
     let output = Command::new(&hakana_bin)
-        .args(["analyze", "--root", test_dir.to_str().unwrap()])
+        .args(["analyze"])
+        .current_dir(test_dir.to_str().unwrap())
         .output()
         .expect("Failed to run hakana analyze");
 
@@ -258,10 +217,8 @@ fn test_cli_client_connects_to_server() {
     println!("stdout: {}", stdout);
     println!("stderr: {}", stderr);
 
-    // The client should have connected to the server (not run standalone)
-    // Check that it got a response (either issues or "No issues reported")
     assert!(
-        stdout.contains("Analyzed") || stdout.contains("No issues"),
+        stdout.contains("ERROR:"),
         "Expected analysis output, got: {}",
         stdout
     );

--- a/src/server/watchman.rs
+++ b/src/server/watchman.rs
@@ -1,29 +1,18 @@
-//! Watchman integration for the hakana server.
-//!
-//! This module handles file system watching using watchman to detect changes
-//! in Hack/PHP files and trigger re-analysis. It also watches for config file
-//! changes to trigger full re-analysis when the config is modified.
-
 use hakana_orchestrator::file::FileStatus;
 use rustc_hash::FxHashMap;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::mpsc;
-use std::thread;
+use tokio::sync::mpsc;
 use watchman_client::SubscriptionData;
 use watchman_client::prelude::*;
 
-/// Events sent from the watchman thread.
 #[derive(Debug)]
 pub enum WatchmanEvent {
-    /// Source file changes (hack/php/hhi files).
     FileChanges(FxHashMap<String, FileStatus>),
-    /// Config file changed - triggers full re-analysis.
     ConfigChanged,
 }
 
-/// Check if watchman is available.
 pub fn check_available() -> Result<(), String> {
     match Command::new("watchman").arg("version").output() {
         Ok(output) => {
@@ -37,110 +26,67 @@ pub fn check_available() -> Result<(), String> {
     }
 }
 
-/// Get the current watchman clock. This should be called BEFORE initial analysis
-/// so that any file changes during analysis are captured by the subscription.
-pub fn get_clock(root_dir: &Path) -> io::Result<ClockSpec> {
-    // Create a temporary tokio runtime to get the clock synchronously
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
+pub async fn get_clock(root_dir: &Path) -> io::Result<ClockSpec> {
+    let watchman = Connector::new().connect().await.map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("Failed to connect to watchman: {}", e),
+        )
+    })?;
+
+    let canonical_path = CanonicalPath::canonicalize(root_dir).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Failed to canonicalize path: {}", e),
+        )
+    })?;
+
+    let resolved = watchman.resolve_root(canonical_path).await.map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("Failed to resolve watchman root: {}", e),
+        )
+    })?;
+
+    watchman
+        .clock(&resolved, SyncTimeout::Default)
+        .await
         .map_err(|e| {
             io::Error::new(
                 io::ErrorKind::Other,
-                format!("Failed to build tokio runtime: {}", e),
+                format!("Failed to get watchman clock: {}", e),
             )
-        })?;
-
-    rt.block_on(async {
-        let watchman = Connector::new().connect().await.map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::ConnectionRefused,
-                format!("Failed to connect to watchman: {}", e),
-            )
-        })?;
-
-        let canonical_path = CanonicalPath::canonicalize(root_dir).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("Failed to canonicalize path: {}", e),
-            )
-        })?;
-
-        let resolved = watchman.resolve_root(canonical_path).await.map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Failed to resolve watchman root: {}", e),
-            )
-        })?;
-
-        watchman
-            .clock(&resolved, SyncTimeout::Default)
-            .await
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Failed to get watchman clock: {}", e),
-                )
-            })
-    })
+        })
 }
 
-/// Handle for receiving events from watchman.
 pub struct WatchmanHandle {
     rx: mpsc::Receiver<WatchmanEvent>,
 }
 
 impl WatchmanHandle {
-    /// Poll for watchman events (non-blocking).
-    /// Returns all pending events accumulated since last poll.
-    pub fn poll_events(&self) -> Vec<WatchmanEvent> {
-        let mut events = Vec::new();
-        while let Ok(event) = self.rx.try_recv() {
-            events.push(event);
-        }
-        events
+    pub async fn recv(&mut self) -> Option<WatchmanEvent> {
+        self.rx.recv().await
     }
 }
 
-/// Start watchman subscription for file changes.
-///
-/// Returns a handle that can be used to poll for changes.
-///
-/// # Arguments
-/// * `root_dir` - The project root directory
-/// * `ignore_files` - List of file patterns to ignore
-/// * `since_clock` - Watchman clock to start watching from
-/// * `config_path` - Optional path to config file to watch for changes
 pub fn start_subscription(
     root_dir: PathBuf,
     ignore_files: Vec<String>,
     since_clock: ClockSpec,
     config_path: Option<PathBuf>,
 ) -> WatchmanHandle {
-    // Create channel for communicating events from watchman thread
-    let (tx, rx) = mpsc::channel::<WatchmanEvent>();
+    let (tx, rx) = mpsc::channel::<WatchmanEvent>(64);
 
-    // Spawn a thread with its own tokio runtime for watchman
-    thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Failed to build tokio runtime");
-
-        rt.block_on(async move {
-            if let Err(e) =
-                run_subscription(root_dir, tx, ignore_files, since_clock, config_path).await
-            {
-                eprintln!("Watchman subscription error: {}", e);
-            }
-        });
+    tokio::spawn(async move {
+        if let Err(e) = run_subscription(root_dir, tx, ignore_files, since_clock, config_path).await
+        {
+            eprintln!("Watchman subscription error: {}", e);
+        }
     });
 
     WatchmanHandle { rx }
 }
 
-/// Run the watchman subscription in an async context.
-/// Sends file changes through the channel when detected.
 async fn run_subscription(
     root_dir: PathBuf,
     tx: mpsc::Sender<WatchmanEvent>,
@@ -167,7 +113,6 @@ async fn run_subscription(
 
     let project_root = resolved.path();
 
-    // Compute the relative config path for comparison
     let config_relative_path = config_path.as_ref().and_then(|p| {
         if p.is_absolute() {
             p.strip_prefix(&project_root).ok().map(|p| p.to_path_buf())
@@ -180,15 +125,11 @@ async fn run_subscription(
         eprintln!("Watching config file: {:?}", rel_path);
     }
 
-    // Build the watchman expression with ignore patterns, including config file
     let expression = build_expression(&ignore_files, &project_root, config_relative_path.as_ref());
 
-    // Create subscription request for Hack/PHP files and config file
-    // Use `since` to only get changes after the clock obtained before initial analysis
     let subscribe_request = SubscribeRequest {
         since: Some(Clock::Spec(since_clock)),
         expression: Some(expression),
-        // Debounce to avoid rapid-fire changes
         defer_vcs: true,
         ..Default::default()
     };
@@ -199,7 +140,6 @@ async fn run_subscription(
 
     eprintln!("Watchman subscription created: {}", subscription.name());
 
-    // Process subscription events
     loop {
         match subscription.next().await {
             Ok(SubscriptionData::FilesChanged(result)) => {
@@ -212,7 +152,6 @@ async fn run_subscription(
                         let file_path = project_root.join(&file_name);
                         let file_path_str = file_path.to_string_lossy().to_string();
 
-                        // Check if this is the config file
                         if let Some(ref config_rel) = config_relative_path {
                             if Path::new(&file_name) == config_rel.as_path() {
                                 eprintln!("Config file changed: {:?}", file_name);
@@ -221,29 +160,22 @@ async fn run_subscription(
                             }
                         }
 
-                        // Determine file status based on existence
                         let status = if file_path.exists() {
                             if file_path.is_dir() {
-                                // Skip directories that exist - we only care about deleted dirs
                                 continue;
                             }
-                            // For existing files, treat all as Modified
-                            // The hash comparison in the orchestrator will handle this correctly
                             FileStatus::Modified(0, 0)
                         } else {
-                            // File doesn't exist - it was deleted
                             if file_path_str.ends_with(".hack")
                                 || file_path_str.ends_with(".php")
                                 || file_path_str.ends_with(".hhi")
                             {
                                 FileStatus::Deleted
                             } else {
-                                // Could be a deleted directory
                                 FileStatus::DeletedDir
                             }
                         };
 
-                        // Only include hack/php/hhi files
                         if file_path_str.ends_with(".hack")
                             || file_path_str.ends_with(".php")
                             || file_path_str.ends_with(".hhi")
@@ -253,19 +185,20 @@ async fn run_subscription(
                         }
                     }
 
-                    // Send config changed event first (it triggers full re-analysis)
                     if config_changed {
-                        if tx.send(WatchmanEvent::ConfigChanged).is_err() {
+                        if tx.send(WatchmanEvent::ConfigChanged).await.is_err() {
                             eprintln!("Server shut down, stopping watchman subscription");
                             break;
                         }
                     }
 
-                    // Then send file changes
                     if !new_statuses.is_empty() {
                         eprintln!("Watchman detected {} file change(s)", new_statuses.len());
-                        // Send changes through channel; ignore errors if receiver is dropped
-                        if tx.send(WatchmanEvent::FileChanges(new_statuses)).is_err() {
+                        if tx
+                            .send(WatchmanEvent::FileChanges(new_statuses))
+                            .await
+                            .is_err()
+                        {
                             eprintln!("Server shut down, stopping watchman subscription");
                             break;
                         }
@@ -292,23 +225,6 @@ async fn run_subscription(
     Ok(())
 }
 
-/// Build a watchman expression that matches Hack/PHP files and optionally a config file,
-/// while excluding ignored paths.
-///
-/// Creates an expression like:
-/// ["allof",
-///   ["type", "f"],
-///   ["anyof",
-///     ["suffix", ["hack", "php", "hhi"]],
-///     ["name", "hakana.json", "wholename"]  // if config_path is provided
-///   ],
-///   ["not", ["anyof",
-///     ["dirname", ".git"],
-///     ["dirname", "ignored_dir"],
-///     ["name", "specific/file.hack"],
-///     ...
-///   ]]
-/// ]
 fn build_expression(
     ignore_files: &[String],
     project_root: &Path,
@@ -316,31 +232,24 @@ fn build_expression(
 ) -> Expr {
     let project_root_str = project_root.to_string_lossy();
 
-    // Build list of exclusions
-    let mut exclusions: Vec<Expr> = vec![
-        // Always exclude .git directory
-        Expr::DirName(DirNameTerm {
-            path: ".git".into(),
-            depth: None,
-        }),
-    ];
+    let mut exclusions: Vec<Expr> = vec![Expr::DirName(DirNameTerm {
+        path: ".git".into(),
+        depth: None,
+    })];
 
     for ignore_pattern in ignore_files {
-        // Strip the project root prefix to get relative path
         let relative_pattern = if ignore_pattern.starts_with(project_root_str.as_ref()) {
             ignore_pattern[project_root_str.len()..].trim_start_matches('/')
         } else {
             ignore_pattern.as_str()
         };
 
-        // Handle directory patterns (ending with /**)
         if let Some(dir_path) = relative_pattern.strip_suffix("/**") {
             exclusions.push(Expr::DirName(DirNameTerm {
                 path: dir_path.into(),
                 depth: None,
             }));
         } else {
-            // Handle specific file patterns
             exclusions.push(Expr::Name(NameTerm {
                 paths: vec![relative_pattern.into()],
                 wholename: true,
@@ -348,8 +257,6 @@ fn build_expression(
         }
     }
 
-    // Build the file matching expression
-    // Match files with hack/php/hhi suffix, OR the config file
     let file_match = if let Some(config_rel_path) = config_path {
         let config_path_str = config_rel_path.to_string_lossy().to_string();
         Expr::Any(vec![
@@ -363,17 +270,13 @@ fn build_expression(
         Expr::Suffix(vec!["hack".into(), "php".into(), "hhi".into()])
     };
 
-    // Build the full expression:
-    // Match files with hack/php/hhi suffix (or config file), excluding ignored paths
     if exclusions.len() > 1 {
-        // We have exclusions beyond just .git
         Expr::All(vec![
             Expr::FileType(FileType::Regular),
             file_match,
             Expr::Not(Box::new(Expr::Any(exclusions))),
         ])
     } else {
-        // Just the .git exclusion
         Expr::All(vec![
             Expr::FileType(FileType::Regular),
             file_match,

--- a/tests/server/1/index.hack
+++ b/tests/server/1/index.hack
@@ -1,0 +1,3 @@
+function main(): void {
+    echo "test\n";
+}

--- a/tests/server/2/index.hack
+++ b/tests/server/2/index.hack
@@ -1,0 +1,3 @@
+function main(): void {
+    echo "test\n";
+}

--- a/tests/server/3/index.hack
+++ b/tests/server/3/index.hack
@@ -1,0 +1,4 @@
+function main(): int {
+    echo "test\n";
+    return "aa";
+}


### PR DESCRIPTION
Currently the hakana server uses a watchman subscription to
poll for changes to Hack files and perform incremental analysis,
but the LSP server still does its own file watching and pushes
its own changes to the server, so each change triggers two analysis runs.
We should instead have the server notify us when its internal
file watching has triggered an analysis and updated diagnostics.

* Convert all server I/O to async so that we can support multiple
  connections.
* Split out the standalone and server-based backends in the LSP server
  and have the latter fetch diagnostics in a background task.
* Remove now-unnecessary async version of `scan_and_analyze` from
  orchestrator.
* Fix server tests that were always failing silently.

## Testing
* `hakana analyze` with a running server reports issues if the server state is warm, otherwise waits for analysis completion
* LSP server likewise reports issues from existing state if available otherwise updates diagnostics as changes occur
* `hakana analyze --standalone` is not affected