### PR TITLE
Don't use starting clock for watchman subscription

### DIFF
--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -116,10 +116,6 @@ impl Server {
     pub async fn run(&mut self) -> io::Result<()> {
         let ignore_files = self.load_ignore_files();
 
-        info!("Getting watchman clock...");
-        let watchman_clock = watchman::get_clock(Path::new(&self.config.root_dir)).await?;
-        info!("Watchman clock: {:?}", watchman_clock);
-
         info!(
             "Starting watchman subscription for: {}",
             self.config.root_dir
@@ -128,9 +124,9 @@ impl Server {
         let handle = watchman::start_subscription(
             PathBuf::from(&self.config.root_dir),
             ignore_files,
-            watchman_clock,
             config_path,
-        );
+        )
+        .await;
 
         self.main_loop(handle).await
     }
@@ -262,8 +258,14 @@ impl Server {
 
     fn handle_watchman_event(&mut self, event: watchman::WatchmanEvent) {
         match event {
-            watchman::WatchmanEvent::ConfigChanged => {
-                info!("Config file changed, scheduling full re-analysis");
+            watchman::WatchmanEvent::ConfigChanged | watchman::WatchmanEvent::FreshInstance => {
+                if matches!(event, watchman::WatchmanEvent::ConfigChanged) {
+                    info!("Config file changed, scheduling full re-analysis");
+                } else {
+                    info!(
+                        "Scheduling full re-analysis due to non-incremental watchman notification"
+                    );
+                }
                 self.config_changed = true;
                 let mut state = self.state.lock().unwrap();
                 state.pending_changes.clear();
@@ -445,12 +447,15 @@ fn run_analysis(
 mod tests {
     use hakana_protocol::{ClientSocket, GetIssuesRequest, Message};
     use std::{
-        path::{Path, PathBuf},
+        path::PathBuf,
         sync::{Arc, atomic::AtomicBool},
     };
     use tokio::fs;
 
-    use crate::{Server, ServerConfig, watchman};
+    use crate::{
+        Server, ServerConfig,
+        watchman::{self, WatchmanEvent},
+    };
 
     #[tokio::test]
     async fn handles_file_changes_during_analysis() -> std::io::Result<()> {
@@ -488,13 +493,12 @@ mod tests {
             })),
         };
 
-        let watchman_clock = watchman::get_clock(Path::new(&server_config.root_dir)).await?;
         let mut watchman_handle = watchman::start_subscription(
             PathBuf::from(&server_config.root_dir),
             vec![],
-            watchman_clock,
             server_config.config_path.as_ref().map(&PathBuf::from),
-        );
+        )
+        .await;
 
         let mut server = Server::new(server_config).expect("failed to create server");
 
@@ -504,8 +508,12 @@ mod tests {
         let server_task =
             tokio::spawn(async move { server.run().await.expect("failed to run server") });
 
-        // Wait for Watchman to send a notification (which should also have notified the server)
-        watchman_handle.recv().await;
+        // Wait for Watchman to send an incremental notification (which should also have notified the server)
+        while let Some(event) = watchman_handle.recv().await {
+            if matches!(event, WatchmanEvent::FileChanges(..)) {
+                break;
+            }
+        }
 
         let mut client = ClientSocket::connect(&socket_path)
             .await

--- a/src/server/watchman.rs
+++ b/src/server/watchman.rs
@@ -5,10 +5,10 @@
 
 use hakana_orchestrator::file::FileStatus;
 use rustc_hash::FxHashMap;
-use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use watchman_client::SubscriptionData;
 use watchman_client::prelude::*;
 
@@ -16,6 +16,7 @@ use watchman_client::prelude::*;
 pub enum WatchmanEvent {
     FileChanges(FxHashMap<String, FileStatus>),
     ConfigChanged,
+    FreshInstance,
 }
 
 pub fn check_available() -> Result<(), String> {
@@ -31,41 +32,6 @@ pub fn check_available() -> Result<(), String> {
     }
 }
 
-/// Get the current watchman clock. Called BEFORE initial analysis
-/// so that any file changes during analysis are captured by the subscription.
-pub async fn get_clock(root_dir: &Path) -> io::Result<ClockSpec> {
-    let watchman = Connector::new().connect().await.map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::ConnectionRefused,
-            format!("Failed to connect to watchman: {}", e),
-        )
-    })?;
-
-    let canonical_path = CanonicalPath::canonicalize(root_dir).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::NotFound,
-            format!("Failed to canonicalize path: {}", e),
-        )
-    })?;
-
-    let resolved = watchman.resolve_root(canonical_path).await.map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            format!("Failed to resolve watchman root: {}", e),
-        )
-    })?;
-
-    watchman
-        .clock(&resolved, SyncTimeout::Default)
-        .await
-        .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Failed to get watchman clock: {}", e),
-            )
-        })
-}
-
 pub struct WatchmanHandle {
     rx: mpsc::Receiver<WatchmanEvent>,
 }
