### PR TITLE
Raise error when trying to autofix non-autofixable issues

### DIFF
--- a/src/cli/lib.rs
+++ b/src/cli/lib.rs
@@ -897,6 +897,11 @@ fn do_fix(
     let issue_name = sub_matches.value_of("issue").unwrap().to_string();
     let issue_kind = IssueKind::from_str_custom(&issue_name, &all_custom_issues).unwrap();
 
+    if !matches!(issue_kind, IssueKind::CustomIssue(..)) && !issue_kind.has_autofix() {
+        println!("Issue type {} does not support autofixing", issue_kind);
+        exit(1);
+    }
+
     let filter = sub_matches.value_of("filter").map(|f| f.to_string());
 
     let mut config = config::Config::new(root_dir.clone(), all_custom_issues);

--- a/src/cli/test_runners/utils.rs
+++ b/src/cli/test_runners/utils.rs
@@ -139,6 +139,7 @@ pub fn default_config_for_test(dir: &str, hooks_provider: &dyn HooksProvider) ->
     };
     analysis_config.find_unused_definitions = if let Ok(dir_issue) = &dir_issue {
         dir_issue.is_unused_definition()
+            || matches!(dir_issue, IssueKind::MissingIndirectServiceCallsAttribute)
     } else {
         dir.to_ascii_lowercase().contains("unused") && !dir.contains("UnusedExpression")
     };

--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -178,6 +178,32 @@ pub enum IssueKind {
     VariableDefinedOutsideIf,
 }
 
+static AUTOFIXABLE_ISSUES: [IssueKind; 23] = [
+    IssueKind::UnusedClass,
+    IssueKind::UnusedTypeDefinition,
+    IssueKind::UnusedFunction,
+    IssueKind::UnusedInterface,
+    IssueKind::UnusedPrivateProperty,
+    IssueKind::UnusedPrivateMethod,
+    IssueKind::UnusedInheritedMethod,
+    IssueKind::UnusedPublicOrProtectedProperty,
+    IssueKind::UnusedPublicOrProtectedMethod,
+    IssueKind::UnusedXhpAttribute,
+    IssueKind::UnusedTrait,
+    IssueKind::OnlyUsedInTests,
+    IssueKind::EmptyBlock,
+    IssueKind::UnnecessaryShapesIdx,
+    IssueKind::UnusedClosureParameter,
+    IssueKind::UnusedAssignment,
+    IssueKind::UnusedAssignmentStatement,
+    IssueKind::ImplicitStringCast,
+    IssueKind::NoJoinInAsyncFunction,
+    IssueKind::ImplicitAsioJoin,
+    IssueKind::ImpossibleNullTypeComparison,
+    IssueKind::NonBoolCondition,
+    IssueKind::MissingIndirectServiceCallsAttribute,
+];
+
 impl IssueKind {
     pub fn from_str_custom(
         str: &str,
@@ -259,6 +285,10 @@ impl IssueKind {
                 | Self::AwaitVariableDefinedOutsideIf
                 | Self::VariableDefinedOutsideIf
         )
+    }
+
+    pub fn has_autofix(&self) -> bool {
+        AUTOFIXABLE_ISSUES.contains(&self)
     }
 }
 
@@ -359,4 +389,48 @@ pub fn get_issue_from_comment(
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsStr, io, path::PathBuf, str::FromStr};
+
+    use crate::issue::{AUTOFIXABLE_ISSUES, IssueKind};
+
+    #[test]
+    fn autofixable_issues_list_should_reflect_reality() -> io::Result<()> {
+        let autofix_tests = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent() // src
+            .expect("Failed to get parent")
+            .parent() // hakana root
+            .expect("Failed to get source root")
+            .join("tests")
+            .join("fix");
+
+        for entry in std::fs::read_dir(&autofix_tests)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                let name = path
+                    .file_name()
+                    .and_then(&OsStr::to_str)
+                    .expect("failed to get file name");
+                let issue = IssueKind::from_str(name).expect("failed to get issue");
+                assert!(
+                    AUTOFIXABLE_ISSUES.contains(&issue),
+                    "Issue {} is not marked as autofixable",
+                    issue
+                );
+            }
+        }
+
+        for issue in &AUTOFIXABLE_ISSUES {
+            assert!(
+                autofix_tests.join(issue.to_string()).is_dir(),
+                "Issue {} is listed as autofixable but has no tests under tests/fix/ to back up this claim",
+                issue
+            )
+        }
+
+        Ok(())
+    }
 }

