### PR TITLE
Update to vergen v9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,4 @@ debug = true
 
 [build-dependencies]
 anyhow = { version = "1.0", default-features = false }
-vergen = "6"
+vergen-git2 = { version = "9.1.0", features = ["build"] }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
-use vergen::{Config, vergen};
+use vergen_git2::{BuildBuilder, Emitter, Git2Builder};
 
-fn main() -> Result<()> {
-    // Generate the default 'cargo:' instruction output
-    vergen(Config::default())
+pub fn main() -> Result<()> {
+    Emitter::default()
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&Git2Builder::all_git()?)?
+        .emit()
 }


### PR DESCRIPTION
The ancient `vergen` dependency finally stopped working. Update to vergen v9 instead.