### PR TITLE
Update workflows to use the lockfile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,7 @@ on:
         "tests/**",
         "third-party/**",
         "Cargo.toml",
+        "Cargo.lock",
         "build.rs",
         "init.sh",
         ".github/workflows/rust.yml",
@@ -55,7 +56,7 @@ jobs:
         run: ./init.sh
       - name: Build & Run tests
         run: |
-          cargo run --release --bin hakana test tests
+          cargo run --locked --release --bin hakana test tests
 
           # run Rust unit tests
-          cargo test --release --workspace
+          cargo test --locked --release --workspace


### PR DESCRIPTION
Trigger builds when Cargo.lock changes and run `cargo` subcommands with `--locked` to ensure they use pinned dependencies.