--- a/src/orchestrator/unused_symbols.rs
+++ b/src/orchestrator/unused_symbols.rs
@@ -218,19 +218,30 @@ pub(crate) fn find_unused_definitions(
             }
 
             if !referenced_symbols_and_members.contains(&(*classlike_name, StrId::EMPTY)) {
-                if !config.allow_issue_kind_in_file(&IssueKind::UnusedClass, file_path)
+                let issue_kind = match classlike_info.kind {
+                    SymbolKind::Interface => IssueKind::UnusedInterface,
+                    SymbolKind::Trait => IssueKind::UnusedTrait,
+                    _ => IssueKind::UnusedClass,
+                };
+
+                if !config.allow_issue_kind_in_file(&issue_kind, file_path)
                     || classlike_info
                         .suppressed_issues
                         .iter()
-                        .any(|(i, _)| i == &IssueKind::UnusedClass)
+                        .any(|(i, _)| i == &issue_kind)
                 {
                     continue;
                 }
 
                 let mut issue = Issue::new(
-                    IssueKind::UnusedClass,
+                    issue_kind,
                     format!(
-                        "Unused class, interface or enum {}",
+                        "Unused {} {}",
+                        match classlike_info.kind {
+                            SymbolKind::Interface => "interface",
+                            SymbolKind::Trait => "trait",
+                            _ => "class, interface or enum",
+                        },
                         interner.lookup(classlike_name),
                     ),
                     *pos,

--- a/tests/diff/removeTrait/output.txt
+++ b/tests/diff/removeTrait/output.txt
@@ -1,2 +1,2 @@
-ERROR: UnusedClass - input.hack:1:7 - Unused class, interface or enum T
+ERROR: UnusedTrait - input.hack:1:7 - Unused trait T
 ERROR: NonExistentMethod - input.hack:9:5 - Method C::foo does not exist

--- a/tests/fix/ImplicitStringCast/simple/input.hack
+++ b/tests/fix/ImplicitStringCast/simple/input.hack
@@ -1,0 +1,3 @@
+function foo(float $a): void {
+    echo 'hello '.$a;
+}

--- a/tests/fix/ImplicitStringCast/simple/output.txt
+++ b/tests/fix/ImplicitStringCast/simple/output.txt
@@ -1,0 +1,3 @@
+function foo(float $a): void {
+    echo 'hello '.((string)$a);
+}

--- a/tests/fix/MissingIndirectServiceCallsAttribute/simple/input.hack
+++ b/tests/fix/MissingIndirectServiceCallsAttribute/simple/input.hack
@@ -1,0 +1,8 @@
+<<\Hakana\CallsService('MyService')>>
+function calls_service(): void {
+    echo "calling service";
+}
+
+function caller(): void {
+    calls_service();
+}

--- a/tests/fix/MissingIndirectServiceCallsAttribute/simple/output.txt
+++ b/tests/fix/MissingIndirectServiceCallsAttribute/simple/output.txt
@@ -1,0 +1,9 @@
+<<\Hakana\CallsService('MyService')>>
+function calls_service(): void {
+    echo "calling service";
+}
+
+<<\Hakana\IndirectlyCallsService('MyService')>>
+function caller(): void {
+    calls_service();
+}

--- a/tests/fix/UnusedClosureParameter/simple/input.hack
+++ b/tests/fix/UnusedClosureParameter/simple/input.hack
@@ -1,0 +1,4 @@
+function foo(): void {
+    $fn = ($x) ==> 1;
+    echo $fn(42);
+}

--- a/tests/fix/UnusedClosureParameter/simple/output.txt
+++ b/tests/fix/UnusedClosureParameter/simple/output.txt
@@ -1,0 +1,4 @@
+function foo(): void {
+    $fn = ($_x) ==> 1;
+    echo $fn(42);
+}

--- a/tests/fix/UnusedInheritedMethod/simple/input.hack
+++ b/tests/fix/UnusedInheritedMethod/simple/input.hack
@@ -1,0 +1,13 @@
+abstract class Base {
+    public function overridden(): void {}
+}
+
+final class Child extends Base {
+    <<__Override>>
+    public function overridden(): void {}
+}
+
+<<__EntryPoint>>
+function main(): void {
+    new Child();
+}

--- a/tests/fix/UnusedInheritedMethod/simple/output.txt
+++ b/tests/fix/UnusedInheritedMethod/simple/output.txt
@@ -1,0 +1,11 @@
+abstract class Base {
+    public function overridden(): void {}
+}
+
+final class Child extends Base {
+}
+
+<<__EntryPoint>>
+function main(): void {
+    new Child();
+}

--- a/tests/fix/UnusedInterface/simple/input.hack
+++ b/tests/fix/UnusedInterface/simple/input.hack
@@ -1,0 +1,10 @@
+interface Unused {}
+
+interface Used {}
+
+final class Foo implements Used {}
+
+<<__EntryPoint>>
+function main(): void {
+    new Foo();
+}

--- a/tests/fix/UnusedInterface/simple/output.txt
+++ b/tests/fix/UnusedInterface/simple/output.txt
@@ -1,0 +1,10 @@
+
+
+interface Used {}
+
+final class Foo implements Used {}
+
+<<__EntryPoint>>
+function main(): void {
+    new Foo();
+}

--- a/tests/fix/UnusedPrivateProperty/simple/input.hack
+++ b/tests/fix/UnusedPrivateProperty/simple/input.hack
@@ -1,0 +1,14 @@
+final class Foo {
+    private int $unused = 0;
+    private int $used = 1;
+
+    public function bar(): int {
+        return $this->used;
+    }
+}
+
+<<__EntryPoint>>
+function main(): void {
+    $f = new Foo();
+    echo $f->bar();
+}

--- a/tests/fix/UnusedPrivateProperty/simple/output.txt
+++ b/tests/fix/UnusedPrivateProperty/simple/output.txt
@@ -1,0 +1,14 @@
+final class Foo {
+    private int ;
+    private int $used = 1;
+
+    public function bar(): int {
+        return $this->used;
+    }
+}
+
+<<__EntryPoint>>
+function main(): void {
+    $f = new Foo();
+    echo $f->bar();
+}

--- a/tests/fix/UnusedPublicOrProtectedMethod/simple/input.hack
+++ b/tests/fix/UnusedPublicOrProtectedMethod/simple/input.hack
@@ -1,0 +1,13 @@
+final class Foo {
+    public function unused(): void {}
+
+    public function used(): void {
+        echo "used";
+    }
+}
+
+<<__EntryPoint>>
+function main(): void {
+    $f = new Foo();
+    $f->used();
+}

--- a/tests/fix/UnusedPublicOrProtectedMethod/simple/output.txt
+++ b/tests/fix/UnusedPublicOrProtectedMethod/simple/output.txt
@@ -1,0 +1,12 @@
+final class Foo {
+
+    public function used(): void {
+        echo "used";
+    }
+}
+
+<<__EntryPoint>>
+function main(): void {
+    $f = new Foo();
+    $f->used();
+}

--- a/tests/fix/UnusedPublicOrProtectedProperty/simple/input.hack
+++ b/tests/fix/UnusedPublicOrProtectedProperty/simple/input.hack
@@ -1,0 +1,10 @@
+final class Foo {
+    public int $unused = 0;
+    public int $used = 1;
+}
+
+<<__EntryPoint>>
+function main(): void {
+    $f = new Foo();
+    echo $f->used;
+}

--- a/tests/fix/UnusedPublicOrProtectedProperty/simple/output.txt
+++ b/tests/fix/UnusedPublicOrProtectedProperty/simple/output.txt
@@ -1,0 +1,10 @@
+final class Foo {
+    public int ;
+    public int $used = 1;
+}
+
+<<__EntryPoint>>
+function main(): void {
+    $f = new Foo();
+    echo $f->used;
+}

--- a/tests/fix/UnusedTrait/simple/input.hack
+++ b/tests/fix/UnusedTrait/simple/input.hack
@@ -1,0 +1,19 @@
+trait UnusedTrait {
+    public function unused(): void {}
+}
+
+trait UsedTrait {
+    public function used(): void {
+        echo "used";
+    }
+}
+
+final class Foo {
+    use UsedTrait;
+}
+
+<<__EntryPoint>>
+function main(): void {
+    $f = new Foo();
+    $f->used();
+}

--- a/tests/fix/UnusedTrait/simple/output.txt
+++ b/tests/fix/UnusedTrait/simple/output.txt
@@ -1,0 +1,17 @@
+
+
+trait UsedTrait {
+    public function used(): void {
+        echo "used";
+    }
+}
+
+final class Foo {
+    use UsedTrait;
+}
+
+<<__EntryPoint>>
+function main(): void {
+    $f = new Foo();
+    $f->used();
+}

--- a/tests/fix/UnusedTypeDefinition/simple/input.hack
+++ b/tests/fix/UnusedTypeDefinition/simple/input.hack
@@ -1,0 +1,5 @@
+type MyAlias = int;
+
+function foo(): int {
+    return 1;
+}

--- a/tests/fix/UnusedTypeDefinition/simple/output.txt
+++ b/tests/fix/UnusedTypeDefinition/simple/output.txt
@@ -1,0 +1,5 @@
+
+
+function foo(): int {
+    return 1;
+}


### PR DESCRIPTION
Not all issue types have an autofix implemented, but `hakana fix` accepts all of them even if no autofix exists, which is confusing. Since autofix logic is interspersed with regular analysis, maintain a central list of autofixable issues and emit a helpful error message when running `hakana fix` with a non-autofixable issue type. Mandate that every autofixable issue type has corresponding integration tests so that the central list does not get stale.