@@ -76,20 +42,24 @@ impl WatchmanHandle {
     }
 }
 
-pub fn start_subscription(
+pub async fn start_subscription(
     root_dir: PathBuf,
     ignore_files: Vec<String>,
-    since_clock: ClockSpec,
     config_path: Option<PathBuf>,
 ) -> WatchmanHandle {
     let (tx, rx) = mpsc::channel::<WatchmanEvent>(64);
+    let (startup_tx, startup_rx) = oneshot::channel();
 
     tokio::spawn(async move {
-        if let Err(e) = run_subscription(root_dir, tx, ignore_files, since_clock, config_path).await
+        if let Err(e) = run_subscription(root_dir, tx, startup_tx, ignore_files, config_path).await
         {
             log::error!("Watchman subscription error: {}", e);
         }
     });
+
+    startup_rx
+        .await
+        .expect("failed to start watchman subscription");
 
     WatchmanHandle { rx }
 }
@@ -97,8 +67,8 @@ pub fn start_subscription(
 async fn run_subscription(
     root_dir: PathBuf,
     tx: mpsc::Sender<WatchmanEvent>,
+    startup_tx: oneshot::Sender<bool>,
     ignore_files: Vec<String>,
-    since_clock: ClockSpec,
     config_path: Option<PathBuf>,
 ) -> Result<(), watchman_client::Error> {
     log::info!("Connecting to watchman...");
@@ -134,9 +104,8 @@ async fn run_subscription(
 
     let expression = build_expression(&ignore_files, &project_root, config_relative_path.as_ref());
 
-    // Use `since` to only get changes after the clock obtained before initial analysis
     let subscribe_request = SubscribeRequest {
-        since: Some(Clock::Spec(since_clock)),
+        since: None,
         expression: Some(expression),
         defer_vcs: true,
         ..Default::default()
@@ -147,6 +116,10 @@ async fn run_subscription(
         .await?;
 
     log::info!("Watchman subscription created: {}", subscription.name());
+
+    startup_tx
+        .send(true)
+        .expect("failed to send startup notification");
 
     loop {
         let event = subscription.next().await;
@@ -168,6 +141,19 @@ async fn handle_subscription_event(
 ) -> bool {
     match event {
         Ok(SubscriptionData::FilesChanged(result)) => {
+            // `is_fresh_instance` means the set of changed files in the response is the full set of files
+            // matching the subscription query, rather than an incremental changeset.
+            // Trigger a full reanalysis in this case.
+            if result.is_fresh_instance {
+                log::info!("non-incremental watchman notification, triggering full reanalysis");
+                if tx.send(WatchmanEvent::FreshInstance).await.is_err() {
+                    log::info!("Server shut down, stopping watchman subscription");
+                    return false;
+                }
+
+                return true;
+            }
+
             if let Some(files) = result.files {
                 let mut new_statuses = FxHashMap::default();
                 let mut config_changed = false;


### PR DESCRIPTION
We currently pass a starting clock to our watchman subscription to ensure we receive notifications for file changes that occurred between the start of the initial analysis and the subscription itself starting. Let's try to rule this out as a cause of our file watching issues by replacing it with a startup notification that ensures we start the watchman subscriber before the initial analysis.

Also ensure we handle non-incremental watchman notifications correctly by triggering a full reanalysis if we see one.