### PR TITLE
Detect tautological `$foo ?? null` null coalesces

### DIFF
--- a/src/analyzer/expr/binop/coalesce_analyzer.rs
+++ b/src/analyzer/expr/binop/coalesce_analyzer.rs
@@ -1,11 +1,14 @@
 use std::rc::Rc;
 
 use crate::scope::BlockContext;
+use crate::scope_analyzer::ScopeAnalyzer;
 use crate::statements_analyzer::StatementsAnalyzer;
 
 use crate::expression_analyzer;
 use crate::function_analysis_data::FunctionAnalysisData;
 use crate::stmt_analyzer::AnalysisError;
+use hakana_code_info::analysis_result::Replacement;
+use hakana_code_info::issue::{Issue, IssueKind};
 use hakana_code_info::t_union::TUnion;
 use hakana_code_info::ttype::{add_union_type, combine_union_types, get_mixed_any, get_null};
 use hakana_code_info::var_name::VarName;
@@ -24,12 +27,14 @@ pub(crate) fn analyze<'expr>(
     let mut root_expr = left;
     let mut root_not_left = false;
     let mut has_arrayget_key = false;
+    let mut has_array_access = false;
 
     loop {
         match &root_expr.2 {
             aast::Expr_::ArrayGet(boxed) => {
                 root_expr = &boxed.0;
                 root_not_left = true;
+                has_array_access = true;
 
                 if let Some(dim) = &boxed.1 {
                     if let aast::Expr_::ArrayGet(..)
@@ -53,6 +58,34 @@ pub(crate) fn analyze<'expr>(
             _ => {
                 break;
             }
+        }
+    }
+
+    // Check for tautological `$foo ?? null` checks where the LHS is always known to be defined.
+    // Do this only for the null literal rather than any nullable RHS since implementing the latter logic
+    // would have diminishing returns.
+    if !has_array_access && matches!(right.2, aast::Expr_::Null) {
+        let issue = Issue::new(
+            IssueKind::RedundantIssetCheck,
+            "Unnecessary isset check".to_string(),
+            statements_analyzer.get_hpos(pos),
+            &context.function_context.calling_functionlike_id,
+        );
+
+        if statements_analyzer.should_autofix(context, analysis_data, &issue) {
+            analysis_data.add_replacement(
+                (
+                    left.pos().end_offset() as u32,
+                    right.pos().end_offset() as u32,
+                ),
+                Replacement::Remove,
+            );
+        } else {
+            analysis_data.maybe_add_issue(
+                issue,
+                statements_analyzer.get_config(),
+                statements_analyzer.get_file_path_actual(),
+            );
         }
     }
 

--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -178,7 +178,7 @@ pub enum IssueKind {
     VariableDefinedOutsideIf,
 }
 
-static AUTOFIXABLE_ISSUES: [IssueKind; 23] = [
+static AUTOFIXABLE_ISSUES: [IssueKind; 24] = [
     IssueKind::UnusedClass,
     IssueKind::UnusedTypeDefinition,
     IssueKind::UnusedFunction,
@@ -202,6 +202,7 @@ static AUTOFIXABLE_ISSUES: [IssueKind; 23] = [
     IssueKind::ImpossibleNullTypeComparison,
     IssueKind::NonBoolCondition,
     IssueKind::MissingIndirectServiceCallsAttribute,
+    IssueKind::RedundantIssetCheck,
 ];
 
 impl IssueKind {

--- a/tests/fix/RedundantIssetCheck/nullCoalesceNullRHS/input.hack
+++ b/tests/fix/RedundantIssetCheck/nullCoalesceNullRHS/input.hack
@@ -1,0 +1,16 @@
+final class A {
+    public ?string $maybe;
+}
+
+function foo(?string $input, A $a, dict<string, string> $dict, string $foo): bool {
+    // both of these are redundant since the LHS is known
+    $b = $a->maybe ?? null;
+    $c = $input ?? null;
+
+    // not redundant as the key may be absent
+    $d = $dict['foo'] ?? null;
+
+    $e = $foo ?? 'bar';
+
+    return true;
+}

--- a/tests/fix/RedundantIssetCheck/nullCoalesceNullRHS/output.txt
+++ b/tests/fix/RedundantIssetCheck/nullCoalesceNullRHS/output.txt
@@ -1,0 +1,16 @@
+final class A {
+    public ?string $maybe;
+}
+
+function foo(?string $input, A $a, dict<string, string> $dict, string $foo): bool {
+    // both of these are redundant since the LHS is known
+    $b = $a->maybe;
+    $c = $input;
+
+    // not redundant as the key may be absent
+    $d = $dict['foo'] ?? null;
+
+    $e = $foo ?? 'bar';
+
+    return true;
+}

--- a/tests/inference/NullCoalesce/asNonnull/input.hack
+++ b/tests/inference/NullCoalesce/asNonnull/input.hack
@@ -1,4 +1,5 @@
 function foo(?string $a): string {
+    /* HAKANA_FIXME[RedundantIssetCheck] */
     $b = ($a ?? null) as nonnull;
     return $b;
 }

--- a/tests/inference/NullCoalesce/withNullRHS/input.hack
+++ b/tests/inference/NullCoalesce/withNullRHS/input.hack
@@ -1,0 +1,16 @@
+final class A {
+    public ?string $maybe;
+}
+
+function foo(?string $input, A $a, dict<string, string> $dict, string $foo): bool {
+    // both of these are redundant since the LHS is known
+    $b = $a->maybe ?? null;
+    $c = $input ?? null;
+
+    // not redundant as the key may be absent
+    $d = $dict['foo'] ?? null;
+
+    $e = $foo ?? 'bar';
+
+    return true;
+}

--- a/tests/inference/NullCoalesce/withNullRHS/output.txt
+++ b/tests/inference/NullCoalesce/withNullRHS/output.txt
@@ -1,0 +1,3 @@
+ERROR: RedundantIssetCheck - input.hack:7:10 - Unnecessary isset check
+ERROR: RedundantIssetCheck - input.hack:8:10 - Unnecessary isset check
+ERROR: RedundantIssetCheck - input.hack:13:10 - Unnecessary isset check

--- a/tests/inference/TypeReconciliation/Isset/nullCoalesceNonNullable/input.hack
+++ b/tests/inference/TypeReconciliation/Isset/nullCoalesceNonNullable/input.hack
@@ -1,6 +1,6 @@
 function foo(vec<string> $strs): vec<string> {
     /* HAKANA_FIXME[RedundantIssetCheck] */
     $a = $strs ?? null;
-    
+
     if ($a is nonnull) {}
 }

--- a/tests/inference/TypeReconciliation/RedundantCondition/checkAfterInoutAssignmentInNullCoalesce/input.hack
+++ b/tests/inference/TypeReconciliation/RedundantCondition/checkAfterInoutAssignmentInNullCoalesce/input.hack
@@ -1,5 +1,6 @@
 function foo(): void {
 	$err = null;
+	/* HAKANA_FIXME[RedundantIssetCheck] */
 	bar(inout $err) ?? null;
     if ($err is nonnull) {
 	    echo $err;


### PR DESCRIPTION
Add detection and corresponding autofix for tautological null coalesces where the LHS is always defined and the RHS is the literal `null`. Do this only for the `null` literal case rather than any RHS that has `null` type since implementing the latter logic would have diminishing returns.