### PR TITLE
Replace logger with log crate

### DIFF
--- a/src/analyzer/Cargo.toml
+++ b/src/analyzer/Cargo.toml
@@ -10,7 +10,7 @@ rand = "0.8.5"
 indexmap = "1.8.0"
 itertools = "0.10.1"
 hakana-algebra = { path = "../algebra" }
-hakana-logger = { path = "../logger" }
+log = "0.4"
 hakana-code-info = { path = "../code_info" }
 hakana-str = { path = "../str" }
 hakana-reflector = { path = "../code_info_builder" }

--- a/src/analyzer/dataflow/program_analyzer.rs
+++ b/src/analyzer/dataflow/program_analyzer.rs
@@ -2,11 +2,10 @@ use hakana_code_info::code_location::FilePath;
 use hakana_code_info::data_flow::node::DataFlowNodeId;
 use hakana_code_info::data_flow::node::DataFlowNodeKind;
 use hakana_code_info::function_context::FunctionLikeIdentifier;
-use hakana_logger::Logger;
-use hakana_logger::Verbosity;
 use hakana_str::Interner;
 use hakana_str::StrId;
 use itertools::Itertools;
+use log::{Level, info, log_enabled};
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 use std::rc::Rc;
@@ -24,7 +23,6 @@ use hakana_code_info::taint::{SinkType, get_sinks_for_sources};
 pub fn find_tainted_data(
     graph: &DataFlowGraph,
     config: &Config,
-    logger: &Logger,
     interner: &Interner,
 ) -> Vec<Issue> {
     let mut new_issues = vec![];
@@ -35,46 +33,16 @@ pub fn find_tainted_data(
         .map(|v| Rc::new(TaintedNode::from(v)))
         .collect::<Vec<_>>();
 
-    logger.log_sync("Security analysis: detecting paths");
-    logger.log_sync(&format!(" - initial sources count: {}", sources.len()));
-    logger.log_sync(&format!(" - initial sinks count:   {}", graph.sinks.len()));
+    info!("Security analysis: detecting paths");
+    info!(" - initial sources count: {}", sources.len());
+    info!(" - initial sinks count:   {}", graph.sinks.len());
 
-    // println!("{:#?}", graph);
-
-    // for (sink_id, _) in &graph.sinks {
-    //     println!("sink: {}", sink_id.to_string(interner));
-    // }
-
-    // for (from_id, to) in &graph.forward_edges {
-    //     for (to_id, path) in to {
-    //         println!(
-    //             "{} --{}--> {}",
-    //             from_id.to_string(interner),
-    //             path.kind,
-    //             to_id.to_string(interner)
-    //         );
-    //     }
-    // }
-
-    find_paths_to_sinks(
-        sources,
-        graph,
-        config,
-        logger,
-        &mut new_issues,
-        true,
-        interner,
-    );
+    find_paths_to_sinks(sources, graph, config, &mut new_issues, true, interner);
 
     new_issues
 }
 
-pub fn find_connections(
-    graph: &DataFlowGraph,
-    config: &Config,
-    logger: &Logger,
-    interner: &Interner,
-) -> Vec<Issue> {
+pub fn find_connections(graph: &DataFlowGraph, config: &Config, interner: &Interner) -> Vec<Issue> {
     let mut new_issues = vec![];
 
     let sources = graph
@@ -84,37 +52,17 @@ pub fn find_connections(
         .map(|(_, v)| Rc::new(TaintedNode::from(v)))
         .collect::<Vec<_>>();
 
-    logger.log_sync(&format!(" - initial sources count: {}", sources.len()));
+    info!(" - initial sources count: {}", sources.len());
 
-    // for (from_id, to) in &graph.forward_edges {
-    //     for (to_id, _) in to {
-    //         println!(
-    //             "{} -> {}",
-    //             from_id.to_string(interner),
-    //             to_id.to_string(interner)
-    //         );
-    //     }
-    // }
-
-    find_paths_to_sinks(
-        sources,
-        graph,
-        config,
-        logger,
-        &mut new_issues,
-        false,
-        interner,
-    );
+    find_paths_to_sinks(sources, graph, config, &mut new_issues, false, interner);
 
     new_issues
 }
 
-#[inline]
 fn find_paths_to_sinks(
     mut sources: Vec<Rc<TaintedNode>>,
     graph: &DataFlowGraph,
     config: &Config,
-    logger: &Logger,
     new_issues: &mut Vec<Issue>,
     match_sinks: bool,
     interner: &Interner,
@@ -128,10 +76,7 @@ fn find_paths_to_sinks(
     if !match_sinks || !graph.sinks.is_empty() {
         for i in 0..config.security_config.max_depth {
             if !sources.is_empty() {
-                let now = if matches!(
-                    logger.get_verbosity(),
-                    Verbosity::Debugging | Verbosity::Timing
-                ) {
+                let now = if log_enabled!(Level::Debug) {
                     Some(Instant::now())
                 } else {
                     None
@@ -142,10 +87,7 @@ fn find_paths_to_sinks(
                 let mut file_nodes = FxHashMap::default();
 
                 for source in sources {
-                    let inow = if matches!(
-                        logger.get_verbosity(),
-                        Verbosity::Debugging | Verbosity::Timing
-                    ) {
+                    let inow = if log_enabled!(Level::Debug) {
                         Some(Instant::now())
                     } else {
                         None
@@ -174,16 +116,16 @@ fn find_paths_to_sinks(
                     if let Some(inow) = inow {
                         let ielapsed = inow.elapsed();
                         if ielapsed.as_millis() > 100 {
-                            logger.log_sync(&format!(
+                            info!(
                                 "    - took {:.2?} to generate from {}",
                                 ielapsed,
                                 source_id.to_string(interner)
-                            ));
+                            );
                         }
                     }
                 }
 
-                logger.log_sync(&format!(
+                info!(
                     " - generated {} new destinations from {} sources{}",
                     new_sources.len(),
                     actual_source_count,
@@ -193,18 +135,18 @@ fn find_paths_to_sinks(
                     } else {
                         "".to_string()
                     }
-                ));
+                );
 
                 let top_files = file_nodes.iter().sorted_by(|a, b| b.1.cmp(a.1)).take(5);
 
                 for top_file in top_files {
                     if *top_file.1 > 10000 {
-                        logger.log_sync(&format!(
+                        info!(
                             "   - {} in {}:{}",
                             top_file.1,
                             top_file.0.0.get_relative_path(interner, &config.root_dir),
                             top_file.0.1,
-                        ));
+                        );
                     }
                 }
 

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 hakana-orchestrator = { path = "../orchestrator" }
 hakana-analyzer = { path = "../analyzer" }
 hakana-logger = { path = "../logger" }
+log = "0.4"
 hakana-code-info = { path = "../code_info" }
 hakana-str = { path = "../str" }
 hakana-language-server = { path = "../language_server" }

--- a/src/cli/lib.rs
+++ b/src/cli/lib.rs
@@ -7,12 +7,12 @@ use hakana_code_info::analysis_result::{
 use hakana_code_info::data_flow::graph::{GraphKind, WholeProgramKind};
 use hakana_code_info::issue::IssueKind;
 use hakana_language_server::server_client::ServerConnection;
-use hakana_logger::{Logger, Verbosity};
 use hakana_protocol::ClientSocket;
 use hakana_str::Interner;
 use indexmap::IndexMap;
 use indicatif::{ProgressBar, ProgressStyle};
 use line_break_map::LineBreakMap;
+use log::LevelFilter;
 use rand::Rng;
 use rustc_hash::FxHashSet;
 use serde_json::json;
@@ -628,37 +628,46 @@ pub async fn init(
         _ => 8,
     };
 
-    let logger = match matches.subcommand() {
+    let show_progress = match matches.subcommand() {
         Some(("test", sub_matches)) => {
             if sub_matches.is_present("debug") {
-                Logger::CommandLine(Verbosity::Debugging)
+                hakana_logger::init_stdout_logger(LevelFilter::Debug);
             } else {
-                Logger::DevNull
+                hakana_logger::init_stdout_logger(LevelFilter::Off);
             }
+            false
         }
         Some(("server", sub_matches)) => {
-            if sub_matches.is_present("debug") {
-                Logger::CommandLine(Verbosity::Debugging)
+            let level = if sub_matches.is_present("debug") {
+                LevelFilter::Debug
             } else {
-                Logger::CommandLine(Verbosity::Simple)
-            }
+                LevelFilter::Info
+            };
+            hakana_logger::init_file_logger("/tmp/hakana-server.log", level);
+            false
         }
         Some((_, sub_matches)) => {
             if sub_matches.is_present("debug") {
-                Logger::CommandLine(Verbosity::Debugging)
+                hakana_logger::init_stdout_logger(LevelFilter::Debug);
+                false
             } else if sub_matches.is_present("show-timing") {
-                Logger::CommandLine(Verbosity::Timing)
+                hakana_logger::init_stdout_logger(LevelFilter::Debug);
+                false
             } else if stdout_is_tty {
-                Logger::CommandLine(Verbosity::Simple)
+                hakana_logger::init_stdout_logger(LevelFilter::Info);
+                true
             } else {
-                Logger::DevNull
+                hakana_logger::init_stdout_logger(LevelFilter::Off);
+                false
             }
         }
         _ => {
             if stdout_is_tty {
-                Logger::CommandLine(Verbosity::Simple)
+                hakana_logger::init_stdout_logger(LevelFilter::Info);
+                true
             } else {
-                Logger::DevNull
+                hakana_logger::init_stdout_logger(LevelFilter::Off);
+                false
             }
         }
     };
@@ -704,7 +713,7 @@ pub async fn init(
                 &cwd,
                 cache_dir,
                 threads,
-                logger,
+                show_progress,
                 header,
                 &mut had_error,
             )
@@ -718,7 +727,7 @@ pub async fn init(
                 sub_matches,
                 analysis_hooks,
                 threads,
-                logger,
+                show_progress,
                 header,
                 &mut had_error,
             );
@@ -731,7 +740,7 @@ pub async fn init(
                 sub_matches,
                 analysis_hooks,
                 threads,
-                logger,
+                show_progress,
                 header,
                 &mut had_error,
             );
@@ -745,7 +754,7 @@ pub async fn init(
                 config_path,
                 &cwd,
                 threads,
-                logger,
+                show_progress,
                 header,
             );
         }
@@ -758,7 +767,7 @@ pub async fn init(
                 config_path,
                 &cwd,
                 threads,
-                logger,
+                show_progress,
                 header,
             );
         }
@@ -772,7 +781,7 @@ pub async fn init(
                 config_path,
                 &cwd,
                 threads,
-                logger,
+                show_progress,
                 header,
             );
         }
@@ -785,7 +794,7 @@ pub async fn init(
                 config_path,
                 &cwd,
                 threads,
-                logger,
+                show_progress,
                 header,
             );
         }
@@ -798,7 +807,7 @@ pub async fn init(
                 config_path,
                 &cwd,
                 threads,
-                logger,
+                show_progress,
                 header,
             );
         }
@@ -811,7 +820,7 @@ pub async fn init(
                 config_path,
                 cwd,
                 threads,
-                logger,
+                show_progress,
                 header,
             );
         }
@@ -835,7 +844,7 @@ pub async fn init(
 
             test_runner.run_test(
                 sub_matches.value_of("TEST").expect("required").to_string(),
-                Arc::new(logger),
+                show_progress,
                 !sub_matches.is_present("no-cache"),
                 sub_matches.is_present("reuse-codebase"),
                 &mut had_error,
@@ -845,21 +854,13 @@ pub async fn init(
             );
         }
         Some(("find-executable", sub_matches)) => {
-            do_find_executable(sub_matches, &root_dir, &cwd, threads, logger);
+            do_find_executable(sub_matches, &root_dir, &cwd, threads, show_progress);
         }
         Some(("lint", sub_matches)) => {
             do_lint(sub_matches, &root_dir, &mut had_error, custom_linters);
         }
         Some(("server", sub_matches)) => {
-            do_server(
-                sub_matches,
-                &root_dir,
-                threads,
-                logger,
-                header,
-                analysis_hooks,
-            )
-            .await;
+            do_server(sub_matches, &root_dir, threads, header, analysis_hooks).await;
         }
         Some(("cyclomatic-complexity", sub_matches)) => {
             do_cyclomatic_complexity(
@@ -869,7 +870,7 @@ pub async fn init(
                 config_path,
                 &cwd,
                 threads,
-                logger,
+                show_progress,
                 header,
                 &mut had_error,
             );
@@ -890,7 +891,7 @@ fn do_fix(
     config_path: Option<&Path>,
     cwd: String,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
 ) {
     let issue_name = sub_matches.value_of("issue").unwrap().to_string();
@@ -924,7 +925,7 @@ fn do_fix(
         Arc::new(config),
         None,
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,
@@ -947,7 +948,7 @@ fn do_find_executable(
     root_dir: &str,
     cwd: &String,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
 ) {
     let output_file = sub_matches.value_of("output").unwrap().to_string();
     let config = config::Config::new(root_dir.to_string(), FxHashSet::default());
@@ -957,7 +958,7 @@ fn do_find_executable(
         None,
         &Arc::new(config),
         threads,
-        Arc::new(logger),
+        show_progress,
     ) {
         Ok(file_infos) => {
             let output_path = if output_file.starts_with('/') {
@@ -993,7 +994,7 @@ fn do_remove_unused_fixmes(
     config_path: Option<&Path>,
     cwd: &String,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
 ) {
     let filter = sub_matches.value_of("filter").map(|f| f.to_string());
@@ -1025,7 +1026,7 @@ fn do_remove_unused_fixmes(
         Arc::new(config),
         None,
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,
@@ -1051,7 +1052,7 @@ fn do_add_fixmes(
     config_path: Option<&Path>,
     cwd: &String,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
 ) {
     let filter_issue_strings = sub_matches
@@ -1102,7 +1103,7 @@ fn do_add_fixmes(
         Arc::new(config),
         None,
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,
@@ -1128,7 +1129,7 @@ fn do_migrate(
     config_path: Option<&Path>,
     cwd: &String,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
 ) {
     let migration_name = sub_matches.value_of("migration").unwrap().to_string();
@@ -1194,7 +1195,7 @@ fn do_migrate(
         Arc::new(config),
         None,
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,
@@ -1220,7 +1221,7 @@ fn do_migration_candidates(
     config_path: Option<&Path>,
     cwd: &String,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
 ) {
     let migration_name = sub_matches.value_of("migration").unwrap().to_string();
@@ -1267,7 +1268,7 @@ fn do_migration_candidates(
         config.clone(),
         None,
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,
@@ -1298,7 +1299,7 @@ fn do_codegen(
     config_path: Option<&Path>,
     cwd: &String,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
 ) {
     let codegen_name = sub_matches.value_of("name");
@@ -1350,7 +1351,7 @@ fn do_codegen(
         config.clone(),
         None,
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,
@@ -1450,7 +1451,7 @@ fn do_find_paths(
     sub_matches: &clap::ArgMatches,
     analysis_hooks: Vec<Box<dyn CustomHook>>,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
     had_error: &mut bool,
 ) {
@@ -1486,7 +1487,7 @@ fn do_find_paths(
         Arc::new(config),
         None,
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,
@@ -1518,7 +1519,7 @@ fn do_security_check(
     sub_matches: &clap::ArgMatches,
     analysis_hooks: Vec<Box<dyn CustomHook>>,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
     had_error: &mut bool,
 ) {
@@ -1556,7 +1557,7 @@ fn do_security_check(
         Arc::new(config),
         None,
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,
@@ -1600,7 +1601,7 @@ async fn do_analysis(
     cwd: &String,
     cache_dir: String,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
     had_error: &mut bool,
 ) {
@@ -1826,7 +1827,7 @@ async fn do_analysis(
             Some(&cache_dir)
         },
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,
@@ -2647,7 +2648,6 @@ async fn do_server(
     sub_matches: &clap::ArgMatches,
     root_dir: &str,
     threads: u8,
-    logger: Logger,
     header: &str,
     analysis_hooks: Vec<Box<dyn CustomHook>>,
 ) {
@@ -2724,7 +2724,7 @@ async fn do_server(
         chaos_monkey: None,
     };
 
-    match Server::new(server_config, Arc::new(logger)) {
+    match Server::new(server_config) {
         Ok(mut server) => {
             tty_println!("Starting hakana server...");
             tty_println!("Socket: {}", server.socket_path().path().display());
@@ -2748,7 +2748,7 @@ fn do_cyclomatic_complexity(
     config_path: Option<&Path>,
     cwd: &String,
     threads: u8,
-    logger: Logger,
+    show_progress: bool,
     header: &str,
     had_error: &mut bool,
 ) {
@@ -2793,7 +2793,7 @@ fn do_cyclomatic_complexity(
         Arc::new(config),
         None,
         threads,
-        Arc::new(logger),
+        show_progress,
         header,
         Arc::new(interner),
         None,

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -62,6 +62,8 @@ pub fn parse_args() -> McpConfig {
 
 /// Run the MCP server with the given plugins and header.
 pub async fn run(plugins: Vec<Box<dyn CustomHook>>, header: String) {
+    hakana_logger::init_stderr_logger(log::LevelFilter::Info);
+
     let config = parse_args();
 
     // Convert hooks to Arc for reuse

--- a/src/cli/test_runners/integration_test.rs
+++ b/src/cli/test_runners/integration_test.rs
@@ -1,5 +1,4 @@
 use hakana_code_info::analysis_result::AnalysisResult;
-use hakana_logger::Logger;
 use hakana_orchestrator::SuccessfulScanData;
 
 use super::test_runner::HooksProvider;
@@ -8,14 +7,12 @@ use crate::test_runners::tests::{
     GotoDefinitionTest, LinterTest, MigrationCandidatesTest, ReferencesTest, SkippedTest,
     StandardAnalysisTest,
 };
-use std::sync::Arc;
 use std::time::Duration;
 
 /// Shared context passed to every [`IntegrationTest`] implementation.
 pub struct TestContext<'a> {
     pub dir: String,
     pub cwd: String,
-    pub logger: Arc<Logger>,
     pub cache_dir: Option<&'a String>,
     pub build_checksum: &'a str,
     pub previous_scan_data: Option<SuccessfulScanData>,

--- a/src/cli/test_runners/test_runner.rs
+++ b/src/cli/test_runners/test_runner.rs
@@ -1,5 +1,4 @@
 use hakana_analyzer::custom_hook::CustomHook;
-use hakana_logger::Logger;
 use hakana_orchestrator::SuccessfulScanData;
 use hakana_orchestrator::wasm::get_single_file_codebase;
 use rand::SeedableRng;
@@ -12,7 +11,6 @@ use std::fs;
 use std::io;
 use std::io::Write;
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Duration;
 
 use super::integration_test::{TestContext, select_test_type};
@@ -28,7 +26,7 @@ impl TestRunner {
     pub fn run_test(
         &self,
         test_or_test_dir: String,
-        logger: Arc<Logger>,
+        _show_progress: bool,
         use_cache: bool,
         reuse_codebase: bool,
         had_error: &mut bool,
@@ -105,7 +103,6 @@ impl TestRunner {
                 let ctx = TestContext {
                     dir: test_folder,
                     cwd,
-                    logger: logger.clone(),
                     cache_dir: cache_dir.as_ref().filter(|_| use_cache),
                     build_checksum,
                     previous_scan_data,

--- a/src/cli/test_runners/tests/code_transform.rs
+++ b/src/cli/test_runners/tests/code_transform.rs
@@ -22,8 +22,7 @@ impl IntegrationTest for CodeTransformTest {
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
         augment_with_local_config(&ctx.dir, &mut analysis_config);
 
-        ctx.logger
-            .log_debug_sync(&format!("running test {}", ctx.dir));
+        log::debug!("running test {}", ctx.dir);
 
         let config = Arc::new(analysis_config);
 
@@ -49,7 +48,7 @@ impl IntegrationTest for CodeTransformTest {
                 None
             },
             1,
-            ctx.logger,
+            false,
             ctx.build_checksum,
             interner,
             ctx.previous_scan_data,

--- a/src/cli/test_runners/tests/cyclomatic_complexity.rs
+++ b/src/cli/test_runners/tests/cyclomatic_complexity.rs
@@ -40,7 +40,7 @@ impl IntegrationTest for CyclomaticComplexityTest {
             config,
             None,
             1,
-            ctx.logger,
+            false,
             ctx.build_checksum,
             interner,
             None,

--- a/src/cli/test_runners/tests/diff.rs
+++ b/src/cli/test_runners/tests/diff.rs
@@ -24,8 +24,7 @@ impl IntegrationTest for DiffTest {
     fn run(&self, ctx: TestContext) -> TestResult {
         let cwd = &ctx.cwd;
 
-        ctx.logger
-            .log_debug_sync(&format!("running test {}", ctx.dir));
+        log::debug!("running test {}", ctx.dir);
 
         if let Some(cache_dir) = ctx.cache_dir {
             fs::remove_dir_all(cache_dir).unwrap();
@@ -81,7 +80,7 @@ impl IntegrationTest for DiffTest {
                 config.clone(),
                 None,
                 1,
-                ctx.logger.clone(),
+                false,
                 ctx.build_checksum,
                 interner.clone(),
                 previous_scan_data,

--- a/src/cli/test_runners/tests/executable_code_finder.rs
+++ b/src/cli/test_runners/tests/executable_code_finder.rs
@@ -20,7 +20,7 @@ impl IntegrationTest for ExecutableCodeFinderTest {
 
         let config = Arc::new(analysis_config);
 
-        match executable_finder::scan_files(&vec![ctx.dir.clone()], None, &config, 1, ctx.logger) {
+        match executable_finder::scan_files(&vec![ctx.dir.clone()], None, &config, 1, false) {
             Ok(test_output) => {
                 let expected_output_path = ctx.dir.clone() + "/output.txt";
                 let expected_output = if Path::new(&expected_output_path).exists() {

--- a/src/cli/test_runners/tests/goto_definition.rs
+++ b/src/cli/test_runners/tests/goto_definition.rs
@@ -29,7 +29,7 @@ impl IntegrationTest for GotoDefinitionTest {
             config,
             None,
             1,
-            ctx.logger,
+            false,
             ctx.build_checksum,
             Arc::new(hakana_str::Interner::default()),
             ctx.previous_scan_data,

--- a/src/cli/test_runners/tests/migration_candidates.rs
+++ b/src/cli/test_runners/tests/migration_candidates.rs
@@ -22,8 +22,7 @@ impl IntegrationTest for MigrationCandidatesTest {
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
         augment_with_local_config(&ctx.dir, &mut analysis_config);
 
-        ctx.logger
-            .log_debug_sync(&format!("running test {}", ctx.dir));
+        log::debug!("running test {}", ctx.dir);
 
         let config = Arc::new(analysis_config);
 
@@ -49,7 +48,7 @@ impl IntegrationTest for MigrationCandidatesTest {
                 None
             },
             1,
-            ctx.logger,
+            false,
             ctx.build_checksum,
             interner,
             ctx.previous_scan_data,

--- a/src/cli/test_runners/tests/references.rs
+++ b/src/cli/test_runners/tests/references.rs
@@ -28,7 +28,7 @@ impl IntegrationTest for ReferencesTest {
             config,
             None,
             1,
-            ctx.logger,
+            false,
             ctx.build_checksum,
             Arc::new(hakana_str::Interner::default()),
             ctx.previous_scan_data,

--- a/src/cli/test_runners/tests/standard_analysis.rs
+++ b/src/cli/test_runners/tests/standard_analysis.rs
@@ -21,8 +21,7 @@ impl IntegrationTest for StandardAnalysisTest {
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
         augment_with_local_config(&ctx.dir, &mut analysis_config);
 
-        ctx.logger
-            .log_debug_sync(&format!("running test {}", ctx.dir));
+        log::debug!("running test {}", ctx.dir);
 
         let config = Arc::new(analysis_config);
 
@@ -48,7 +47,7 @@ impl IntegrationTest for StandardAnalysisTest {
                 None
             },
             1,
-            ctx.logger,
+            false,
             ctx.build_checksum,
             interner,
             ctx.previous_scan_data,

--- a/src/executable_code_finder/Cargo.toml
+++ b/src/executable_code_finder/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 hakana-analyzer = { path = "../analyzer" }
-hakana-logger = { path = "../logger" }
+log = "0.4"
 hakana-code-info = { path = "../code_info" }
 hakana-str = { path = "../str" }
 hakana-orchestrator = { path = "../orchestrator" }

--- a/src/executable_code_finder/lib.rs
+++ b/src/executable_code_finder/lib.rs
@@ -1,10 +1,10 @@
 use hakana_analyzer::config::Config;
 use hakana_code_info::code_location::FilePath;
 use hakana_code_info::file_info::ParserError;
-use hakana_logger::Logger;
 use hakana_orchestrator::scanner::get_filesystem;
 use hakana_str::{Interner, ThreadedInterner};
 use indicatif::{ProgressBar, ProgressStyle};
+use log::debug;
 use oxidized::aast::{Def, Expr_, Stmt_};
 use oxidized::ast::Pos;
 use oxidized::{
@@ -28,9 +28,9 @@ pub fn scan_files(
     cache_dir: Option<&String>,
     config: &Arc<Config>,
     threads: u8,
-    logger: Arc<Logger>,
+    show_progress: bool,
 ) -> Result<Vec<ExecutableLines>, ()> {
-    logger.log_debug_sync(&format!("{:#?}", scan_dirs));
+    debug!("{:#?}", scan_dirs);
 
     let mut files_to_scan = vec![];
     let mut files_to_analyze = vec![];
@@ -40,7 +40,6 @@ pub fn scan_files(
     get_filesystem(
         &mut files_to_scan,
         &mut interner,
-        &logger,
         scan_dirs,
         &existing_file_system,
         config,
@@ -54,7 +53,7 @@ pub fn scan_files(
     if !files_to_scan.is_empty() {
         let file_scanning_now = Instant::now();
 
-        let bar = if logger.show_progress() {
+        let bar = if show_progress {
             let pb = ProgressBar::new(files_to_scan.len() as u64);
             let sty =
                 ProgressStyle::with_template("{bar:40.green/yellow} {pos:>7}/{len:7}").unwrap();
@@ -87,7 +86,6 @@ pub fn scan_files(
             let interner = interner.clone();
             let bar = bar.clone();
             let files_processed = files_processed.clone();
-            let logger = logger.clone();
             let executable_lines = executable_lines.clone();
             let root_dir = config.root_dir.clone();
 
@@ -95,7 +93,7 @@ pub fn scan_files(
                 let new_interner = ThreadedInterner::new(interner);
 
                 for file_path in &path_group {
-                    let res = scan_file(&new_interner, &root_dir, *file_path, &logger.clone());
+                    let res = scan_file(&new_interner, &root_dir, *file_path);
                     let mut executable_lines = executable_lines.lock().unwrap();
                     if !res.executable_lines.is_empty() {
                         executable_lines.push(res);
@@ -117,12 +115,7 @@ pub fn scan_files(
             bar.finish_and_clear();
         }
 
-        if logger.can_log_timing() {
-            logger.log_sync(&format!(
-                "Scanning files took {:.2?}",
-                file_scanning_now.elapsed()
-            ));
-        }
+        debug!("Scanning files took {:.2?}", file_scanning_now.elapsed());
     }
 
     Ok(Arc::try_unwrap(executable_lines)
@@ -141,12 +134,11 @@ pub(crate) fn scan_file(
     interner: &ThreadedInterner,
     root_dir: &str,
     file_path: FilePath,
-    logger: &Logger,
 ) -> ExecutableLines {
     let interner = interner.parent.lock().unwrap();
     let str_path = interner.lookup(&file_path.0).to_string();
 
-    logger.log_debug_sync(&format!("scanning {}", str_path));
+    debug!("scanning {}", str_path);
     let aast = hakana_orchestrator::get_aast_for_path(file_path, &str_path);
     let aast = match aast {
         Ok(aast) => aast,

--- a/src/language_server/Cargo.toml
+++ b/src/language_server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 hakana-orchestrator = { path = "../orchestrator" }
 hakana-analyzer = { path = "../analyzer" }
 hakana-logger = { path = "../logger" }
+log = "0.4"
 hakana-str = { path = "../str" }
 hakana-code-info = { path = "../code_info" }
 hakana-protocol = { path = "../protocol" }

--- a/src/language_server/lib.rs
+++ b/src/language_server/lib.rs
@@ -313,10 +313,8 @@ impl Backend {
 
         let (log_tx, mut log_rx) = tokio::sync::mpsc::channel(1);
 
-        println!("analysiseee");
-
         let mut task_result = tokio::task::spawn_blocking(move || {
-            use hakana_logger::Logger;
+            hakana_logger::init_channel_logger(log_tx, log::LevelFilter::Info);
 
             scan_and_analyze(
                 Vec::new(),
@@ -325,7 +323,7 @@ impl Backend {
                 analysis_config,
                 None,
                 8,
-                Arc::new(Logger::Channel(log_tx)),
+                false,
                 "",
                 interner,
                 successful_scan_data,

--- a/src/language_server/lib.rs
+++ b/src/language_server/lib.rs
@@ -311,7 +311,7 @@ impl Backend {
         let interner = self.starter_interner.clone();
         let client = self.client.clone();
 
-        let (log_tx, mut log_rx) = tokio::sync::mpsc::channel(1);
+        let (log_tx, mut log_rx) = tokio::sync::mpsc::channel(64);
 
         let mut task_result = tokio::task::spawn_blocking(move || {
             hakana_logger::init_channel_logger(log_tx, log::LevelFilter::Info);

--- a/src/language_server/server_client.rs
+++ b/src/language_server/server_client.rs
@@ -67,7 +67,7 @@ impl ServerConnection {
             return Ok(socket);
         }
 
-        eprintln!("Server connection failed, attempting to respawn...");
+        log::info!("Server connection failed, attempting to respawn...");
 
         let mut server_process =
             Self::spawn_server(&self.project_root, self.hakana_binary.as_deref())?;
@@ -91,7 +91,7 @@ impl ServerConnection {
             Self::find_hakana_binary()?
         };
 
-        eprintln!(
+        log::info!(
             "Spawning hakana server: {} server --root {}",
             binary.display(),
             project_root.display()
@@ -101,7 +101,7 @@ impl ServerConnection {
         let stdout = std::fs::File::create(&log_path)?;
         let stderr = stdout.try_clone()?;
 
-        eprintln!("Server log file: {}", log_path.display());
+        log::info!("Server log file: {}", log_path.display());
 
         let child = Command::new(&binary)
             .arg("server")
@@ -172,7 +172,7 @@ impl ServerConnection {
                     let log_path = std::env::temp_dir().join("hakana-server.log");
                     let log_contents = std::fs::read_to_string(&log_path)
                         .unwrap_or_else(|_| "<no log available>".to_string());
-                    eprintln!("Server log contents:\n{}", log_contents);
+                    log::info!("Server log contents:\n{}", log_contents);
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
                         format!(

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2024"
 path = "lib.rs"
 
 [dependencies]
+anyhow = "1"
+log = "0.4"
+log4rs = "1"
 tokio = { version = "1.26.0", features = ["sync"] }

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -9,5 +9,5 @@ path = "lib.rs"
 [dependencies]
 anyhow = "1"
 log = "0.4"
-log4rs = "1"
+log4rs = { version = "1", features = ["gzip"] }
 tokio = { version = "1.26.0", features = ["sync"] }

--- a/src/logger/lib.rs
+++ b/src/logger/lib.rs
@@ -1,82 +1,92 @@
+use log::LevelFilter;
+use log4rs::Config;
+use log4rs::append::Append;
+use log4rs::config::{Appender, Root};
+use log4rs::encode::Encode;
+use log4rs::encode::pattern::PatternEncoder;
+use log4rs::encode::writer::simple::SimpleWriter;
 use tokio::sync::mpsc::Sender;
 
-pub enum Logger {
-    DevNull,
-    CommandLine(Verbosity),
-    Channel(tokio::sync::mpsc::Sender<String>),
+pub use log;
+pub use log4rs;
+
+pub fn init_stdout_logger(level: LevelFilter) {
+    let stdout = log4rs::append::console::ConsoleAppender::builder()
+        .encoder(Box::new(PatternEncoder::new("{m}{n}")))
+        .build();
+
+    let config = Config::builder()
+        .appender(Appender::builder().build("stdout", Box::new(stdout)))
+        .build(Root::builder().appender("stdout").build(level))
+        .unwrap();
+
+    log4rs::init_config(config).ok();
 }
 
-impl Logger {
-    fn try_send(tx: &Sender<String>, message: &str) {
-        if let Err(e) = tx.blocking_send(message.to_string()) {
-            eprintln!("error reporting event {}", e);
-        }
-    }
+pub fn init_file_logger(path: &str, level: LevelFilter) {
+    let file = log4rs::append::file::FileAppender::builder()
+        .encoder(Box::new(PatternEncoder::new(
+            "{d(%Y-%m-%dT%H:%M:%S)} [{l}] {m}{n}",
+        )))
+        .build(path)
+        .unwrap();
 
-    pub async fn log(&self, message: &str) {
-        match self {
-            Logger::DevNull => {}
-            Logger::CommandLine(_) => {
-                println!("{}", message);
-            }
-            Logger::Channel(tx) => Logger::try_send(tx, message),
-        }
-    }
+    let config = Config::builder()
+        .appender(Appender::builder().build("file", Box::new(file)))
+        .build(Root::builder().appender("file").build(level))
+        .unwrap();
 
-    pub fn log_sync(&self, message: &str) {
-        match self {
-            Logger::DevNull => {}
-            Logger::CommandLine(_) => {
-                println!("{}", message);
-            }
-            Logger::Channel(tx) => Logger::try_send(tx, message),
-        }
-    }
+    log4rs::init_config(config).ok();
+}
 
-    pub async fn log_debug(&self, message: &str) {
-        match self {
-            Logger::DevNull | Logger::Channel(_) => {}
-            Logger::CommandLine(verbosity) => {
-                if matches!(verbosity, Verbosity::Debugging | Verbosity::DebuggingByLine) {
-                    println!("{}", message);
-                }
-            }
-        }
-    }
+pub fn init_stderr_logger(level: LevelFilter) {
+    let stderr = log4rs::append::console::ConsoleAppender::builder()
+        .encoder(Box::new(PatternEncoder::new("{m}{n}")))
+        .target(log4rs::append::console::Target::Stderr)
+        .build();
 
-    pub fn log_debug_sync(&self, message: &str) {
-        if let Logger::CommandLine(verbosity) = self {
-            if matches!(verbosity, Verbosity::Debugging | Verbosity::DebuggingByLine) {
-                println!("{}", message);
-            }
-        }
-    }
+    let config = Config::builder()
+        .appender(Appender::builder().build("stderr", Box::new(stderr)))
+        .build(Root::builder().appender("stderr").build(level))
+        .unwrap();
 
-    pub fn can_log_timing(&self) -> bool {
-        match self {
-            Logger::DevNull | Logger::Channel(_) => false,
-            Logger::CommandLine(verbosity) => {
-                matches!(verbosity, Verbosity::Debugging | Verbosity::Timing)
-            }
-        }
-    }
+    log4rs::init_config(config).ok();
+}
 
-    pub fn get_verbosity(&self) -> Verbosity {
-        match self {
-            Logger::DevNull | Logger::Channel(_) => Verbosity::Simple,
-            Logger::CommandLine(verbosity) => *verbosity,
-        }
-    }
+pub fn init_channel_logger(tx: Sender<String>, level: LevelFilter) {
+    let appender = ChannelAppender::new(tx);
 
-    pub fn show_progress(&self) -> bool {
-        matches!(self, Logger::CommandLine(Verbosity::Simple))
+    let config = Config::builder()
+        .appender(Appender::builder().build("channel", Box::new(appender)))
+        .build(Root::builder().appender("channel").build(level))
+        .unwrap();
+
+    log4rs::init_config(config).ok();
+}
+
+#[derive(Debug)]
+pub struct ChannelAppender {
+    tx: Sender<String>,
+    encoder: PatternEncoder,
+}
+
+impl ChannelAppender {
+    pub fn new(tx: Sender<String>) -> Self {
+        Self {
+            tx,
+            encoder: PatternEncoder::new("{m}"),
+        }
     }
 }
 
-#[derive(Copy, Clone)]
-pub enum Verbosity {
-    Simple,
-    Timing,
-    Debugging,
-    DebuggingByLine,
+impl Append for ChannelAppender {
+    fn append(&self, record: &log::Record) -> anyhow::Result<()> {
+        let mut buf = Vec::new();
+        self.encoder.encode(&mut SimpleWriter(&mut buf), record)?;
+        let message = String::from_utf8_lossy(&buf).to_string();
+        let _ = self.tx.blocking_send(message);
+        Ok(())
+    }
+
+    fn flush(&self) {}
 }

--- a/src/logger/lib.rs
+++ b/src/logger/lib.rs
@@ -97,7 +97,7 @@ impl Append for ChannelAppender {
         let mut buf = Vec::new();
         self.encoder.encode(&mut SimpleWriter(&mut buf), record)?;
         let message = String::from_utf8_lossy(&buf).to_string();
-        let _ = self.tx.blocking_send(message);
+        let _ = self.tx.try_send(message);
         Ok(())
     }
 

--- a/src/logger/lib.rs
+++ b/src/logger/lib.rs
@@ -24,11 +24,24 @@ pub fn init_stdout_logger(level: LevelFilter) {
 }
 
 pub fn init_file_logger(path: &str, level: LevelFilter) {
-    let file = log4rs::append::file::FileAppender::builder()
+    use log4rs::append::rolling_file::RollingFileAppender;
+    use log4rs::append::rolling_file::policy::compound::CompoundPolicy;
+    use log4rs::append::rolling_file::policy::compound::roll::fixed_window::FixedWindowRoller;
+    use log4rs::append::rolling_file::policy::compound::trigger::size::SizeTrigger;
+
+    let roller = FixedWindowRoller::builder()
+        .build(&format!("{}.{{}}.gz", path), 2)
+        .unwrap();
+
+    let trigger = SizeTrigger::new(128 * 1024 * 1024);
+
+    let policy = CompoundPolicy::new(Box::new(trigger), Box::new(roller));
+
+    let file = RollingFileAppender::builder()
         .encoder(Box::new(PatternEncoder::new(
             "{d(%Y-%m-%dT%H:%M:%S)} [{l}] {m}{n}",
         )))
-        .build(path)
+        .build(path, Box::new(policy))
         .unwrap();
 
     let config = Config::builder()

--- a/src/mcp_server/Cargo.toml
+++ b/src/mcp_server/Cargo.toml
@@ -14,7 +14,7 @@ hakana-protocol = { path = "../protocol" }
 tokio = { version = "1.28", features = ["rt-multi-thread", "net", "time", "io-util"] }
 hakana-server = { path = "../server" }
 hakana-str = { path = "../str" }
-hakana-logger = { path = "../logger" }
+log = "0.4"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/mcp_server/protocol.rs
+++ b/src/mcp_server/protocol.rs
@@ -109,10 +109,10 @@ impl McpServer {
         }
 
         if !self.socket_path.server_exists() {
-            eprintln!("Spawning hakana server...");
+            log::info!("Spawning hakana server...");
             self.spawn_server()?;
 
-            eprintln!("Waiting for server to start...");
+            log::info!("Waiting for server to start...");
             let start = Instant::now();
             let timeout = Duration::from_secs(300);
 
@@ -125,7 +125,7 @@ impl McpServer {
                 }
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
-            eprintln!("Server socket appeared, waiting for analysis to complete...");
+            log::info!("Server socket appeared, waiting for analysis to complete...");
         }
 
         self.wait_for_server_ready().await?;
@@ -148,7 +148,7 @@ impl McpServer {
             .clone()
             .unwrap_or_else(|| format!("{}/hakana.json", self.root_dir));
 
-        eprintln!(
+        log::info!(
             "Spawning: {} server --root {}",
             hakana_exe.display(),
             self.root_dir
@@ -187,9 +187,10 @@ impl McpServer {
                     client.request(&Message::Status(StatusRequest)).await
             {
                 if status.ready && !status.analysis_in_progress {
-                    eprintln!(
+                    log::info!(
                         "\nServer analysis complete: {} files, {} symbols",
-                        status.files_count, status.symbols_count
+                        status.files_count,
+                        status.symbols_count
                     );
                     return Ok(());
                 }
@@ -535,7 +536,7 @@ pub async fn run_mcp_server(
 
     run_mcp_server_io(&mut server, stdin, &mut stdout).await?;
 
-    eprintln!("Hakana MCP server shutting down");
+    log::info!("Hakana MCP server shutting down");
     Ok(())
 }
 

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -8,7 +8,7 @@ hakana-reflector = { path = "../code_info_builder" }
 hakana-code-info = { path = "../code_info" }
 hakana-str = { path = "../str" }
 hakana-analyzer = { path = "../analyzer" }
-hakana-logger = { path = "../logger" }
+log = "0.4"
 hakana-aast-helper = { path = "../aast_utils" }
 aast_parser = { path = "../../third-party/hhvm/hphp/hack/src/parser/cargo/aast_parser" }
 ocamlrep = { version = "0.1.0", git = "https://github.com/facebook/ocamlrep/", branch = "main" }

--- a/src/orchestrator/analyzer.rs
+++ b/src/orchestrator/analyzer.rs
@@ -9,9 +9,9 @@ use hakana_code_info::codebase_info::CodebaseInfo;
 use hakana_code_info::file_info::ParserError;
 use hakana_code_info::issue::{Issue, IssueKind};
 use hakana_code_info::symbol_references::SymbolReferences;
-use hakana_logger::Logger;
 use hakana_str::{Interner, StrId};
 use indicatif::{ProgressBar, ProgressStyle};
+use log::debug;
 use oxidized::aast;
 use oxidized::scoured_comments::ScouredComments;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -29,7 +29,7 @@ pub fn analyze_files(
     filter: Option<String>,
     ignored_paths: &Option<FxHashSet<String>>,
     threads: u8,
-    logger: Arc<Logger>,
+    show_progress: bool,
     file_analysis_time: &mut Duration,
     files_processed: Option<Arc<AtomicU32>>,
 ) -> io::Result<()> {
@@ -63,7 +63,7 @@ pub fn analyze_files(
             .push(str_path);
     }
 
-    let bar = if logger.show_progress() {
+    let bar = if show_progress {
         let pb = ProgressBar::new(total_file_count);
         let sty = ProgressStyle::with_template("{bar:40.green/yellow} {pos:>7}/{len:7}").unwrap();
         pb.set_style(sty);
@@ -92,8 +92,6 @@ pub fn analyze_files(
         let files_processed_counter = files_processed_counter.clone();
         let bar = bar.clone();
 
-        let logger = logger.clone();
-
         let arc_file_analysis_time = arc_file_analysis_time.clone();
 
         let handle = std::thread::spawn(move || {
@@ -119,7 +117,6 @@ pub fn analyze_files(
                         &analysis_config,
                         &mut new_analysis_result,
                         resolved_names,
-                        &logger,
                     );
                 }
 
@@ -161,9 +158,8 @@ fn analyze_file(
     config: &Arc<Config>,
     analysis_result: &mut AnalysisResult,
     resolved_names: &FxHashMap<u32, StrId>,
-    logger: &Logger,
 ) -> Duration {
-    logger.log_debug_sync(&format!("Analyzing {}", &str_path));
+    debug!("Analyzing {}", &str_path);
 
     if let Ok(metadata) = fs::metadata(str_path) {
         let updated_time = metadata

--- a/src/orchestrator/cache.rs
+++ b/src/orchestrator/cache.rs
@@ -2,9 +2,9 @@ use hakana_code_info::code_location::FilePath;
 use hakana_code_info::codebase_info::CodebaseInfo;
 use hakana_code_info::issue::Issue;
 use hakana_code_info::symbol_references::SymbolReferences;
-use hakana_logger::Logger;
 use hakana_str::Interner;
 use hakana_str::StrId;
+use log::info;
 use rustc_hash::FxHashMap;
 use std::fs;
 use std::path::Path;
@@ -14,10 +14,9 @@ use crate::file::VirtualFileSystem;
 pub(crate) fn load_cached_codebase(
     codebase_path: &String,
     use_codebase_cache: bool,
-    logger: &Logger,
 ) -> Option<CodebaseInfo> {
     if Path::new(codebase_path).exists() && use_codebase_cache {
-        logger.log_sync("Deserializing stored codebase cache");
+        info!("Deserializing stored codebase cache");
         let serialized = fs::read(codebase_path)
             .unwrap_or_else(|_| panic!("Could not read file {}", &codebase_path));
         if let Ok(d) = bincode::deserialize::<CodebaseInfo>(&serialized) {
@@ -31,10 +30,9 @@ pub(crate) fn load_cached_codebase(
 pub(crate) fn load_cached_interner(
     symbols_path: &String,
     use_codebase_cache: bool,
-    logger: &Logger,
 ) -> Option<Interner> {
     if Path::new(symbols_path).exists() && use_codebase_cache {
-        logger.log_sync("Deserializing stored symbol cache");
+        info!("Deserializing stored symbol cache");
         let serialized = fs::read(symbols_path)
             .unwrap_or_else(|_| panic!("Could not read file {}", &symbols_path));
         if let Ok(d) = bincode::deserialize::<Interner>(&serialized) {
@@ -48,10 +46,9 @@ pub(crate) fn load_cached_interner(
 pub(crate) fn load_cached_aast_names(
     aast_names_path: &String,
     use_codebase_cache: bool,
-    logger: &Logger,
 ) -> Option<FxHashMap<FilePath, FxHashMap<u32, StrId>>> {
     if Path::new(aast_names_path).exists() && use_codebase_cache {
-        logger.log_sync("Deserializing aast names cache");
+        info!("Deserializing aast names cache");
         let serialized = fs::read(aast_names_path)
             .unwrap_or_else(|_| panic!("Could not read file {}", &aast_names_path));
         if let Ok(d) =
@@ -67,10 +64,9 @@ pub(crate) fn load_cached_aast_names(
 pub(crate) fn load_cached_existing_references(
     existing_references_path: &String,
     use_codebase_cache: bool,
-    logger: &Logger,
 ) -> Option<SymbolReferences> {
     if Path::new(existing_references_path).exists() && use_codebase_cache {
-        logger.log_sync("Deserializing existing references cache");
+        info!("Deserializing existing references cache");
         let serialized = fs::read(existing_references_path)
             .unwrap_or_else(|_| panic!("Could not read file {}", &existing_references_path));
         if let Ok(d) = bincode::deserialize::<SymbolReferences>(&serialized) {
@@ -84,10 +80,9 @@ pub(crate) fn load_cached_existing_references(
 pub(crate) fn load_cached_existing_issues(
     existing_issues_path: &String,
     use_codebase_cache: bool,
-    logger: &Logger,
 ) -> Option<FxHashMap<FilePath, Vec<Issue>>> {
     if Path::new(existing_issues_path).exists() && use_codebase_cache {
-        logger.log_sync("Deserializing existing issues cache");
+        info!("Deserializing existing issues cache");
         let serialized = fs::read(existing_issues_path)
             .unwrap_or_else(|_| panic!("Could not read file {}", &existing_issues_path));
         if let Ok(d) = bincode::deserialize::<FxHashMap<FilePath, Vec<Issue>>>(&serialized) {

--- a/src/orchestrator/diff.rs
+++ b/src/orchestrator/diff.rs
@@ -4,7 +4,6 @@ use hakana_code_info::codebase_info::CodebaseInfo;
 use hakana_code_info::diff::CodebaseDiff;
 use hakana_code_info::issue::Issue;
 use hakana_code_info::symbol_references::SymbolReferences;
-use hakana_logger::Logger;
 use hakana_str::Interner;
 use hakana_str::StrId;
 use rustc_hash::FxHashMap;
@@ -23,7 +22,6 @@ pub(crate) struct CachedAnalysis {
 }
 
 pub(crate) fn mark_safe_symbols_from_diff(
-    logger: &Logger,
     codebase_diff: CodebaseDiff,
     codebase: &CodebaseInfo,
     interner: &mut Interner,
@@ -43,20 +41,19 @@ pub(crate) fn mark_safe_symbols_from_diff(
             )
         } else if let (Some(issues_path), Some(references_path)) = (issues_path, references_path) {
             let existing_references = if let Some(existing_references) =
-                load_cached_existing_references(references_path, true, logger)
+                load_cached_existing_references(references_path, true)
             {
                 existing_references
             } else {
                 return CachedAnalysis::default();
             };
 
-            let existing_issues = if let Some(existing_issues) =
-                load_cached_existing_issues(issues_path, true, logger)
-            {
-                existing_issues
-            } else {
-                return CachedAnalysis::default();
-            };
+            let existing_issues =
+                if let Some(existing_issues) = load_cached_existing_issues(issues_path, true) {
+                    existing_issues
+                } else {
+                    return CachedAnalysis::default();
+                };
 
             (existing_references, existing_issues, FxHashMap::default())
         } else {

--- a/src/orchestrator/lib.rs
+++ b/src/orchestrator/lib.rs
@@ -13,9 +13,9 @@ use hakana_code_info::data_flow::graph::{GraphKind, WholeProgramKind};
 use hakana_code_info::file_info::ParserError;
 use hakana_code_info::issue::{Issue, IssueKind};
 use hakana_code_info::symbol_references::SymbolReferences;
-use hakana_logger::Logger;
 use hakana_str::{Interner, StrId};
 use indicatif::ProgressBar;
+use log::{debug, info};
 use oxidized::aast;
 use oxidized::scoured_comments::ScouredComments;
 use populator::populate_codebase;
@@ -87,7 +87,7 @@ pub fn scan_and_analyze<F: FnOnce()>(
     config: Arc<Config>,
     cache_dir: Option<&String>,
     threads: u8,
-    logger: Arc<Logger>,
+    show_progress: bool,
     header: &str,
     interner: Arc<Interner>,
     previous_scan_data: Option<SuccessfulScanData>,
@@ -102,7 +102,7 @@ pub fn scan_and_analyze<F: FnOnce()>(
         config,
         cache_dir,
         threads,
-        logger,
+        show_progress,
         header,
         interner,
         previous_scan_data,
@@ -120,7 +120,7 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
     config: Arc<Config>,
     cache_dir: Option<&String>,
     threads: u8,
-    logger: Arc<Logger>,
+    show_progress: bool,
     header: &str,
     interner: Arc<Interner>,
     previous_scan_data: Option<SuccessfulScanData>,
@@ -140,7 +140,7 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
         .map(|p| p.total_files_to_scan.clone());
     let files_analyzed = analysis_progress.as_ref().map(|p| p.files_analyzed.clone());
 
-    logger.log_sync("Scanning files");
+    info!("Scanning files");
 
     let ScanFilesResult {
         mut codebase,
@@ -155,7 +155,7 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
         cache_dir,
         &config,
         threads,
-        logger.clone(),
+        show_progress,
         header,
         &interner,
         previous_scan_data,
@@ -166,12 +166,10 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
 
     let file_discovery_and_scanning_elapsed = file_discovery_and_scanning_now.elapsed();
 
-    if logger.can_log_timing() {
-        logger.log_sync(&format!(
-            "File discovery & scanning took {:.2?}",
-            file_discovery_and_scanning_elapsed
-        ));
-    }
+    debug!(
+        "File discovery & scanning took {:.2?}",
+        file_discovery_and_scanning_elapsed
+    );
 
     if let Some(cache_dir) = cache_dir {
         let timestamp_path = format!("{}/buildinfo", cache_dir);
@@ -187,7 +185,6 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
 
     let mut cached_analysis = if config.ast_diff {
         mark_safe_symbols_from_diff(
-            &logger,
             codebase_diff,
             &codebase,
             &mut interner,
@@ -202,7 +199,7 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
         CachedAnalysis::default()
     };
 
-    logger.log_sync("Calculating symbol inheritance");
+    info!("Calculating symbol inheritance");
 
     let populating_now = Instant::now();
 
@@ -221,16 +218,11 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
 
     let populating_elapsed = populating_now.elapsed();
 
-    if logger.can_log_timing() {
-        logger.log_sync(&format!(
-            "Populating codebase took {:.2?}",
-            populating_elapsed
-        ));
-    }
+    debug!("Populating codebase took {:.2?}", populating_elapsed);
 
     // Check for duplicate definitions and skip analysis if found
     if codebase.has_duplicates() {
-        logger.log_sync("ERROR: Duplicate definitions found in codebase. Skipping analysis.");
+        info!("ERROR: Duplicate definitions found in codebase. Skipping analysis.");
 
         let duplicate_issues = emit_duplicate_definition_issues(&codebase, &interner);
 
@@ -274,7 +266,7 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
         cached_analysis.definition_locations,
     );
 
-    logger.log_sync(&format!("Analyzing {} files", files_to_analyze.len()));
+    info!("Analyzing {} files", files_to_analyze.len());
     if let Some(total_files_to_analyze) = analysis_progress
         .as_ref()
         .map(|p| p.total_files_to_analyze.clone())
@@ -294,17 +286,15 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
         filter,
         &ignored_paths,
         threads,
-        logger.clone(),
+        show_progress,
         &mut pure_file_analysis_time,
         files_analyzed,
     )?;
 
-    if logger.can_log_timing() {
-        logger.log_sync(&format!(
-            "File analysis took {:.2?} (excluding re-parsing)",
-            pure_file_analysis_time
-        ));
-    }
+    debug!(
+        "File analysis took {:.2?} (excluding re-parsing)",
+        pure_file_analysis_time
+    );
 
     let mut analysis_result = (*analysis_result.lock().unwrap()).clone();
 
@@ -332,13 +322,11 @@ pub fn scan_and_analyze_with_progress<F: FnOnce()>(
             WholeProgramKind::Taint => find_tainted_data(
                 &analysis_result.program_dataflow_graph,
                 &config,
-                &logger,
                 &scan_data.interner,
             ),
             WholeProgramKind::Query => find_connections(
                 &analysis_result.program_dataflow_graph,
                 &config,
-                &logger,
                 &scan_data.interner,
             ),
         };

--- a/src/orchestrator/scanner.rs
+++ b/src/orchestrator/scanner.rs
@@ -29,12 +29,12 @@ use hakana_code_info::codebase_info::symbols::SymbolKind;
 use hakana_code_info::diff::CodebaseDiff;
 use hakana_code_info::file_info::FileInfo;
 use hakana_code_info::file_info::ParserError;
-use hakana_logger::Logger;
 use hakana_str::Interner;
 use hakana_str::StrId;
 use hakana_str::ThreadedInterner;
 use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
+use log::{debug, info};
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -54,7 +54,7 @@ pub fn scan_files(
     cache_dir: Option<&String>,
     config: &Arc<Config>,
     threads: u8,
-    logger: Arc<Logger>,
+    show_progress: bool,
     build_checksum: &str,
     starter_interner: &Arc<Interner>,
     starter_data: Option<SuccessfulScanData>,
@@ -62,7 +62,7 @@ pub fn scan_files(
     files_scanned: Option<Arc<AtomicU32>>,
     total_files_to_scan: Option<Arc<AtomicU32>>,
 ) -> io::Result<ScanFilesResult> {
-    logger.log_debug_sync(&format!("{:#?}", scan_dirs));
+    debug!("{:#?}", scan_dirs);
 
     let mut files_to_scan = vec![];
 
@@ -126,9 +126,7 @@ pub fn scan_files(
     let load_from_cache_now = Instant::now();
 
     if let Some(symbols_path) = &symbols_path {
-        if let Some(cached_interner) =
-            load_cached_interner(symbols_path, use_codebase_cache, &logger)
-        {
+        if let Some(cached_interner) = load_cached_interner(symbols_path, use_codebase_cache) {
             interner = cached_interner;
         }
     }
@@ -149,7 +147,6 @@ pub fn scan_files(
         get_filesystem(
             &mut files_to_scan,
             &mut interner,
-            &logger,
             scan_dirs,
             &existing_file_system,
             config,
@@ -161,12 +158,7 @@ pub fn scan_files(
 
     let file_discovery_elapsed = file_discovery_now.elapsed();
 
-    if logger.can_log_timing() {
-        logger.log_sync(&format!(
-            "File discovery took {:.2?}",
-            file_discovery_elapsed
-        ));
-    }
+    debug!("File discovery took {:.2?}", file_discovery_elapsed);
 
     let file_statuses =
         file_system.get_file_statuses(&files_to_scan, &interner, &existing_file_system);
@@ -180,9 +172,7 @@ pub fn scan_files(
     // this needs to come after we've loaded interned strings
     if !has_starter {
         if let Some(codebase_path) = &codebase_path {
-            if let Some(cache_codebase) =
-                load_cached_codebase(codebase_path, use_codebase_cache, &logger)
-            {
+            if let Some(cache_codebase) = load_cached_codebase(codebase_path, use_codebase_cache) {
                 codebase = cache_codebase;
             }
         }
@@ -190,7 +180,7 @@ pub fn scan_files(
 
     if let Some(aast_names_path) = &aast_names_path {
         if let Some(cached_resolved_names) =
-            load_cached_aast_names(aast_names_path, use_codebase_cache, &logger)
+            load_cached_aast_names(aast_names_path, use_codebase_cache)
         {
             resolved_names = cached_resolved_names
         };
@@ -198,12 +188,10 @@ pub fn scan_files(
 
     let load_from_cache_elapsed = load_from_cache_now.elapsed();
 
-    if logger.can_log_timing() {
-        logger.log_sync(&format!(
-            "Loading serialised codebase information from cache took {:.2?}",
-            load_from_cache_elapsed
-        ));
-    }
+    debug!(
+        "Loading serialised codebase information from cache took {:.2?}",
+        load_from_cache_elapsed
+    );
 
     invalidate_changed_codebase_elements(&mut codebase, &changed_files);
 
@@ -267,7 +255,7 @@ pub fn scan_files(
             total_counter.store(files_to_scan.len() as u32, Ordering::Relaxed);
         }
 
-        let bar = if logger.show_progress() {
+        let bar = if show_progress {
             let pb = ProgressBar::new(files_to_scan.len() as u64);
             let sty =
                 ProgressStyle::with_template("{bar:40.green/yellow} {pos:>7}/{len:7}").unwrap();
@@ -321,7 +309,6 @@ pub fn scan_files(
             let resolved_names = resolved_names.clone();
 
             let config = config.clone();
-            let logger = logger.clone();
             let invalid_files = invalid_files.clone();
 
             let handle = std::thread::spawn(move || {
@@ -347,7 +334,6 @@ pub fn scan_files(
                         empty_name_context.clone(),
                         analyze_map.contains(&str_path),
                         !config.test_files.iter().any(|p| p.matches(&str_path)),
-                        &logger.clone(),
                     ) {
                         Ok(scanner_result) => {
                             local_resolved_names.insert(*file_path, scanner_result);
@@ -399,12 +385,7 @@ pub fn scan_files(
 
         let file_scanning_elapsed = file_scanning_now.elapsed();
 
-        if logger.can_log_timing() {
-            logger.log_sync(&format!(
-                "Scanning files took {:.2?}",
-                file_scanning_elapsed
-            ));
-        }
+        debug!("Scanning files took {:.2?}", file_scanning_elapsed);
     }
 
     let interner = Arc::try_unwrap(interner).unwrap().into_inner().unwrap();
@@ -459,7 +440,6 @@ pub fn scan_files(
 pub fn get_filesystem(
     files_to_scan: &mut Vec<String>,
     interner: &mut Interner,
-    logger: &Logger,
     scan_dirs: &Vec<String>,
     existing_file_system: &Option<VirtualFileSystem>,
     config: &Arc<Config>,
@@ -473,10 +453,10 @@ pub fn get_filesystem(
         add_builtins_to_scan(files_to_scan, interner, &mut file_system);
     }
 
-    logger.log_sync("Looking for Hack files");
+    info!("Looking for Hack files");
 
     for scan_dir in scan_dirs {
-        logger.log_debug_sync(&format!(" - in {}", scan_dir));
+        debug!(" - in {}", scan_dir);
 
         files_to_scan.extend(file_system.find_files_in_dir(
             scan_dir,
@@ -524,9 +504,8 @@ pub(crate) fn scan_file(
     empty_name_context: NameContext<'_>,
     user_defined: bool,
     is_production_code: bool,
-    logger: &Logger,
 ) -> Result<FxHashMap<u32, StrId>, ParserError> {
-    logger.log_debug_sync(&format!("scanning {}", str_path));
+    debug!("scanning {}", str_path);
 
     let aast = get_aast_for_path(file_path, str_path);
 

--- a/src/orchestrator/wasm.rs
+++ b/src/orchestrator/wasm.rs
@@ -11,7 +11,6 @@ use hakana_code_info::data_flow::graph::{GraphKind, WholeProgramKind};
 use hakana_code_info::file_info::ParserError;
 use hakana_code_info::issue::{Issue, IssueKind};
 use hakana_code_info::symbol_references::SymbolReferences;
-use hakana_logger::Logger;
 use hakana_str::{Interner, StrId, ThreadedInterner};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::{Arc, Mutex};
@@ -77,7 +76,6 @@ pub fn scan_and_analyze_single_file(
         let issues = find_tainted_data(
             &analysis_result.program_dataflow_graph,
             &analysis_config,
-            &Logger::DevNull,
             &interner,
         );
 
@@ -104,8 +102,6 @@ pub fn get_single_file_codebase(
 
     let mut file_system = VirtualFileSystem::default();
 
-    let silent_logger = Logger::DevNull;
-
     // add HHVM libs
     for file in HhiAsset::iter() {
         let interned_file_path = FilePath(threaded_interner.intern(file.to_string()));
@@ -122,7 +118,6 @@ pub fn get_single_file_codebase(
             empty_name_context.clone(),
             false,
             false,
-            &silent_logger,
         )
         .unwrap();
     }
@@ -143,7 +138,6 @@ pub fn get_single_file_codebase(
             empty_name_context.clone(),
             false,
             false,
-            &silent_logger,
         )
         .unwrap();
     }
@@ -163,7 +157,6 @@ pub fn get_single_file_codebase(
             empty_name_context.clone(),
             false,
             false,
-            &silent_logger,
         )
         .unwrap();
     }

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -9,7 +9,7 @@ hakana-orchestrator = { path = "../orchestrator" }
 hakana-analyzer = { path = "../analyzer" }
 hakana-code-info = { path = "../code_info" }
 hakana-str = { path = "../str" }
-hakana-logger = { path = "../logger" }
+log = "0.4"
 rustc-hash = "1.1.0"
 watchman_client = "0.9"
 tokio = { version = "1.28", features = ["rt-multi-thread", "sync", "time"] }

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -2,16 +2,15 @@
 
 use crate::{ServerConfig, ServerState};
 use hakana_code_info::analysis_result::AnalysisResult;
-use hakana_logger::Logger;
 use hakana_orchestrator::SuccessfulScanData;
 use hakana_orchestrator::file::FileStatus;
+use hakana_protocol::GetIssuesResponse;
 use hakana_protocol::{
-    AckResponse,
-    FindReferencesRequest, FindReferencesResponse, FindSymbolReferencesRequest,
+    AckResponse, FindReferencesRequest, FindReferencesResponse, FindSymbolReferencesRequest,
     FindSymbolReferencesResponse, GotoDefinitionRequest, GotoDefinitionResponse, Message,
     ProtocolIssue, ReferenceLocation, StatusResponse,
 };
-use hakana_protocol::GetIssuesResponse;
+use log::info;
 use rustc_hash::FxHashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -21,7 +20,6 @@ use tokio::sync::mpsc::Sender;
 pub struct RequestHandler {
     config: Arc<ServerConfig>,
     state: Arc<Mutex<ServerState>>,
-    logger: Arc<Logger>,
     shutdown_tx: Sender<bool>,
     start_time: Instant,
 }
@@ -30,14 +28,12 @@ impl RequestHandler {
     pub fn new(
         config: Arc<ServerConfig>,
         state: Arc<Mutex<ServerState>>,
-        logger: Arc<Logger>,
         shutdown_tx: Sender<bool>,
         start_time: Instant,
     ) -> Self {
         Self {
             config,
             state,
-            logger,
             shutdown_tx,
             start_time,
         }
@@ -250,10 +246,9 @@ impl RequestHandler {
 
     /// Handle shutdown request.
     pub async fn handle_shutdown(&self) -> Message {
-        self.logger.log_sync("Shutdown requested");
+        info!("Shutdown requested");
         if let Err(e) = self.shutdown_tx.send(true).await {
-            let msg = format!("error requesting shutdown: {}", e);
-            self.logger.log_sync(msg.as_str());
+            info!("error requesting shutdown: {}", e);
         }
         Message::Ack(AckResponse)
     }
@@ -331,8 +326,7 @@ impl RequestHandler {
             }
         }
 
-        self.logger
-            .log_sync(&format!("Returning {} issues", issues.len()));
+        info!("Returning {} issues", issues.len());
 
         let state = self.state.lock().unwrap();
 
@@ -351,10 +345,10 @@ impl RequestHandler {
         use hakana_protocol::FileChangeStatus;
 
         let change_count = changes.len();
-        self.logger.log_sync(&format!(
+        info!(
             "Received {} file change notification(s) from client",
             change_count
-        ));
+        );
 
         let mut state = self.state.lock().unwrap();
 
@@ -367,10 +361,7 @@ impl RequestHandler {
             state.pending_changes.insert(change.path, status);
         }
 
-        self.logger.log_sync(&format!(
-            "Total pending changes: {}",
-            state.pending_changes.len()
-        ));
+        info!("Total pending changes: {}", state.pending_changes.len());
 
         Message::Ack(AckResponse)
     }

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -8,13 +8,13 @@ pub use state::ServerState;
 use hakana_analyzer::config::Config;
 use hakana_analyzer::custom_hook::CustomHook;
 use hakana_code_info::analysis_result::AnalysisResult;
-use hakana_logger::Logger;
 use hakana_orchestrator::file::FileStatus;
 use hakana_orchestrator::{AnalysisProgress, SuccessfulScanData};
 use hakana_protocol::{
     ClientConnection, ErrorCode, ErrorResponse, Message, ServerSocket, SocketPath,
 };
 use hakana_str::Interner;
+use log::info;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -53,7 +53,6 @@ pub struct Server {
     config: Arc<ServerConfig>,
     socket: ServerSocket,
     state: Arc<Mutex<ServerState>>,
-    logger: Arc<Logger>,
     start_time: Instant,
     watchman_handle: Option<watchman::WatchmanHandle>,
     config_changed: bool,
@@ -66,7 +65,7 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn new(config: ServerConfig, logger: Arc<Logger>) -> io::Result<Self> {
+    pub fn new(config: ServerConfig) -> io::Result<Self> {
         if let Err(e) = watchman::check_available() {
             return Err(io::Error::new(
                 io::ErrorKind::NotFound,
@@ -88,10 +87,10 @@ impl Server {
 
         let socket = ServerSocket::bind(socket_path)?;
 
-        logger.log_sync(&format!(
+        info!(
             "Server listening on: {}",
             socket.socket_path().path().display()
-        ));
+        );
 
         let (analysis_tx, analysis_rx) = tokio::sync::broadcast::channel(8);
         let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
@@ -100,7 +99,6 @@ impl Server {
             config: Arc::new(config),
             socket,
             state: Arc::new(Mutex::new(ServerState::new())),
-            logger,
             start_time: Instant::now(),
             watchman_handle: None,
             config_changed: false,
@@ -118,15 +116,14 @@ impl Server {
     pub async fn run(&mut self) -> io::Result<()> {
         let ignore_files = self.load_ignore_files();
 
-        self.logger.log_sync("Getting watchman clock...");
+        info!("Getting watchman clock...");
         let watchman_clock = watchman::get_clock(Path::new(&self.config.root_dir)).await?;
-        self.logger
-            .log_sync(&format!("Watchman clock: {:?}", watchman_clock));
+        info!("Watchman clock: {:?}", watchman_clock);
 
-        self.logger.log_sync(&format!(
+        info!(
             "Starting watchman subscription for: {}",
             self.config.root_dir
-        ));
+        );
         let config_path = self.config.config_path.as_ref().map(PathBuf::from);
         let handle = watchman::start_subscription(
             PathBuf::from(&self.config.root_dir),
@@ -140,7 +137,7 @@ impl Server {
     }
 
     async fn main_loop(&mut self) -> io::Result<()> {
-        self.logger.log_sync("Performing initial analysis...");
+        info!("Performing initial analysis...");
 
         {
             let mut state = self.state.lock().unwrap();
@@ -160,8 +157,7 @@ impl Server {
                         state.pending_changes.clear();
                         state.set_analysis_in_progress(true);
                         state.set_phase("Reloading config".to_string());
-                        self.logger
-                            .log_sync("Config file changed, performing full re-analysis...");
+                        info!("Config file changed, performing full re-analysis...");
                         state.analysis_data = None;
                         self.spawn_analysis(&mut state, None);
                     } else if !state.pending_changes.is_empty() {
@@ -169,8 +165,7 @@ impl Server {
                         let change_count = changes.len();
                         state.set_analysis_in_progress(true);
                         state.set_phase("Analyzing changes".to_string());
-                        self.logger
-                            .log_sync(&format!("Re-analyzing {} changed files...", change_count));
+                        info!("Re-analyzing {} changed files...", change_count);
                         self.spawn_analysis(&mut state, Some(changes));
                     }
                 }
@@ -183,7 +178,7 @@ impl Server {
                             self.handle_connection(conn);
                         }
                         Err(e) => {
-                            self.logger.log_sync(&format!("Accept error: {}", e));
+                            info!("Accept error: {}", e);
                         }
                     }
                 }
@@ -199,7 +194,7 @@ impl Server {
                     self.handle_analysis_result(result);
                 }
                 _ = self.shutdown_rx.recv() => {
-                    self.logger.log_sync("Server shutting down...");
+                    info!("Server shutting down...");
                     return Ok(());
                 }
             }
@@ -212,7 +207,6 @@ impl Server {
         changes: Option<FxHashMap<String, FileStatus>>,
     ) {
         let config = self.config.clone();
-        let logger = self.logger.clone();
         let previous_analysis_data = state.analysis_data.take();
 
         let files_scanned = state.files_scanned.clone();
@@ -226,7 +220,6 @@ impl Server {
         tokio::task::spawn_blocking(move || {
             let result = run_analysis(
                 &config,
-                &logger,
                 previous_analysis_data,
                 changes,
                 files_scanned,
@@ -255,15 +248,14 @@ impl Server {
                     .values()
                     .map(|v| v.len())
                     .sum();
-                self.logger
-                    .log_sync(&format!("Analysis complete: {} issues", issue_count));
+                info!("Analysis complete: {} issues", issue_count);
                 state.update_state(result.clone());
             }
             Ok(Err(e)) => {
-                self.logger.log_sync(&format!("Analysis failed: {}", e));
+                info!("Analysis failed: {}", e);
             }
             Err(_) => {
-                self.logger.log_sync("Analysis task was cancelled");
+                info!("Analysis task was cancelled");
             }
         }
         state.set_analysis_in_progress(false);
@@ -273,8 +265,7 @@ impl Server {
     fn handle_watchman_event(&mut self, event: watchman::WatchmanEvent) {
         match event {
             watchman::WatchmanEvent::ConfigChanged => {
-                self.logger
-                    .log_sync("Config file changed, scheduling full re-analysis");
+                info!("Config file changed, scheduling full re-analysis");
                 self.config_changed = true;
                 let mut state = self.state.lock().unwrap();
                 state.pending_changes.clear();
@@ -284,11 +275,11 @@ impl Server {
                     let mut state = self.state.lock().unwrap();
                     let change_count = changes.len();
                     state.pending_changes.extend(changes);
-                    self.logger.log_sync(&format!(
+                    info!(
                         "Received {} file change(s) from watchman ({} pending)",
                         change_count,
                         state.pending_changes.len()
-                    ));
+                    );
                 }
             }
         }
@@ -307,10 +298,10 @@ impl Server {
                         .map(|v| format!("{}/{}", self.config.root_dir, v))
                         .collect();
                     if !ignore_files.is_empty() {
-                        self.logger.log_sync(&format!(
+                        info!(
                             "Watchman will ignore {} path pattern(s)",
                             ignore_files.len()
-                        ));
+                        );
                     }
                     return ignore_files;
                 }
@@ -320,11 +311,9 @@ impl Server {
     }
 
     fn handle_connection(&self, mut conn: ClientConnection) {
-        let logger = self.logger.clone();
         let handler = RequestHandler::new(
             self.config.clone(),
             self.state.clone(),
-            self.logger.clone(),
             self.shutdown_tx.clone(),
             self.start_time,
         );
@@ -335,12 +324,12 @@ impl Server {
                 let msg = match conn.read_message().await {
                     Ok(msg) => msg,
                     Err(e) => {
-                        logger.log_sync(&format!("Read error: {}", e));
+                        info!("Read error: {}", e);
                         return;
                     }
                 };
 
-                logger.log_sync(&format!("Received: {:?}", msg.message_type()));
+                info!("Received: {:?}", msg.message_type());
 
                 let response = match msg {
                     Message::GetIssues(req) => {
@@ -360,14 +349,14 @@ impl Server {
                     }),
                 };
 
-                logger.log_sync(&format!("Sending response: {:?}", response.message_type()));
+                info!("Sending response: {:?}", response.message_type());
 
                 if let Err(e) = conn.write_message(&response).await {
-                    logger.log_sync(&format!("Write error: {}", e));
+                    info!("Write error: {}", e);
                     return;
                 }
 
-                logger.log_sync("Response sent successfully");
+                info!("Response sent successfully");
             }
         });
     }
@@ -375,7 +364,6 @@ impl Server {
 
 fn run_analysis(
     config: &ServerConfig,
-    logger: &Arc<Logger>,
     previous_analysis_data: Option<Arc<(AnalysisResult, SuccessfulScanData)>>,
     changes: Option<FxHashMap<String, FileStatus>>,
     files_scanned: Arc<AtomicU32>,
@@ -402,18 +390,18 @@ fn run_analysis(
     if let Some(config_path) = &config.config_path {
         let path = Path::new(config_path);
         if path.exists() {
-            logger.log_sync(&format!("Loading config from: {}", config_path));
+            info!("Loading config from: {}", config_path);
             let _ = analysis_config.update_from_file(&config.root_dir, path, &mut interner);
             if let Some(ref allowed) = analysis_config.allowed_issues {
-                logger.log_sync(&format!("Allowed issues: {} types", allowed.len()));
+                info!("Allowed issues: {} types", allowed.len());
             } else {
-                logger.log_sync("No allowed_issues filter (all issues enabled)");
+                info!("No allowed_issues filter (all issues enabled)");
             }
         } else {
-            logger.log_sync(&format!("Config file not found: {}", config_path));
+            info!("Config file not found: {}", config_path);
         }
     } else {
-        logger.log_sync("No config path specified");
+        info!("No config path specified");
     }
 
     let (previous_scan_data, previous_analysis_result) = previous_analysis_data
@@ -439,7 +427,7 @@ fn run_analysis(
         Arc::new(analysis_config),
         None,
         config.threads,
-        logger.clone(),
+        false,
         &config.header,
         Arc::new(interner),
         previous_scan_data,
@@ -457,7 +445,6 @@ fn run_analysis(
 
 #[cfg(test)]
 mod tests {
-    use hakana_logger::Logger;
     use hakana_protocol::{ClientSocket, GetIssuesRequest, Message};
     use std::{
         path::{Path, PathBuf},
@@ -511,11 +498,7 @@ mod tests {
             server_config.config_path.as_ref().map(&PathBuf::from),
         );
 
-        let mut server = Server::new(
-            server_config,
-            Arc::new(Logger::CommandLine(hakana_logger::Verbosity::Debugging)),
-        )
-        .expect("failed to create server");
+        let mut server = Server::new(server_config).expect("failed to create server");
 
         let socket_path = server.socket_path().clone();
         let shutdown_tx = server.shutdown_tx.clone();

--- a/src/server/watchman.rs
+++ b/src/server/watchman.rs
@@ -87,7 +87,7 @@ pub fn start_subscription(
     tokio::spawn(async move {
         if let Err(e) = run_subscription(root_dir, tx, ignore_files, since_clock, config_path).await
         {
-            eprintln!("Watchman subscription error: {}", e);
+            log::error!("Watchman subscription error: {}", e);
         }
     });
 
@@ -101,18 +101,18 @@ async fn run_subscription(
     since_clock: ClockSpec,
     config_path: Option<PathBuf>,
 ) -> Result<(), watchman_client::Error> {
-    eprintln!("Connecting to watchman...");
+    log::info!("Connecting to watchman...");
 
     let watchman = Connector::new().connect().await?;
 
-    eprintln!("Connected to watchman, resolving root...");
+    log::info!("Connected to watchman, resolving root...");
 
     let canonical_path =
         CanonicalPath::canonicalize(&root_dir).map_err(watchman_client::Error::ConnectionError)?;
 
     let resolved = watchman.resolve_root(canonical_path).await?;
 
-    eprintln!(
+    log::info!(
         "Watchman watching: {:?} (watcher: {})",
         resolved.path(),
         resolved.watcher()
@@ -129,7 +129,7 @@ async fn run_subscription(
     });
 
     if let Some(ref rel_path) = config_relative_path {
-        eprintln!("Watching config file: {:?}", rel_path);
+        log::info!("Watching config file: {:?}", rel_path);
     }
 
     let expression = build_expression(&ignore_files, &project_root, config_relative_path.as_ref());
@@ -146,7 +146,7 @@ async fn run_subscription(
         .subscribe::<NameOnly>(&resolved, subscribe_request)
         .await?;
 
-    eprintln!("Watchman subscription created: {}", subscription.name());
+    log::info!("Watchman subscription created: {}", subscription.name());
 
     loop {
         let event = subscription.next().await;
@@ -179,7 +179,7 @@ async fn handle_subscription_event(
 
                     if let Some(config_rel) = config_relative_path {
                         if Path::new(&file_name) == config_rel.as_path() {
-                            eprintln!("Config file changed: {:?}", file_name);
+                            log::info!("Config file changed: {:?}", file_name);
                             config_changed = true;
                             continue;
                         }
@@ -215,36 +215,36 @@ async fn handle_subscription_event(
                 // Config changed triggers full re-analysis, so send it first
                 if config_changed {
                     if tx.send(WatchmanEvent::ConfigChanged).await.is_err() {
-                        eprintln!("Server shut down, stopping watchman subscription");
+                        log::info!("Server shut down, stopping watchman subscription");
                         return false;
                     }
                 }
 
                 if !new_statuses.is_empty() {
-                    eprintln!("Watchman detected {} file change(s)", new_statuses.len());
+                    log::info!("Watchman detected {} file change(s)", new_statuses.len());
                     if tx
                         .send(WatchmanEvent::FileChanges(new_statuses))
                         .await
                         .is_err()
                     {
-                        eprintln!("Server shut down, stopping watchman subscription");
+                        log::info!("Server shut down, stopping watchman subscription");
                         return false;
                     }
                 }
             }
         }
         Ok(SubscriptionData::StateEnter { state_name, .. }) => {
-            eprintln!("Watchman state enter: {}", state_name);
+            log::info!("Watchman state enter: {}", state_name);
         }
         Ok(SubscriptionData::StateLeave { state_name, .. }) => {
-            eprintln!("Watchman state leave: {}", state_name);
+            log::info!("Watchman state leave: {}", state_name);
         }
         Ok(SubscriptionData::Canceled) => {
-            eprintln!("Watchman subscription canceled");
+            log::info!("Watchman subscription canceled");
             return false;
         }
         Err(e) => {
-            eprintln!("Watchman subscription error: {}", e);
+            log::error!("Watchman subscription error: {}", e);
             return false;
         }
     }


### PR DESCRIPTION
Hakana has thus far been using ad-hoc logging variously to stdout or stderr, either via the internal logger crate or literal `println` macros. This isn't great for server mode however as the logs are missing timestamps and severity information which would be expected in such a context. We may also be missing logs when the server is running but no LSP server is connected because the logs are emitted to stdout which is mapped to a file by the process that started the server.

So rework logging to use the `log` crate's facade consistently with `log4rs` as the implementation.
The format is as before except for server mode which now includes timestamps and severity as well.
The server is configured to rotate logs once they hit 128MiB in size and maintains at most two compressed previous copies.