### PR TITLE
Add more logging around watchman

### DIFF
--- a/src/language_server/server_client.rs
+++ b/src/language_server/server_client.rs
@@ -97,20 +97,14 @@ impl ServerConnection {
             project_root.display()
         );
 
-        let log_path = std::env::temp_dir().join("hakana-server.log");
-        let stdout = std::fs::File::create(&log_path)?;
-        let stderr = stdout.try_clone()?;
-
-        log::info!("Server log file: {}", log_path.display());
-
         let child = Command::new(&binary)
             .arg("server")
             .arg("--root")
             .arg(project_root)
             .current_dir(project_root)
             .stdin(Stdio::null())
-            .stdout(Stdio::from(stdout))
-            .stderr(Stdio::from(stderr))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()
             .map_err(|e| {
                 io::Error::new(

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -22,6 +22,8 @@ use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Instant;
 
+use crate::watchman::WatchmanHandle;
+
 #[derive(Clone)]
 pub struct ServerConfig {
     pub root_dir: String,
@@ -54,7 +56,6 @@ pub struct Server {
     socket: ServerSocket,
     state: Arc<Mutex<ServerState>>,
     start_time: Instant,
-    watchman_handle: Option<watchman::WatchmanHandle>,
     config_changed: bool,
     analysis_rx:
         tokio::sync::broadcast::Receiver<Result<Arc<(AnalysisResult, SuccessfulScanData)>, String>>,
@@ -100,7 +101,6 @@ impl Server {
             socket,
             state: Arc::new(Mutex::new(ServerState::new())),
             start_time: Instant::now(),
-            watchman_handle: None,
             config_changed: false,
             analysis_rx,
             analysis_tx,
@@ -131,12 +131,11 @@ impl Server {
             watchman_clock,
             config_path,
         );
-        self.watchman_handle = Some(handle);
 
-        self.main_loop().await
+        self.main_loop(handle).await
     }
 
-    async fn main_loop(&mut self) -> io::Result<()> {
+    async fn main_loop(&mut self, mut watchman: WatchmanHandle) -> io::Result<()> {
         info!("Performing initial analysis...");
 
         {
@@ -182,13 +181,12 @@ impl Server {
                         }
                     }
                 }
-                Some(event) = async {
-                    match self.watchman_handle.as_mut() {
-                        Some(handle) => handle.recv().await,
-                        None => std::future::pending().await,
+                watchman_event = watchman.recv() => {
+                    if let Some(event) = watchman_event {
+                        self.handle_watchman_event(event);
+                    } else {
+                        log::error!("watchman subscriber is not active");
                     }
-                } => {
-                    self.handle_watchman_event(event);
                 }
                 result = self.analysis_rx.recv() => {
                     self.handle_analysis_result(result);

--- a/src/server/watchman.rs
+++ b/src/server/watchman.rs
@@ -214,6 +214,7 @@ async fn handle_subscription_event(
 
                 // Config changed triggers full re-analysis, so send it first
                 if config_changed {
+                    log::info!("Watchman detected config file change, triggering full reanalysis");
                     if tx.send(WatchmanEvent::ConfigChanged).await.is_err() {
                         log::info!("Server shut down, stopping watchman subscription");
                         return false;
@@ -231,6 +232,8 @@ async fn handle_subscription_event(
                         return false;
                     }
                 }
+            } else {
+                log::info!("Received watchman file changes event without files");
             }
         }
         Ok(SubscriptionData::StateEnter { state_name, .. }) => {


### PR DESCRIPTION
Ensure we emit info logs for all file changes events we process, and simplify ownership of the watchman receiver on the server thread, complaining if the subscriber goes away.

Also remove the now-unnecessary stdio redirection for servers spawned by the LSP server.