### PR TITLE
Fix clippy issues

### DIFF
--- a/src/aast_utils/name_context.rs
+++ b/src/aast_utils/name_context.rs
@@ -391,7 +391,7 @@ fn get_aliased_classes(interner: &mut ThreadedInterner) -> FxHashMap<StrId, StrI
         .into_iter()
         .map(|k| {
             (
-                interner.intern(k.split('\\').last().unwrap().to_string()),
+                interner.intern(k.split('\\').next_back().unwrap().to_string()),
                 interner.intern(k.to_string()),
             )
         })
@@ -452,7 +452,7 @@ fn get_aliased_functions(interner: &mut ThreadedInterner) -> FxHashMap<StrId, St
         .into_iter()
         .map(|k| {
             (
-                interner.intern(k.split('\\').last().unwrap().to_string()),
+                interner.intern(k.split('\\').next_back().unwrap().to_string()),
                 interner.intern(k.to_string()),
             )
         })

--- a/src/algebra/clause.rs
+++ b/src/algebra/clause.rs
@@ -16,7 +16,7 @@ pub enum ClauseKey {
 impl Display for ClauseKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ClauseKey::Name(var_name) => write!(f, "{}", var_name.to_string()),
+            ClauseKey::Name(var_name) => write!(f, "{}", var_name),
             ClauseKey::Range(start, end) => write!(f, "{}-{}", start, end),
         }
     }

--- a/src/algebra/lib.rs
+++ b/src/algebra/lib.rs
@@ -137,26 +137,25 @@ pub fn simplify_cnf(clauses: Vec<&Clause>) -> Vec<Clause> {
                 }
 
                 if let Some(matching_clause_possibilities) = clause_b.possibilities.get(clause_var)
+                    && matching_clause_possibilities.contains_key(&negated_hash)
                 {
-                    if matching_clause_possibilities.contains_key(&negated_hash) {
-                        let mut clause_var_possibilities = matching_clause_possibilities.clone();
+                    let mut clause_var_possibilities = matching_clause_possibilities.clone();
 
-                        clause_var_possibilities.retain(|k, _| k != &negated_hash);
+                    clause_var_possibilities.retain(|k, _| k != &negated_hash);
 
-                        removed_clauses.insert(*clause_b);
+                    removed_clauses.insert(*clause_b);
 
-                        if clause_var_possibilities.is_empty() {
-                            let maybe_updated_clause = clause_b.remove_possibilities(clause_var);
+                    if clause_var_possibilities.is_empty() {
+                        let maybe_updated_clause = clause_b.remove_possibilities(clause_var);
 
-                            if let Some(x) = maybe_updated_clause {
-                                added_clauses.push(x);
-                            }
-                        } else {
-                            let updated_clause = clause_b
-                                .add_possibility(clause_var.clone(), clause_var_possibilities);
-
-                            added_clauses.push(updated_clause);
+                        if let Some(x) = maybe_updated_clause {
+                            added_clauses.push(x);
                         }
+                    } else {
+                        let updated_clause =
+                            clause_b.add_possibility(clause_var.clone(), clause_var_possibilities);
+
+                        added_clauses.push(updated_clause);
                     }
                 }
             }
@@ -318,13 +317,13 @@ pub fn get_truths_from_formula(
                     .or_insert_with(Vec::new)
                     .push(vec![possible_type.clone()]);
 
-                if let Some(creating_conditional_id) = creating_conditional_id {
-                    if creating_conditional_id == clause.creating_conditional_id {
-                        active_truths
-                            .entry(var_name.clone())
-                            .or_insert_with(FxHashSet::default)
-                            .insert(truths.get(var_name).unwrap().len() - 1);
-                    }
+                if let Some(creating_conditional_id) = creating_conditional_id
+                    && creating_conditional_id == clause.creating_conditional_id
+                {
+                    active_truths
+                        .entry(var_name.clone())
+                        .or_insert_with(FxHashSet::default)
+                        .insert(truths.get(var_name).unwrap().len() - 1);
                 }
             } else {
                 if clause.generated {
@@ -341,13 +340,13 @@ pub fn get_truths_from_formula(
                     ],
                 );
 
-                if let Some(creating_conditional_id) = creating_conditional_id {
-                    if creating_conditional_id == clause.creating_conditional_id {
-                        active_truths
-                            .entry(var_name.clone())
-                            .or_insert_with(FxHashSet::default)
-                            .insert(truths.get(var_name).unwrap().len() - 1);
-                    }
+                if let Some(creating_conditional_id) = creating_conditional_id
+                    && creating_conditional_id == clause.creating_conditional_id
+                {
+                    active_truths
+                        .entry(var_name.clone())
+                        .or_insert_with(FxHashSet::default)
+                        .insert(truths.get(var_name).unwrap().len() - 1);
                 }
             }
         }

--- a/src/analyzer/classlike_analyzer.rs
+++ b/src/analyzer/classlike_analyzer.rs
@@ -134,7 +134,7 @@ impl<'a> ClassLikeAnalyzer<'a> {
         let mut analysis_data = FunctionAnalysisData::new(
             DataFlowGraph::new(statements_analyzer.get_config().graph_kind),
             &statements_analyzer.file_analyzer.file_source,
-            &statements_analyzer.comments,
+            statements_analyzer.comments,
             &statements_analyzer.get_config().all_custom_issues,
             None,
             None,
@@ -196,26 +196,24 @@ impl<'a> ClassLikeAnalyzer<'a> {
         // Check if interface has only one implementor
         if matches!(classlike_storage.kind, SymbolKind::Interface)
             && classlike_storage.is_production_code
+            && let Some(descendants) = codebase.direct_classlike_descendants.get(&name)
+            && descendants.len() == 1
         {
-            if let Some(descendants) = codebase.direct_classlike_descendants.get(&name) {
-                if descendants.len() == 1 {
-                    let implementor_name = descendants.iter().next().unwrap();
-                    analysis_data.maybe_add_issue(
-                        Issue::new(
-                            IssueKind::InterfaceSingleImplementor,
-                            format!(
-                                "Interface {} has only one implementing class {}",
-                                statements_analyzer.interner.lookup(&name),
-                                statements_analyzer.interner.lookup(implementor_name)
-                            ),
-                            classlike_storage.name_location,
-                            &Some(FunctionLikeIdentifier::Function(name)),
-                        ),
-                        statements_analyzer.get_config(),
-                        statements_analyzer.get_file_path_actual(),
-                    );
-                }
-            }
+            let implementor_name = descendants.iter().next().unwrap();
+            analysis_data.maybe_add_issue(
+                Issue::new(
+                    IssueKind::InterfaceSingleImplementor,
+                    format!(
+                        "Interface {} has only one implementing class {}",
+                        statements_analyzer.interner.lookup(&name),
+                        statements_analyzer.interner.lookup(implementor_name)
+                    ),
+                    classlike_storage.name_location,
+                    &Some(FunctionLikeIdentifier::Function(name)),
+                ),
+                statements_analyzer.get_config(),
+                statements_analyzer.get_file_path_actual(),
+            );
         }
 
         let mut existing_enum_str_values = FxHashMap::default();
@@ -233,42 +231,36 @@ impl<'a> ClassLikeAnalyzer<'a> {
                         true,
                     )?;
 
-                    if codebase.enum_exists(&name) {
-                        if let (Some(expr_value), Some(constant_name)) = (
+                    if codebase.enum_exists(&name)
+                        && let (Some(expr_value), Some(constant_name)) = (
                             analysis_data.get_expr_type(expr.pos()),
                             resolved_names.get(&(constant.id.0.start_offset() as u32)),
-                        ) {
-                            if let Some(string_value) = expr_value.get_single_literal_string_value()
+                        )
+                    {
+                        if let Some(string_value) = expr_value.get_single_literal_string_value() {
+                            if let Some(existing_name) = existing_enum_str_values.get(&string_value)
                             {
-                                if let Some(existing_name) =
-                                    existing_enum_str_values.get(&string_value)
-                                {
-                                    emit_dupe_enum_case_issue(
-                                        &mut analysis_data,
-                                        statements_analyzer,
-                                        name,
-                                        existing_name,
-                                        expr,
-                                    );
-                                } else {
-                                    existing_enum_str_values.insert(string_value, *constant_name);
-                                }
-                            } else if let Some(int_value) =
-                                expr_value.get_single_literal_int_value()
-                            {
-                                if let Some(existing_name) =
-                                    existing_enum_int_values.get(&int_value)
-                                {
-                                    emit_dupe_enum_case_issue(
-                                        &mut analysis_data,
-                                        statements_analyzer,
-                                        name,
-                                        existing_name,
-                                        expr,
-                                    );
-                                } else {
-                                    existing_enum_int_values.insert(int_value, *constant_name);
-                                }
+                                emit_dupe_enum_case_issue(
+                                    &mut analysis_data,
+                                    statements_analyzer,
+                                    name,
+                                    existing_name,
+                                    expr,
+                                );
+                            } else {
+                                existing_enum_str_values.insert(string_value, *constant_name);
+                            }
+                        } else if let Some(int_value) = expr_value.get_single_literal_int_value() {
+                            if let Some(existing_name) = existing_enum_int_values.get(&int_value) {
+                                emit_dupe_enum_case_issue(
+                                    &mut analysis_data,
+                                    statements_analyzer,
+                                    name,
+                                    existing_name,
+                                    expr,
+                                );
+                            } else {
+                                existing_enum_int_values.insert(int_value, *constant_name);
                             }
                         }
                     }
@@ -312,15 +304,15 @@ impl<'a> ClassLikeAnalyzer<'a> {
             // Constant types
             for (constant_name, constant_info) in &classlike_storage.constants {
                 // Only track constants defined in this class
-                if constant_info.defining_class == name {
-                    if let Some(provided_type) = &constant_info.provided_type {
-                        add_symbol_references_with_location(
-                            provided_type,
-                            Some(FunctionLikeIdentifier::Method(name, *constant_name)),
-                            &mut analysis_data,
-                            constant_info.type_pos,
-                        );
-                    }
+                if constant_info.defining_class == name
+                    && let Some(provided_type) = &constant_info.provided_type
+                {
+                    add_symbol_references_with_location(
+                        provided_type,
+                        Some(FunctionLikeIdentifier::Method(name, *constant_name)),
+                        &mut analysis_data,
+                        constant_info.type_pos,
+                    );
                 }
             }
         }

--- a/src/analyzer/config/mod.rs
+++ b/src/analyzer/config/mod.rs
@@ -189,10 +189,10 @@ impl Config {
     }
 
     pub fn can_add_issue(&self, issue: &Issue) -> bool {
-        if let Some(issue_filter) = &self.allowed_issues {
-            if !issue_filter.contains(&issue.kind) {
-                return false;
-            }
+        if let Some(issue_filter) = &self.allowed_issues
+            && !issue_filter.contains(&issue.kind)
+        {
+            return false;
         }
 
         true

--- a/src/analyzer/dataflow/program_analyzer.rs
+++ b/src/analyzer/dataflow/program_analyzer.rs
@@ -232,20 +232,20 @@ fn get_child_nodes(
     if let Some(forward_edges) = graph.forward_edges.get(&generated_source.id) {
         if !match_sinks {
             for t in source_taints {
-                if let SinkType::Custom(target_id) = t {
-                    if &generated_source.id.to_string(interner) == target_id {
-                        let message = format!(
-                            "Data found its way to {} using path {}",
-                            target_id,
-                            generated_source.get_trace(interner, &config.root_dir)
-                        );
-                        new_issues.push(Issue::new(
-                            IssueKind::TaintedData(Box::new(t.clone())),
-                            message,
-                            **generated_source.pos.as_ref().unwrap(),
-                            &None,
-                        ));
-                    }
+                if let SinkType::Custom(target_id) = t
+                    && &generated_source.id.to_string(interner) == target_id
+                {
+                    let message = format!(
+                        "Data found its way to {} using path {}",
+                        target_id,
+                        generated_source.get_trace(interner, &config.root_dir)
+                    );
+                    new_issues.push(Issue::new(
+                        IssueKind::TaintedData(Box::new(t.clone())),
+                        message,
+                        **generated_source.pos.as_ref().unwrap(),
+                        &None,
+                    ));
                 }
             }
         }
@@ -276,16 +276,16 @@ fn get_child_nodes(
 
             // if we're going through a scalar type guard and the last non-default path was
             // an array or property assignment, skip
-            if let PathKind::ScalarTypeGuard = &path.kind {
-                if has_recent_assignment(&generated_source.path_types) {
-                    continue;
-                }
+            if let PathKind::ScalarTypeGuard = &path.kind
+                && has_recent_assignment(&generated_source.path_types)
+            {
+                continue;
             }
 
-            if let PathKind::RefineSymbol(symbol_id) = &path.kind {
-                if has_unmatched_property_assignment(symbol_id, &generated_source.path_types) {
-                    continue;
-                }
+            if let PathKind::RefineSymbol(symbol_id) = &path.kind
+                && has_unmatched_property_assignment(symbol_id, &generated_source.path_types)
+            {
+                continue;
             }
 
             if should_ignore_array_fetch(
@@ -310,20 +310,20 @@ fn get_child_nodes(
 
             if !match_sinks {
                 for t in source_taints {
-                    if let SinkType::Custom(target_id) = t {
-                        if &to_id.to_string(interner) == target_id {
-                            let message = format!(
-                                "Data found its way to {} using path {}",
-                                target_id,
-                                generated_source.get_trace(interner, &config.root_dir)
-                            );
-                            new_issues.push(Issue::new(
-                                IssueKind::TaintedData(Box::new(t.clone())),
-                                message,
-                                **generated_source.pos.as_ref().unwrap(),
-                                &None,
-                            ));
-                        }
+                    if let SinkType::Custom(target_id) = t
+                        && &to_id.to_string(interner) == target_id
+                    {
+                        let message = format!(
+                            "Data found its way to {} using path {}",
+                            target_id,
+                            generated_source.get_trace(interner, &config.root_dir)
+                        );
+                        new_issues.push(Issue::new(
+                            IssueKind::TaintedData(Box::new(t.clone())),
+                            message,
+                            **generated_source.pos.as_ref().unwrap(),
+                            &None,
+                        ));
                     }
                 }
             }
@@ -365,46 +365,44 @@ fn get_child_nodes(
 
             new_destination.path_types = new_path_types;
 
-            if match_sinks {
-                if let Some(sink) = graph.sinks.get(to_id) {
-                    if let DataFlowNodeKind::TaintSink {
-                        types,
-                        pos: sink_pos,
-                        ..
-                    } = &sink.kind
-                    {
-                        let mut matching_sinks = types.clone();
-                        matching_sinks.retain(|t| new_taints.contains(t));
+            if match_sinks
+                && let Some(sink) = graph.sinks.get(to_id)
+                && let DataFlowNodeKind::TaintSink {
+                    types,
+                    pos: sink_pos,
+                    ..
+                } = &sink.kind
+            {
+                let mut matching_sinks = types.clone();
+                matching_sinks.retain(|t| new_taints.contains(t));
 
-                        if !matching_sinks.is_empty() {
-                            let taint_sources = generated_source.get_taint_sources();
-                            for taint_source in taint_sources {
-                                for matching_sink in &matching_sinks {
-                                    if !config.allow_data_from_source_in_file(
-                                        taint_source,
-                                        matching_sink,
-                                        &new_destination,
-                                        interner,
-                                    ) {
-                                        continue;
-                                    }
-
-                                    new_destination.taint_sinks.retain(|s| s != matching_sink);
-
-                                    let message = format!(
-                                        "Data from {} found its way to {} using path {}",
-                                        taint_source.get_error_message(),
-                                        matching_sink.get_error_message(),
-                                        new_destination.get_trace(interner, &config.root_dir)
-                                    );
-                                    new_issues.push(Issue::new(
-                                        IssueKind::TaintedData(Box::new(matching_sink.clone())),
-                                        message,
-                                        *sink_pos,
-                                        &None,
-                                    ));
-                                }
+                if !matching_sinks.is_empty() {
+                    let taint_sources = generated_source.get_taint_sources();
+                    for taint_source in taint_sources {
+                        for matching_sink in &matching_sinks {
+                            if !config.allow_data_from_source_in_file(
+                                taint_source,
+                                matching_sink,
+                                &new_destination,
+                                interner,
+                            ) {
+                                continue;
                             }
+
+                            new_destination.taint_sinks.retain(|s| s != matching_sink);
+
+                            let message = format!(
+                                "Data from {} found its way to {} using path {}",
+                                taint_source.get_error_message(),
+                                matching_sink.get_error_message(),
+                                new_destination.get_trace(interner, &config.root_dir)
+                            );
+                            new_issues.push(Issue::new(
+                                IssueKind::TaintedData(Box::new(matching_sink.clone())),
+                                message,
+                                *sink_pos,
+                                &None,
+                            ));
                         }
                     }
                 }
@@ -548,10 +546,10 @@ pub(crate) fn should_ignore_array_fetch(
                             continue;
                         }
 
-                        if let PathKind::ArrayFetch(_, fetch_value) = &path_type {
-                            if fetch_value == previous_assignment_value {
-                                return false;
-                            }
+                        if let PathKind::ArrayFetch(_, fetch_value) = &path_type
+                            && fetch_value == previous_assignment_value
+                        {
+                            return false;
                         }
 
                         return true;
@@ -567,19 +565,15 @@ pub(crate) fn should_ignore_array_fetch(
         }
     }
 
-    if let PathKind::RemoveDictKey(key_name) = path_type {
-        if match_type == &ArrayDataKind::ArrayValue {
-            if let Some(PathKind::ArrayAssignment(ArrayDataKind::ArrayValue, assigned_name)) =
-                previous_path_types
-                    .iter()
-                    .filter(|t| !matches!(t, PathKind::Default))
-                    .last()
-            {
-                if assigned_name == key_name {
-                    return true;
-                }
-            }
-        }
+    if let PathKind::RemoveDictKey(key_name) = path_type
+        && match_type == &ArrayDataKind::ArrayValue
+        && let Some(PathKind::ArrayAssignment(ArrayDataKind::ArrayValue, assigned_name)) =
+            previous_path_types
+                .iter()
+                .rfind(|t| !matches!(t, PathKind::Default))
+        && assigned_name == key_name
+    {
+        return true;
     }
 
     false
@@ -609,10 +603,10 @@ pub(crate) fn should_ignore_property_fetch(
                         continue;
                     }
 
-                    if let PathKind::PropertyFetch(_, fetch_value) = &path_type {
-                        if fetch_value == previous_assignment_value {
-                            return false;
-                        }
+                    if let PathKind::PropertyFetch(_, fetch_value) = &path_type
+                        && fetch_value == previous_assignment_value
+                    {
+                        return false;
                     }
 
                     return true;

--- a/src/analyzer/dataflow/unused_variable_analyzer.rs
+++ b/src/analyzer/dataflow/unused_variable_analyzer.rs
@@ -132,7 +132,6 @@ pub fn check_variables_redefined_in_loop(
     let multi_assignment_vars: FxHashMap<&String, &FxHashSet<(u32, u32)>> = variable_assignments
         .iter()
         .filter(|(_, offsets)| offsets.len() > 1)
-        .map(|(name, offsets)| (name, offsets))
         .collect();
 
     if multi_assignment_vars.is_empty() {
@@ -155,7 +154,7 @@ pub fn check_variables_redefined_in_loop(
 
     // Build a reverse index: offset -> source node for quick lookup
     let mut offset_to_source: FxHashMap<u32, &DataFlowNode> = FxHashMap::default();
-    for (_, source_node) in &graph.sources {
+    for source_node in graph.sources.values() {
         if let (DataFlowNodeKind::VariableUseSource { pos, .. }, DataFlowNodeId::Var(..)) =
             (&source_node.kind, &source_node.id)
         {
@@ -396,19 +395,16 @@ pub fn check_variables_scoped_incorrectly(
     (incorrectly_scoped, async_incorrectly_scoped)
 }
 
-fn get_sources_grouped_by_usage<'a>(
-    graph: &'a DataFlowGraph,
+fn get_sources_grouped_by_usage(
+    graph: &DataFlowGraph,
     function_pos: HPos,
-) -> Vec<(
-    Vec<&'a DataFlowNode>,
-    FxHashMap<&'a DataFlowNode, Vec<HPos>>,
-)> {
+) -> Vec<(Vec<&DataFlowNode>, FxHashMap<&DataFlowNode, Vec<HPos>>)> {
     let mut sink_to_sources: FxHashMap<DataFlowNodeId, Vec<&DataFlowNode>> = FxHashMap::default();
     let mut source_to_sinks = FxHashMap::default();
 
     // First, collect all relevant sources
     let mut relevant_sources = Vec::new();
-    for (_, source_node) in &graph.sources {
+    for source_node in graph.sources.values() {
         if let DataFlowNodeKind::VariableUseSource { kind, pure, .. } = &source_node.kind {
             // Skip function parameters - they're not "defined outside if blocks" in the problematic sense
             if matches!(
@@ -603,15 +599,15 @@ fn get_all_variable_uses(
         visited_nodes.insert(node_id.clone());
 
         // Check if this node is a sink
-        if let Some(sink_node) = graph.sinks.get(&node_id) {
-            if let DataFlowNodeKind::VariableUseSink { .. } = &sink_node.kind {
-                sink_nodes.push(sink_node.id.clone());
-            }
+        if let Some(sink_node) = graph.sinks.get(&node_id)
+            && let DataFlowNodeKind::VariableUseSink { .. } = &sink_node.kind
+        {
+            sink_nodes.push(sink_node.id.clone());
         }
 
         // Add connected nodes to visit
         if let Some(edges) = graph.forward_edges.get(&node_id) {
-            for (to_id, _) in edges {
+            for to_id in edges.keys() {
                 if !visited_nodes.contains(to_id) {
                     to_visit.push(to_id.clone());
                 }
@@ -790,64 +786,59 @@ impl<'ast> Visitor<'ast> for Scanner<'_> {
             _ => false,
         });
 
-        if has_matching_node {
-            if let aast::Stmt_::Expr(boxed) = &stmt.1 {
-                if let aast::Expr_::Assign(boxed) = &boxed.2 {
-                    let expression_effects = analysis_data
+        if has_matching_node
+            && let aast::Stmt_::Expr(boxed) = &stmt.1
+            && let aast::Expr_::Assign(boxed) = &boxed.2
+        {
+            let expression_effects = analysis_data
+                .expr_effects
+                .get(&(
+                    boxed.2.1.start_offset() as u32,
+                    boxed.2.1.end_offset() as u32,
+                ))
+                .unwrap_or(&0);
+
+            if let EFFECT_PURE | EFFECT_READ_GLOBALS | EFFECT_READ_PROPS = *expression_effects {
+                if !self.in_single_block {
+                    let span = stmt.0.to_raw_span();
+                    analysis_data.add_replacement(
+                        (stmt.0.start_offset() as u32, stmt.0.end_offset() as u32),
+                        Replacement::TrimPrecedingWhitespace(span.start.beg_of_line() as u32),
+                    );
+
+                    self.remove_fixme_comments(stmt, analysis_data, stmt.0.start_offset());
+                }
+            } else {
+                analysis_data.add_replacement(
+                    (
+                        stmt.0.start_offset() as u32,
+                        boxed.2.1.start_offset() as u32,
+                    ),
+                    Replacement::Remove,
+                );
+
+                // remove trailing array fetches
+                if let aast::Expr_::ArrayGet(array_get) = &boxed.2.2
+                    && let Some(array_offset_expr) = &array_get.1
+                {
+                    let array_offset_effects = analysis_data
                         .expr_effects
                         .get(&(
-                            boxed.2.1.start_offset() as u32,
-                            boxed.2.1.end_offset() as u32,
+                            array_offset_expr.1.start_offset() as u32,
+                            array_offset_expr.1.end_offset() as u32,
                         ))
                         .unwrap_or(&0);
 
                     if let EFFECT_PURE | EFFECT_READ_GLOBALS | EFFECT_READ_PROPS =
-                        *expression_effects
+                        *array_offset_effects
                     {
-                        if !self.in_single_block {
-                            let span = stmt.0.to_raw_span();
-                            analysis_data.add_replacement(
-                                (stmt.0.start_offset() as u32, stmt.0.end_offset() as u32),
-                                Replacement::TrimPrecedingWhitespace(
-                                    span.start.beg_of_line() as u32
-                                ),
-                            );
-
-                            self.remove_fixme_comments(stmt, analysis_data, stmt.0.start_offset());
-                        }
-                    } else {
                         analysis_data.add_replacement(
                             (
-                                stmt.0.start_offset() as u32,
-                                boxed.2.1.start_offset() as u32,
+                                array_offset_expr.pos().start_offset() as u32 - 1,
+                                array_offset_expr.pos().end_offset() as u32 + 1,
                             ),
                             Replacement::Remove,
                         );
-
-                        // remove trailing array fetches
-                        if let aast::Expr_::ArrayGet(array_get) = &boxed.2.2 {
-                            if let Some(array_offset_expr) = &array_get.1 {
-                                let array_offset_effects = analysis_data
-                                    .expr_effects
-                                    .get(&(
-                                        array_offset_expr.1.start_offset() as u32,
-                                        array_offset_expr.1.end_offset() as u32,
-                                    ))
-                                    .unwrap_or(&0);
-
-                                if let EFFECT_PURE | EFFECT_READ_GLOBALS | EFFECT_READ_PROPS =
-                                    *array_offset_effects
-                                {
-                                    analysis_data.add_replacement(
-                                        (
-                                            array_offset_expr.pos().start_offset() as u32 - 1,
-                                            array_offset_expr.pos().end_offset() as u32 + 1,
-                                        ),
-                                        Replacement::Remove,
-                                    );
-                                }
-                            }
-                        }
                     }
                 }
             }
@@ -866,36 +857,34 @@ impl<'a> Scanner<'a> {
     ) {
         for (comment_pos, comment) in self.comments {
             if comment_pos.line() == stmt.0.line() {
-                if let Comment::CmtBlock(block) = comment {
-                    if block.trim() == "HHAST_FIXME[UnusedVariable]" {
-                        analysis_data.add_replacement(
-                            (comment_pos.start_offset() as u32, limit as u32),
-                            Replacement::TrimPrecedingWhitespace(
-                                comment_pos.to_raw_span().start.beg_of_line() as u32,
-                            ),
-                        );
+                if let Comment::CmtBlock(block) = comment
+                    && block.trim() == "HHAST_FIXME[UnusedVariable]"
+                {
+                    analysis_data.add_replacement(
+                        (comment_pos.start_offset() as u32, limit as u32),
+                        Replacement::TrimPrecedingWhitespace(
+                            comment_pos.to_raw_span().start.beg_of_line() as u32,
+                        ),
+                    );
 
-                        return;
-                    }
+                    return;
                 }
-            } else if comment_pos.line() == stmt.0.line() - 1 {
-                if let Comment::CmtBlock(block) = comment {
-                    if let "HAKANA_FIXME[UnusedAssignment]"
-                    | "HAKANA_FIXME[UnusedAssignmentStatement]" = block.trim()
-                    {
-                        let stmt_start = stmt.0.to_raw_span().start;
-                        analysis_data.add_replacement(
-                            (
-                                comment_pos.start_offset() as u32,
-                                (stmt_start.beg_of_line() as u32) - 1,
-                            ),
-                            Replacement::TrimPrecedingWhitespace(
-                                comment_pos.to_raw_span().start.beg_of_line() as u32,
-                            ),
-                        );
-                        return;
-                    }
-                }
+            } else if comment_pos.line() == stmt.0.line() - 1
+                && let Comment::CmtBlock(block) = comment
+                && let "HAKANA_FIXME[UnusedAssignment]" | "HAKANA_FIXME[UnusedAssignmentStatement]" =
+                    block.trim()
+            {
+                let stmt_start = stmt.0.to_raw_span().start;
+                analysis_data.add_replacement(
+                    (
+                        comment_pos.start_offset() as u32,
+                        (stmt_start.beg_of_line() as u32) - 1,
+                    ),
+                    Replacement::TrimPrecedingWhitespace(
+                        comment_pos.to_raw_span().start.beg_of_line() as u32,
+                    ),
+                );
+                return;
             }
         }
     }

--- a/src/analyzer/expr/as_analyzer.rs
+++ b/src/analyzer/expr/as_analyzer.rs
@@ -41,8 +41,8 @@ pub(crate) fn analyze<'expr>(
         match root_expr.2 {
             aast::Expr_::ArrayGet(boxed) => {
                 root_expr = boxed.0;
-                if let Some(dim) = &boxed.1 {
-                    if let aast::Expr_::ArrayGet(..)
+                if let Some(dim) = &boxed.1
+                    && let aast::Expr_::ArrayGet(..)
                     | aast::Expr_::ClassConst(..)
                     | aast::Expr_::Call(..)
                     | aast::Expr_::Cast(..)
@@ -52,9 +52,8 @@ pub(crate) fn analyze<'expr>(
                     | aast::Expr_::Pipe(..)
                     | aast::Expr_::Await(..)
                     | aast::Expr_::Delay(..) = dim.2
-                    {
-                        has_arrayget_key = true;
-                    }
+                {
+                    has_arrayget_key = true;
                 }
             }
             aast::Expr_::ObjGet(boxed) => {
@@ -83,10 +82,10 @@ pub(crate) fn analyze<'expr>(
         )
     {
         replacement_left = get_fake_as_var(left, statements_analyzer, analysis_data, context);
-    } else if let aast::Expr_::Lvar(var) = root_expr.2 {
-        if var.1.1 == "$$" {
-            replacement_left = get_fake_as_var(left, statements_analyzer, analysis_data, context);
-        }
+    } else if let aast::Expr_::Lvar(var) = root_expr.2
+        && var.1.1 == "$$"
+    {
+        replacement_left = get_fake_as_var(left, statements_analyzer, analysis_data, context);
     }
 
     let ternary = aast::Expr(
@@ -220,12 +219,12 @@ fn get_fake_as_var(
         .locals
         .insert(VarName::new(left_var_id.clone()), condition_type);
 
-    return Some(aast::Expr(
+    Some(aast::Expr(
         (),
         left.pos().clone(),
         aast::Expr_::Lvar(Box::new(oxidized::ast::Lid(
             left.pos().clone(),
             (5, left_var_id.clone()),
         ))),
-    ));
+    ))
 }

--- a/src/analyzer/expr/assertion_finder.rs
+++ b/src/analyzer/expr/assertion_finder.rs
@@ -364,40 +364,40 @@ fn scrape_shapes_isset(
             None
         };
 
-        if let Some(FunctionLikeIdentifier::Method(class_name, member_name)) = functionlike_id {
-            if let Some((codebase, interner)) = assertion_context.codebase {
-                if class_name == StrId::SHAPES && member_name == StrId::IDX {
-                    let shape_name = get_var_id(
-                        &call.args[0].to_expr_ref(),
-                        assertion_context.this_class_name,
-                        assertion_context.resolved_names,
-                        assertion_context.codebase,
-                    );
+        if let Some(FunctionLikeIdentifier::Method(class_name, member_name)) = functionlike_id
+            && let Some((codebase, interner)) = assertion_context.codebase
+            && class_name == StrId::SHAPES
+            && member_name == StrId::IDX
+        {
+            let shape_name = get_var_id(
+                call.args[0].to_expr_ref(),
+                assertion_context.this_class_name,
+                assertion_context.resolved_names,
+                assertion_context.codebase,
+            );
 
-                    let dim_id = get_dim_id(
-                        &call.args[1].to_expr_ref(),
-                        Some((codebase, interner)),
-                        assertion_context.resolved_names,
-                    );
+            let dim_id = get_dim_id(
+                call.args[1].to_expr_ref(),
+                Some((codebase, interner)),
+                assertion_context.resolved_names,
+            );
 
-                    if let (Some(shape_name), Some(dim_id)) = (shape_name, dim_id) {
-                        let dict_key = if dim_id.starts_with('\'') {
-                            DictKey::String(dim_id[1..(dim_id.len() - 1)].to_string())
-                        } else if let Ok(arraykey_value) = dim_id.parse::<u64>() {
-                            DictKey::Int(arraykey_value)
-                        } else {
-                            panic!("bad int key {}", dim_id);
-                        };
-                        if_types.insert(
-                            shape_name,
-                            vec![vec![if negated {
-                                Assertion::DoesNotHaveNonnullEntryForKey(dict_key)
-                            } else {
-                                Assertion::HasNonnullEntryForKey(dict_key)
-                            }]],
-                        );
-                    }
-                }
+            if let (Some(shape_name), Some(dim_id)) = (shape_name, dim_id) {
+                let dict_key = if dim_id.starts_with('\'') {
+                    DictKey::String(dim_id[1..(dim_id.len() - 1)].to_string())
+                } else if let Ok(arraykey_value) = dim_id.parse::<u64>() {
+                    DictKey::Int(arraykey_value)
+                } else {
+                    panic!("bad int key {}", dim_id);
+                };
+                if_types.insert(
+                    shape_name,
+                    vec![vec![if negated {
+                        Assertion::DoesNotHaveNonnullEntryForKey(dict_key)
+                    } else {
+                        Assertion::HasNonnullEntryForKey(dict_key)
+                    }]],
+                );
             }
         }
     }
@@ -529,46 +529,46 @@ fn scrape_function_assertions(
 
     if function_name == &StrId::ISSET {
         let (first_arg, first_var_name, first_var_type) = firsts.unwrap();
-        if let Some(first_var_name) = first_var_name {
-            if let Some(first_var_type) = first_var_type {
-                if matches!(first_arg, aast::Expr((), _, aast::Expr_::Lvar(_)))
-                    && &first_arg.1 != pos
-                    && !first_var_type.is_mixed()
-                    && !first_var_type.possibly_undefined_from_try
-                {
-                    if_types.insert(
-                        first_var_name.clone(),
-                        vec![vec![Assertion::IsNotType(TAtomic::TNull)]],
-                    );
-                } else {
-                    if_types.insert(first_var_name.clone(), vec![vec![Assertion::IsIsset]]);
-                }
+        if let Some(first_var_name) = first_var_name
+            && let Some(first_var_type) = first_var_type
+        {
+            if matches!(first_arg, aast::Expr((), _, aast::Expr_::Lvar(_)))
+                && &first_arg.1 != pos
+                && !first_var_type.is_mixed()
+                && !first_var_type.possibly_undefined_from_try
+            {
+                if_types.insert(
+                    first_var_name.clone(),
+                    vec![vec![Assertion::IsNotType(TAtomic::TNull)]],
+                );
+            } else {
+                if_types.insert(first_var_name.clone(), vec![vec![Assertion::IsIsset]]);
             }
         }
     } else if function_name == &StrId::IN_ARRAY {
         let (first_arg, first_var_name, _) = firsts.unwrap();
-        if let (Some(first_var_name), Some(second_arg)) = (first_var_name, args.get(1)) {
-            if let aast::Expr_::ValCollection(vals) = &second_arg.to_expr_ref().2 {
-                let mut in_arr_types = vec![];
-                let mut has_reconcilable_type = true;
-                for val_expr in &vals.2 {
-                    let val_expr_type = analysis_data.get_expr_type(val_expr.pos());
+        if let (Some(first_var_name), Some(second_arg)) = (first_var_name, args.get(1))
+            && let aast::Expr_::ValCollection(vals) = &second_arg.to_expr_ref().2
+        {
+            let mut in_arr_types = vec![];
+            let mut has_reconcilable_type = true;
+            for val_expr in &vals.2 {
+                let val_expr_type = analysis_data.get_expr_type(val_expr.pos());
 
-                    if let Some(val_expr_type) = val_expr_type {
-                        in_arr_types.extend(val_expr_type.types.clone());
-                    } else {
-                        has_reconcilable_type = false;
-                    }
+                if let Some(val_expr_type) = val_expr_type {
+                    in_arr_types.extend(val_expr_type.types.clone());
+                } else {
+                    has_reconcilable_type = false;
                 }
+            }
 
-                if has_reconcilable_type {
-                    let union = TUnion::new(in_arr_types);
-                    if matches!(first_arg, aast::Expr((), _, aast::Expr_::Lvar(_))) {
-                        if_types.insert(
-                            first_var_name.clone(),
-                            vec![vec![Assertion::InArray(union)]],
-                        );
-                    }
+            if has_reconcilable_type {
+                let union = TUnion::new(in_arr_types);
+                if matches!(first_arg, aast::Expr((), _, aast::Expr_::Lvar(_))) {
+                    if_types.insert(
+                        first_var_name.clone(),
+                        vec![vec![Assertion::InArray(union)]],
+                    );
                 }
             }
         }
@@ -733,19 +733,20 @@ pub(crate) fn has_typed_value_comparison(
         assertion_context.codebase,
     );
 
-    if let Some(right_type) = analysis_data.get_expr_type(right.pos()) {
-        if (left_var_id.is_some() || right_var_id.is_none())
-            && right_type.is_single()
-            && !right_type.is_mixed()
-        {
-            return Some(OtherValuePosition::Right);
-        }
+    if let Some(right_type) = analysis_data.get_expr_type(right.pos())
+        && (left_var_id.is_some() || right_var_id.is_none())
+        && right_type.is_single()
+        && !right_type.is_mixed()
+    {
+        return Some(OtherValuePosition::Right);
     }
 
-    if let Some(left_type) = analysis_data.get_expr_type(left.pos()) {
-        if left_var_id.is_none() && left_type.is_single() && !left_type.is_mixed() {
-            return Some(OtherValuePosition::Left);
-        }
+    if let Some(left_type) = analysis_data.get_expr_type(left.pos())
+        && left_var_id.is_none()
+        && left_type.is_single()
+        && !left_type.is_mixed()
+    {
+        return Some(OtherValuePosition::Left);
     }
     None
 }
@@ -829,23 +830,23 @@ fn get_typed_value_equality_assertions(
         }
     }
 
-    if let Some(var_name) = var_name {
-        if let Some(other_value_type) = other_value_type {
-            if other_value_type.is_single() {
-                let orred_types = vec![Assertion::IsEqual(other_value_type.get_single().clone())];
+    if let Some(var_name) = var_name
+        && let Some(other_value_type) = other_value_type
+    {
+        if other_value_type.is_single() {
+            let orred_types = vec![Assertion::IsEqual(other_value_type.get_single().clone())];
 
-                if_types.insert(var_name, vec![orred_types]);
-            }
+            if_types.insert(var_name, vec![orred_types]);
+        }
 
-            if let Some(other_value_var_name) = other_value_var_name {
-                if let Some(var_type) = var_type {
-                    if !var_type.is_mixed() && var_type.is_single() {
-                        let orred_types = vec![Assertion::IsEqual(var_type.get_single().clone())];
+        if let Some(other_value_var_name) = other_value_var_name
+            && let Some(var_type) = var_type
+            && !var_type.is_mixed()
+            && var_type.is_single()
+        {
+            let orred_types = vec![Assertion::IsEqual(var_type.get_single().clone())];
 
-                        if_types.insert(other_value_var_name, vec![orred_types]);
-                    }
-                }
-            }
+            if_types.insert(other_value_var_name, vec![orred_types]);
         }
     }
 
@@ -909,25 +910,23 @@ fn get_typed_value_inequality_assertions(
         }
     }
 
-    if let Some(var_name) = var_name {
-        if let Some(other_value_type) = other_value_type {
-            if other_value_type.is_single() {
-                let orred_types =
-                    vec![Assertion::IsNotEqual(other_value_type.get_single().clone())];
+    if let Some(var_name) = var_name
+        && let Some(other_value_type) = other_value_type
+    {
+        if other_value_type.is_single() {
+            let orred_types = vec![Assertion::IsNotEqual(other_value_type.get_single().clone())];
 
-                if_types.insert(var_name, vec![orred_types]);
-            }
+            if_types.insert(var_name, vec![orred_types]);
+        }
 
-            if let Some(other_value_var_name) = other_value_var_name {
-                if let Some(var_type) = var_type {
-                    if !var_type.is_mixed() && var_type.is_single() {
-                        let orred_types =
-                            vec![Assertion::IsNotEqual(var_type.get_single().clone())];
+        if let Some(other_value_var_name) = other_value_var_name
+            && let Some(var_type) = var_type
+            && !var_type.is_mixed()
+            && var_type.is_single()
+        {
+            let orred_types = vec![Assertion::IsNotEqual(var_type.get_single().clone())];
 
-                        if_types.insert(other_value_var_name, vec![orred_types]);
-                    }
-                }
-            }
+            if_types.insert(other_value_var_name, vec![orred_types]);
         }
     }
 

--- a/src/analyzer/expr/assignment/array_assignment_analyzer.rs
+++ b/src/analyzer/expr/assignment/array_assignment_analyzer.rs
@@ -101,24 +101,23 @@ pub(crate) fn analyze(
         &mut current_type,
     )?;
 
-    if analysis_data.data_flow_graph.kind == GraphKind::FunctionBody {
-        if let Some(root_var_id) = &root_var_id {
-            if let aast::Expr_::Lvar(_) = &root_array_expr.2 {
-                let interner = statements_analyzer.interner;
-                analysis_data
-                    .data_flow_graph
-                    .add_node(DataFlowNode::get_for_variable_source(
-                        VariableSourceKind::Default,
-                        VarId(interner.get(root_var_id).unwrap()),
-                        statements_analyzer.get_hpos(root_array_expr.pos()),
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                    ));
-            }
-        }
+    if analysis_data.data_flow_graph.kind == GraphKind::FunctionBody
+        && let Some(root_var_id) = &root_var_id
+        && let aast::Expr_::Lvar(_) = &root_array_expr.2
+    {
+        let interner = statements_analyzer.interner;
+        analysis_data
+            .data_flow_graph
+            .add_node(DataFlowNode::get_for_variable_source(
+                VariableSourceKind::Default,
+                VarId(interner.get(root_var_id).unwrap()),
+                statements_analyzer.get_hpos(root_array_expr.pos()),
+                false,
+                false,
+                false,
+                false,
+                false,
+            ));
     }
 
     let root_is_string = root_type.has_string();
@@ -230,18 +229,18 @@ fn update_atomic_given_key(
     current_type: &TUnion,
     codebase: &CodebaseInfo,
 ) -> TAtomic {
-    if let TAtomic::TGenericParam(TGenericParam { as_type, .. }) = &atomic_type {
-        if as_type.types.len() == 1 {
-            // destructure generic after update
-            return update_atomic_given_key(
-                as_type.types[0].clone(),
-                key_values,
-                key_type,
-                has_matching_item,
-                current_type,
-                codebase,
-            );
-        }
+    if let TAtomic::TGenericParam(TGenericParam { as_type, .. }) = &atomic_type
+        && as_type.types.len() == 1
+    {
+        // destructure generic after update
+        return update_atomic_given_key(
+            as_type.types[0].clone(),
+            key_values,
+            key_type,
+            has_matching_item,
+            current_type,
+            codebase,
+        );
     }
     if !key_values.is_empty() {
         for key_value in key_values {
@@ -281,12 +280,12 @@ fn update_atomic_given_key(
                 } => {
                     *has_matching_item = true;
 
-                    *type_param = Box::new(combine_union_types(
+                    **type_param = combine_union_types(
                         type_param,
                         &wrap_atomic(key_value.clone()),
                         codebase,
                         true,
-                    ));
+                    );
                 }
                 TAtomic::TDict(TDict {
                     ref mut known_items,
@@ -338,12 +337,12 @@ fn update_atomic_given_key(
                 ref mut known_count,
                 ..
             }) => {
-                *type_param = Box::new(hakana_code_info::ttype::add_union_type(
+                **type_param = hakana_code_info::ttype::add_union_type(
                     arrayish_params.unwrap().1,
                     current_type,
                     codebase,
                     false,
-                ));
+                );
 
                 *known_items = None;
                 *known_count = None;
@@ -351,12 +350,12 @@ fn update_atomic_given_key(
             TAtomic::TKeyset {
                 ref mut type_param, ..
             } => {
-                *type_param = Box::new(hakana_code_info::ttype::add_union_type(
+                **type_param = hakana_code_info::ttype::add_union_type(
                     arrayish_params.unwrap().1,
                     current_type,
                     codebase,
                     false,
-                ));
+                );
             }
             TAtomic::TDict(TDict {
                 ref mut known_items,
@@ -399,10 +398,10 @@ fn add_array_assignment_dataflow(
     key_values: &Vec<TAtomic>,
     inside_general_use: bool,
 ) -> TUnion {
-    if let GraphKind::WholeProgram(WholeProgramKind::Taint) = analysis_data.data_flow_graph.kind {
-        if !child_expr_type.has_taintable_value() {
-            return parent_expr_type;
-        }
+    if let GraphKind::WholeProgram(WholeProgramKind::Taint) = analysis_data.data_flow_graph.kind
+        && !child_expr_type.has_taintable_value()
+    {
+        return parent_expr_type;
     }
 
     let parent_node = if let Some(var_var_id) = var_var_id {
@@ -761,13 +760,13 @@ pub(crate) fn analyze_nested_array_assignment<'a>(
             array_expr_var_type = Rc::new(atomic);
 
             analysis_data.set_rc_expr_type(array_expr.0.pos(), array_expr_var_type.clone());
-        } else if let Some(parent_var_id) = parent_var_id.to_owned() {
-            if context.locals.contains_key(parent_var_id.as_str()) {
-                let scoped_type = context.locals.get(parent_var_id.as_str()).unwrap();
-                analysis_data.set_rc_expr_type(array_expr.0.pos(), scoped_type.clone());
+        } else if let Some(parent_var_id) = parent_var_id.to_owned()
+            && context.locals.contains_key(parent_var_id.as_str())
+        {
+            let scoped_type = context.locals.get(parent_var_id.as_str()).unwrap();
+            analysis_data.set_rc_expr_type(array_expr.0.pos(), scoped_type.clone());
 
-                array_expr_var_type = scoped_type.clone();
-            }
+            array_expr_var_type = scoped_type.clone();
         }
 
         let new_offset_type = array_expr_offset_type.clone().unwrap_or(Rc::new(get_int()));
@@ -857,19 +856,19 @@ pub(crate) fn analyze_nested_array_assignment<'a>(
 
     let first_stmt = &array_exprs.remove(0);
 
-    if let Some(root_var_id) = &root_var_id {
-        if analysis_data.get_expr_type(first_stmt.0.pos()).is_some() {
-            let extended_var_id = root_var_id.clone() + var_id_additions.join("").as_str();
+    if let Some(root_var_id) = &root_var_id
+        && analysis_data.get_expr_type(first_stmt.0.pos()).is_some()
+    {
+        let extended_var_id = root_var_id.clone() + var_id_additions.join("").as_str();
 
-            if full_var_id && extended_var_id.contains("[$") {
-                context.locals.insert(
-                    VarName::new(extended_var_id.clone()),
-                    Rc::new(assign_value_type.clone()),
-                );
-                context
-                    .possibly_assigned_var_ids
-                    .insert(VarName::new(extended_var_id));
-            }
+        if full_var_id && extended_var_id.contains("[$") {
+            context.locals.insert(
+                VarName::new(extended_var_id.clone()),
+                Rc::new(assign_value_type.clone()),
+            );
+            context
+                .possibly_assigned_var_ids
+                .insert(VarName::new(extended_var_id));
         }
     }
 
@@ -919,16 +918,16 @@ pub(crate) fn analyze_nested_array_assignment<'a>(
         *last_array_expr_type = array_expr_type.clone();
         last_array_expr_dim = array_expr.1;
 
-        if let Some(array_expr_id) = &array_expr_id {
-            if array_expr_id.contains("[$") {
-                context.locals.insert(
-                    VarName::new(array_expr_id.clone()),
-                    Rc::new(array_expr_type.clone()),
-                );
-                context
-                    .possibly_assigned_var_ids
-                    .insert(VarName::new(array_expr_id.clone()));
-            }
+        if let Some(array_expr_id) = &array_expr_id
+            && array_expr_id.contains("[$")
+        {
+            context.locals.insert(
+                VarName::new(array_expr_id.clone()),
+                Rc::new(array_expr_type.clone()),
+            );
+            context
+                .possibly_assigned_var_ids
+                .insert(VarName::new(array_expr_id.clone()));
         }
 
         let array_type = analysis_data

--- a/src/analyzer/expr/assignment/instance_property_assignment_analyzer.rs
+++ b/src/analyzer/expr/assignment/instance_property_assignment_analyzer.rs
@@ -91,12 +91,12 @@ pub(crate) fn analyze(
         );
 
         if type_match_found {
-            if let Some(union_type) = union_comparison_result.replacement_union_type {
-                if let Some(var_id) = var_id.clone() {
-                    context
-                        .locals
-                        .insert(VarName::new(var_id), Rc::new(union_type));
-                }
+            if let Some(union_type) = union_comparison_result.replacement_union_type
+                && let Some(var_id) = var_id.clone()
+            {
+                context
+                    .locals
+                    .insert(VarName::new(var_id), Rc::new(union_type));
             }
 
             for (name, mut bound) in union_comparison_result.type_variable_lower_bounds {
@@ -330,7 +330,7 @@ pub(crate) fn analyze_regular_assignment(
         }
 
         for lhs_type_part in &lhs_type.types {
-            if let TAtomic::TNull { .. } = lhs_type_part {
+            if let TAtomic::TNull = lhs_type_part {
                 continue;
             }
 
@@ -361,9 +361,7 @@ pub(crate) fn analyze_regular_assignment(
     if let Some(var_id) = var_id {
         let context_type = Rc::new(context_type.unwrap_or(get_mixed_any()).clone());
 
-        context
-            .locals
-            .insert(VarName::new(var_id.to_owned()), context_type);
+        context.locals.insert(VarName::new(&var_id), context_type);
     }
 
     Ok(assigned_properties)
@@ -784,21 +782,21 @@ pub(crate) fn add_unspecialized_property_assignment_dataflow(
     let declaring_property_class =
         codebase.get_declaring_class_for_property(fq_class_name, &prop_name);
 
-    if let Some(declaring_property_class) = declaring_property_class {
-        if declaring_property_class != *fq_class_name {
-            let declaring_property_node = DataFlowNode::get_for_property(*property_id);
+    if let Some(declaring_property_class) = declaring_property_class
+        && declaring_property_class != *fq_class_name
+    {
+        let declaring_property_node = DataFlowNode::get_for_property(*property_id);
 
-            analysis_data.data_flow_graph.add_path(
-                &property_node.id,
-                &declaring_property_node.id,
-                PathKind::PropertyAssignment(property_id.0, property_id.1),
-                vec![],
-                vec![],
-            );
+        analysis_data.data_flow_graph.add_path(
+            &property_node.id,
+            &declaring_property_node.id,
+            PathKind::PropertyAssignment(property_id.0, property_id.1),
+            vec![],
+            vec![],
+        );
 
-            analysis_data
-                .data_flow_graph
-                .add_node(declaring_property_node);
-        }
+        analysis_data
+            .data_flow_graph
+            .add_node(declaring_property_node);
     }
 }

--- a/src/analyzer/expr/assignment/static_property_assignment_analyzer.rs
+++ b/src/analyzer/expr/assignment/static_property_assignment_analyzer.rs
@@ -213,14 +213,14 @@ pub(crate) fn analyze(
                 &mut union_comparison_result,
             );
 
-            if type_match_found && union_comparison_result.replacement_union_type.is_some() {
-                if let Some(union_type) = union_comparison_result.replacement_union_type {
-                    if let Some(var_id) = var_id.clone() {
-                        context
-                            .locals
-                            .insert(VarName::new(var_id), Rc::new(union_type));
-                    }
-                }
+            if type_match_found
+                && union_comparison_result.replacement_union_type.is_some()
+                && let Some(union_type) = union_comparison_result.replacement_union_type
+                && let Some(var_id) = var_id.clone()
+            {
+                context
+                    .locals
+                    .insert(VarName::new(var_id), Rc::new(union_type));
             }
 
             if !type_match_found && union_comparison_result.type_coerced.is_none() {

--- a/src/analyzer/expr/binop/assignment_analyzer.rs
+++ b/src/analyzer/expr/binop/assignment_analyzer.rs
@@ -69,21 +69,21 @@ pub(crate) fn analyze(
         Some((statements_analyzer.codebase, statements_analyzer.interner)),
     );
 
-    if statements_analyzer.get_config().add_fixmes {
-        if let Some(ref mut current_stmt_offset) = analysis_data.current_stmt_offset {
-            if current_stmt_offset.line != expr.0.pos().line() as u32 {
-                current_stmt_offset.line = expr.0.pos().line() as u32;
-            }
+    if statements_analyzer.get_config().add_fixmes
+        && let Some(ref mut current_stmt_offset) = analysis_data.current_stmt_offset
+    {
+        if current_stmt_offset.line != expr.0.pos().line() as u32 {
+            current_stmt_offset.line = expr.0.pos().line() as u32;
+        }
 
-            if inout_node.is_none() {
-                analysis_data.expr_fixme_positions.insert(
-                    (
-                        expr.0.pos().start_offset() as u32,
-                        expr.0.pos().end_offset() as u32,
-                    ),
-                    *current_stmt_offset,
-                );
-            }
+        if inout_node.is_none() {
+            analysis_data.expr_fixme_positions.insert(
+                (
+                    expr.0.pos().start_offset() as u32,
+                    expr.0.pos().end_offset() as u32,
+                ),
+                *current_stmt_offset,
+            );
         }
     }
 
@@ -180,26 +180,26 @@ pub(crate) fn analyze(
 
     // Track regular assignments (not compound assignments like +=, .=, etc)
     // Also exclude assignments that are part of unary operations (++, --)
-    if let aast::Expr_::Lvar(_) = &assign_var.2 {
-        if binop.is_none() && !context.inside_assignment_op {
-            if let Some(var_id) = &var_id {
-                if context.inside_loop && context.for_loop_init_bounds.0 > 0 {
-                    // do nothing, for loop assignment
-                } else {
-                    analysis_data
-                        .variable_assignments
-                        .entry(var_id.clone())
-                        .or_default()
-                        .insert((
-                            assign_var.pos().start_offset() as u32,
-                            if let Some(e) = expr.2 {
-                                e.pos().end_offset() as u32
-                            } else {
-                                assign_var.pos().end_offset() as u32
-                            },
-                        ));
-                }
-            }
+    if let aast::Expr_::Lvar(_) = &assign_var.2
+        && binop.is_none()
+        && !context.inside_assignment_op
+        && let Some(var_id) = &var_id
+    {
+        if context.inside_loop && context.for_loop_init_bounds.0 > 0 {
+            // do nothing, for loop assignment
+        } else {
+            analysis_data
+                .variable_assignments
+                .entry(var_id.clone())
+                .or_default()
+                .insert((
+                    assign_var.pos().start_offset() as u32,
+                    if let Some(e) = expr.2 {
+                        e.pos().end_offset() as u32
+                    } else {
+                        assign_var.pos().end_offset() as u32
+                    },
+                ));
         }
     }
 
@@ -218,25 +218,25 @@ pub(crate) fn analyze(
     };
 
     if let (Some(var_id), Some(existing_var_type), None) = (&var_id, &existing_var_type, binop) {
-        if context.inside_loop && !context.inside_assignment_op {
-            if let Some(assign_value) = assign_value {
-                if let aast::Expr_::Clone(cloned_expr) = &assign_value.2 {
-                    if let aast::Expr_::Lvar(cloned_var) = &cloned_expr.2 {
-                        if cloned_var.name() == var_id {
-                            let mut origin_node_ids = vec![];
+        if context.inside_loop
+            && !context.inside_assignment_op
+            && let Some(assign_value) = assign_value
+            && let aast::Expr_::Clone(cloned_expr) = &assign_value.2
+            && let aast::Expr_::Lvar(cloned_var) = &cloned_expr.2
+            && cloned_var.name() == var_id
+        {
+            let mut origin_node_ids = vec![];
 
-                            for parent_node in &existing_var_type.parent_nodes {
-                                origin_node_ids.extend(
-                                    analysis_data.data_flow_graph.get_origin_node_ids(
-                                        &parent_node.id,
-                                        &[],
-                                        false,
-                                    ),
-                                );
-                            }
+            for parent_node in &existing_var_type.parent_nodes {
+                origin_node_ids.extend(analysis_data.data_flow_graph.get_origin_node_ids(
+                    &parent_node.id,
+                    &[],
+                    false,
+                ));
+            }
 
-                            if origin_node_ids.len() > 1 {
-                                analysis_data.maybe_add_issue(
+            if origin_node_ids.len() > 1 {
+                analysis_data.maybe_add_issue(
                                     Issue::new(
                                         IssueKind::CloneInsideLoop,
                                         format!("Overwriting an object {} outside the loop with a clone likely not intended", var_id),
@@ -246,10 +246,6 @@ pub(crate) fn analyze(
                                     statements_analyzer.get_config(),
                                     statements_analyzer.get_file_path_actual(),
                                 )
-                            }
-                        }
-                    }
-                }
             }
         }
 
@@ -268,13 +264,11 @@ pub(crate) fn analyze(
                 ));
             }
 
-            if let Some(assign_value) = assign_value {
-                if let aast::Expr_::Clone(cloned_expr) = &assign_value.2 {
-                    if let aast::Expr_::Lvar(cloned_var) = &cloned_expr.2 {
-                        if cloned_var.name() == var_id {}
-                    }
-                }
-            }
+            if let Some(assign_value) = assign_value
+                && let aast::Expr_::Clone(cloned_expr) = &assign_value.2
+                && let aast::Expr_::Lvar(cloned_var) = &cloned_expr.2
+                && cloned_var.name() == var_id
+            {}
 
             origin_node_ids.retain(|id| {
                 if let Some(node) = analysis_data.data_flow_graph.get_node(id) {
@@ -538,7 +532,7 @@ fn analyze_list_assignment(
 
         analyze(
             statements_analyzer,
-            (&assign_var_item, None, None),
+            (assign_var_item, None, None),
             assign_var_item.pos(),
             Some(&value_type),
             analysis_data,
@@ -681,24 +675,23 @@ fn analyze_assignment_to_variable(
         }
     }
 
-    if assign_value_type.is_bool() {
-        if let Some(source_expr) = source_expr {
-            if matches!(source_expr.2, aast::Expr_::Binop(..)) {
-                handle_assignment_with_boolean_logic(
-                    var_expr,
-                    source_expr,
-                    statements_analyzer,
-                    context,
-                    analysis_data,
-                    &var_id,
-                );
-            }
-        }
+    if assign_value_type.is_bool()
+        && let Some(source_expr) = source_expr
+        && matches!(source_expr.2, aast::Expr_::Binop(..))
+    {
+        handle_assignment_with_boolean_logic(
+            var_expr,
+            source_expr,
+            statements_analyzer,
+            context,
+            analysis_data,
+            &var_id,
+        );
     }
 
     context
         .locals
-        .insert(VarName::new(var_id.to_string()), Rc::new(assign_value_type));
+        .insert(VarName::new(&var_id), Rc::new(assign_value_type));
 }
 
 fn handle_assignment_with_boolean_logic(
@@ -781,7 +774,7 @@ pub(crate) fn analyze_inout_param(
 ) -> Result<(), AnalysisError> {
     analyze(
         statements_analyzer,
-        (&expr, None, None),
+        (expr, None, None),
         expr.pos(),
         Some(inout_type),
         analysis_data,

--- a/src/analyzer/expr/binop/coalesce_analyzer.rs
+++ b/src/analyzer/expr/binop/coalesce_analyzer.rs
@@ -36,8 +36,8 @@ pub(crate) fn analyze<'expr>(
                 root_not_left = true;
                 has_array_access = true;
 
-                if let Some(dim) = &boxed.1 {
-                    if let aast::Expr_::ArrayGet(..)
+                if let Some(dim) = &boxed.1
+                    && let aast::Expr_::ArrayGet(..)
                     | aast::Expr_::ClassConst(..)
                     | aast::Expr_::Call(..)
                     | aast::Expr_::Cast(..)
@@ -47,9 +47,8 @@ pub(crate) fn analyze<'expr>(
                     | aast::Expr_::Pipe(..)
                     | aast::Expr_::Await(..)
                     | aast::Expr_::Delay(..) = dim.2
-                    {
-                        has_arrayget_key = true;
-                    }
+                {
+                    has_arrayget_key = true;
                 }
             }
             aast::Expr_::ObjGet(boxed) => {
@@ -141,18 +140,18 @@ pub(crate) fn analyze<'expr>(
                 &root_type,
                 false,
             ));
-        } else if let Some(root_type) = root_type {
-            if root_type.has_typealias() {
-                replacement_left = Some(get_left_expr(
-                    context,
-                    statements_analyzer,
-                    left,
-                    analysis_data,
-                    left,
-                    &None,
-                    true,
-                ));
-            }
+        } else if let Some(root_type) = root_type
+            && root_type.has_typealias()
+        {
+            replacement_left = Some(get_left_expr(
+                context,
+                statements_analyzer,
+                left,
+                analysis_data,
+                left,
+                &None,
+                true,
+            ));
         }
     }
 

--- a/src/analyzer/expr/binop/concat_analyzer.rs
+++ b/src/analyzer/expr/binop/concat_analyzer.rs
@@ -82,7 +82,7 @@ pub(crate) fn analyze_concat_nodes(
                 }
             }
 
-            if simple_string != "" {
+            if !simple_string.is_empty() {
                 nonempty_string = true;
             }
 
@@ -99,7 +99,7 @@ pub(crate) fn analyze_concat_nodes(
                     concat_node.pos().start_offset() as u32,
                     concat_node.pos().end_offset() as u32,
                 ))
-                .map(|t| t.clone());
+                .cloned();
 
             if let Some(expr_type) = expr_type {
                 let mut local_nonempty_string = true;
@@ -113,7 +113,7 @@ pub(crate) fn analyze_concat_nodes(
                                 has_query = true;
                             }
 
-                            if value == "" {
+                            if value.is_empty() {
                                 local_nonempty_string = false;
                             }
 
@@ -142,9 +142,8 @@ pub(crate) fn analyze_concat_nodes(
                         TAtomic::TNothing => analysis_data.maybe_add_issue(
                             Issue::new(
                                 IssueKind::NoValue,
-                                format!(
-                                    "Expected string or int in concatenation, nothing type provided"
-                                ),
+                                "Expected string or int in concatenation, nothing type provided"
+                                    .to_string(),
                                 statements_analyzer.get_hpos(concat_node.pos()),
                                 &context.function_context.calling_functionlike_id,
                             ),

--- a/src/analyzer/expr/call/argument_analyzer.rs
+++ b/src/analyzer/expr/call/argument_analyzer.rs
@@ -71,7 +71,7 @@ pub(crate) fn check_argument_matches(
                 context,
                 arg_value_type: &arg_value_type,
                 arg,
-                param_type: &param_type,
+                param_type,
                 argument_offset,
                 function_call_pos,
                 function_name_pos,
@@ -83,7 +83,7 @@ pub(crate) fn check_argument_matches(
     self::verify_type(
         statements_analyzer,
         &arg_value_type,
-        &param_type,
+        param_type,
         functionlike_id,
         argument_offset,
         arg.to_expr_ref(),
@@ -555,12 +555,11 @@ fn add_dataflow(
         }
 
         for at in &param_type.types {
-            if let Some(shape_name) = at.get_shape_name() {
-                if let Some(t) = codebase.type_definitions.get(&shape_name) {
-                    if t.shape_field_taints.is_some() {
-                        return;
-                    }
-                }
+            if let Some(shape_name) = at.get_shape_name()
+                && let Some(t) = codebase.type_definitions.get(&shape_name)
+                && t.shape_field_taints.is_some()
+            {
+                return;
             }
         }
     }
@@ -626,60 +625,24 @@ fn add_dataflow(
     };
 
     if let GraphKind::WholeProgram(_) = &data_flow_graph.kind {
-        if let FunctionLikeIdentifier::Method(_, method_name) = functionlike_id {
-            if let Some(method_call_info) = method_call_info {
-                if let Some(dependent_classlikes) = codebase
-                    .all_classlike_descendants
-                    .get(&method_call_info.classlike_storage.name)
-                {
-                    if method_name != &statements_analyzer.interner.get("__construct").unwrap() {
-                        for dependent_classlike in dependent_classlikes {
-                            if codebase.declaring_method_exists(dependent_classlike, method_name) {
-                                let new_sink = DataFlowNode::get_for_method_argument(
-                                    &FunctionLikeIdentifier::Method(
-                                        *dependent_classlike,
-                                        *method_name,
-                                    ),
-                                    argument_offset,
-                                    None,
-                                    if specialize_taint {
-                                        Some(function_call_hpos)
-                                    } else {
-                                        None
-                                    },
-                                );
-
-                                data_flow_graph.add_node(new_sink.clone());
-
-                                data_flow_graph.add_path(
-                                    &method_node.id,
-                                    &new_sink.id,
-                                    PathKind::Default,
-                                    vec![],
-                                    vec![],
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if let Some(MethodCallInfo {
-            declaring_method_id: Some(declaring_method_id),
-            ..
-        }) = method_call_info
+        if let FunctionLikeIdentifier::Method(_, method_name) = functionlike_id
+            && let Some(method_call_info) = method_call_info
+            && let Some(dependent_classlikes) = codebase
+                .all_classlike_descendants
+                .get(&method_call_info.classlike_storage.name)
+            && method_name != &statements_analyzer.interner.get("__construct").unwrap()
         {
-            if let Some(method_id) = functionlike_id.as_method_identifier() {
-                if declaring_method_id != &method_id {
+            for dependent_classlike in dependent_classlikes {
+                if codebase.declaring_method_exists(dependent_classlike, method_name) {
                     let new_sink = DataFlowNode::get_for_method_argument(
-                        &FunctionLikeIdentifier::Method(
-                            declaring_method_id.0,
-                            declaring_method_id.1,
-                        ),
+                        &FunctionLikeIdentifier::Method(*dependent_classlike, *method_name),
                         argument_offset,
-                        Some(statements_analyzer.get_hpos(input_expr.pos())),
                         None,
+                        if specialize_taint {
+                            Some(function_call_hpos)
+                        } else {
+                            None
+                        },
                     );
 
                     data_flow_graph.add_node(new_sink.clone());
@@ -693,6 +656,31 @@ fn add_dataflow(
                     );
                 }
             }
+        }
+
+        if let Some(MethodCallInfo {
+            declaring_method_id: Some(declaring_method_id),
+            ..
+        }) = method_call_info
+            && let Some(method_id) = functionlike_id.as_method_identifier()
+            && declaring_method_id != &method_id
+        {
+            let new_sink = DataFlowNode::get_for_method_argument(
+                &FunctionLikeIdentifier::Method(declaring_method_id.0, declaring_method_id.1),
+                argument_offset,
+                Some(statements_analyzer.get_hpos(input_expr.pos())),
+                None,
+            );
+
+            data_flow_graph.add_node(new_sink.clone());
+
+            data_flow_graph.add_path(
+                &method_node.id,
+                &new_sink.id,
+                PathKind::Default,
+                vec![],
+                vec![],
+            );
         }
     }
 
@@ -826,10 +814,9 @@ fn get_argument_taints(
         FunctionLikeIdentifier::Method(fq_class, method_name) => {
             if let ("AsyncMysqlConnection", "query") =
                 (interner.lookup(fq_class), interner.lookup(method_name))
+                && arg_offset == 0
             {
-                if arg_offset == 0 {
-                    return vec![SinkType::Sql];
-                }
+                return vec![SinkType::Sql];
             }
         }
         _ => {}

--- a/src/analyzer/expr/call/arguments_analyzer.rs
+++ b/src/analyzer/expr/call/arguments_analyzer.rs
@@ -239,8 +239,8 @@ pub(crate) fn check_arguments_match(
     for arg in args {
         let was_inside_call = context.inside_general_use;
 
-        if functionlike_id != &FunctionLikeIdentifier::Method(StrId::SHAPES, StrId::PUT) {
-            if matches!(functionlike_info.effects, FnEffect::Some(_))
+        if functionlike_id != &FunctionLikeIdentifier::Method(StrId::SHAPES, StrId::PUT)
+            && (matches!(functionlike_info.effects, FnEffect::Some(_))
                 || matches!(functionlike_info.effects, FnEffect::Arg(_))
                 || functionlike_info.has_throw
                 || functionlike_info.user_defined
@@ -248,10 +248,9 @@ pub(crate) fn check_arguments_match(
                 || matches!(
                     functionlike_id,
                     FunctionLikeIdentifier::Function(StrId::ASIO_JOIN)
-                )
-            {
-                context.inside_general_use = true;
-            }
+                ))
+        {
+            context.inside_general_use = true;
         }
 
         let arg_expr = arg.to_expr_ref();
@@ -296,12 +295,11 @@ pub(crate) fn check_arguments_match(
             functionlike_params.get(*argument_offset)
         };
 
-        if param.is_none() {
-            if let Some(last_param) = last_param {
-                if last_param.is_variadic {
-                    param = Some(last_param);
-                }
-            }
+        if param.is_none()
+            && let Some(last_param) = last_param
+            && last_param.is_variadic
+        {
+            param = Some(last_param);
         }
 
         let mut param_type = get_param_type(
@@ -481,21 +479,19 @@ pub(crate) fn check_arguments_match(
 
         while i < i_max {
             let function_param = &function_params[i];
-            if let Some(default_type) = &function_param.default_type {
-                if let Some(param_type) = &function_param.signature_type {
-                    if param_type.has_template() {
-                        let default_type =
-                            if let DefaultType::NormalData(default_union) = &default_type {
-                                wrap_atomic(default_union.clone())
-                            } else {
-                                // todo handle unresolved constants
-                                get_mixed_any()
-                            };
+            if let Some(default_type) = &function_param.default_type
+                && let Some(param_type) = &function_param.signature_type
+                && param_type.has_template()
+            {
+                let default_type = if let DefaultType::NormalData(default_union) = &default_type {
+                    wrap_atomic(default_union.clone())
+                } else {
+                    // todo handle unresolved constants
+                    get_mixed_any()
+                };
 
-                        if default_type.has_literal_value() {
-                            // todo check templated default arg matches
-                        }
-                    }
+                if default_type.has_literal_value() {
+                    // todo check templated default arg matches
                 }
             }
             i += 1;
@@ -531,14 +527,12 @@ pub(crate) fn check_arguments_match(
             }
         } else if let Some(function_param) = function_params.get(*argument_offset) {
             function_param
+        } else if let Some(last_param) = function_params.last()
+            && last_param.is_variadic
+        {
+            last_param
         } else {
-            if let Some(last_param) = function_params.last()
-                && last_param.is_variadic
-            {
-                last_param
-            } else {
-                break;
-            }
+            break;
         };
 
         if function_param.is_inout {
@@ -558,29 +552,29 @@ pub(crate) fn check_arguments_match(
                     continue;
                 };
 
-                if statements_analyzer.get_config().add_fixmes {
-                    if let Some(ref mut current_stmt_offset) = analysis_data.current_stmt_offset {
-                        if current_stmt_offset.line != arg.as_ainout().unwrap().0.line() as u32 {
-                            if !matches!(arg_expr.2, aast::Expr_::Xml(..)) {
-                                *current_stmt_offset = StmtStart {
-                                    offset: inout_token_pos.start_offset() as u32,
-                                    line: inout_token_pos.line() as u32,
-                                    column: inout_token_pos.to_raw_span().start.column() as u16,
-                                    add_newline: true,
-                                };
-                            } else {
-                                current_stmt_offset.line = inout_token_pos.line() as u32;
-                            }
+                if statements_analyzer.get_config().add_fixmes
+                    && let Some(ref mut current_stmt_offset) = analysis_data.current_stmt_offset
+                {
+                    if current_stmt_offset.line != arg.as_ainout().unwrap().0.line() as u32 {
+                        if !matches!(arg_expr.2, aast::Expr_::Xml(..)) {
+                            *current_stmt_offset = StmtStart {
+                                offset: inout_token_pos.start_offset() as u32,
+                                line: inout_token_pos.line() as u32,
+                                column: inout_token_pos.to_raw_span().start.column() as u16,
+                                add_newline: true,
+                            };
+                        } else {
+                            current_stmt_offset.line = inout_token_pos.line() as u32;
                         }
-
-                        analysis_data.expr_fixme_positions.insert(
-                            (
-                                inout_token_pos.start_offset() as u32,
-                                arg_expr.1.end_offset() as u32,
-                            ),
-                            *current_stmt_offset,
-                        );
                     }
+
+                    analysis_data.expr_fixme_positions.insert(
+                        (
+                            inout_token_pos.start_offset() as u32,
+                            arg_expr.1.end_offset() as u32,
+                        ),
+                        *current_stmt_offset,
+                    );
                 }
 
                 handle_possibly_matching_inout_param(
@@ -658,77 +652,75 @@ pub(crate) fn check_arguments_match(
             context.inside_general_use = false;
         }
 
-        if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {
-            if let Some(removed_taints) = &function_param.removed_taints_when_returning_true {
-                if let Some(expr_var_id) = expression_identifier::get_var_id(
-                    arg_expr,
-                    None,
-                    statements_analyzer.file_analyzer.resolved_names,
-                    Some((statements_analyzer.codebase, statements_analyzer.interner)),
-                ) {
-                    analysis_data.if_true_assertions.insert(
-                        (
-                            function_call_pos.start_offset() as u32,
-                            function_call_pos.end_offset() as u32,
-                        ),
-                        FxHashMap::from_iter([(
-                            "hakana taints".to_string(),
-                            vec![Assertion::RemoveTaints(
-                                VarId(statements_analyzer.interner.get(&expr_var_id).unwrap()),
-                                if removed_taints.is_empty() {
-                                    SinkType::user_controllable_taints()
-                                } else {
-                                    removed_taints.clone()
-                                },
-                            )],
-                        )]),
-                    );
-                }
-            }
+        if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind
+            && let Some(removed_taints) = &function_param.removed_taints_when_returning_true
+            && let Some(expr_var_id) = expression_identifier::get_var_id(
+                arg_expr,
+                None,
+                statements_analyzer.file_analyzer.resolved_names,
+                Some((statements_analyzer.codebase, statements_analyzer.interner)),
+            )
+        {
+            analysis_data.if_true_assertions.insert(
+                (
+                    function_call_pos.start_offset() as u32,
+                    function_call_pos.end_offset() as u32,
+                ),
+                FxHashMap::from_iter([(
+                    "hakana taints".to_string(),
+                    vec![Assertion::RemoveTaints(
+                        VarId(statements_analyzer.interner.get(&expr_var_id).unwrap()),
+                        if removed_taints.is_empty() {
+                            SinkType::user_controllable_taints()
+                        } else {
+                            removed_taints.clone()
+                        },
+                    )],
+                )]),
+            );
         }
     }
 
     // analyze unpacked arg
-    if let Some(unpacked_arg) = unpacked_arg {
-        if let Some(last_param) = function_params.last() {
-            if last_param.is_variadic {
-                let arg_value_type = analysis_data.get_expr_type(unpacked_arg.pos());
+    if let Some(unpacked_arg) = unpacked_arg
+        && let Some(last_param) = function_params.last()
+        && last_param.is_variadic
+    {
+        let arg_value_type = analysis_data.get_expr_type(unpacked_arg.pos());
 
-                let arg_value_type = if let Some(arg_value_type) = arg_value_type {
-                    arg_value_type.clone()
-                } else {
-                    // todo increment mixed count
+        let arg_value_type = if let Some(arg_value_type) = arg_value_type {
+            arg_value_type.clone()
+        } else {
+            // todo increment mixed count
 
-                    get_mixed_any()
-                };
+            get_mixed_any()
+        };
 
-                let was_inside_call = context.inside_general_use;
+        let was_inside_call = context.inside_general_use;
 
-                if matches!(functionlike_info.effects, FnEffect::Some(_)) {
-                    context.inside_general_use = true;
-                }
-
-                argument_analyzer::check_argument_matches(
-                    statements_analyzer,
-                    functionlike_id,
-                    &method_call_info,
-                    last_param,
-                    &last_param_type.unwrap(),
-                    args.len(),
-                    &aast::Argument::Anormal(unpacked_arg.clone()),
-                    true,
-                    arg_value_type,
-                    context,
-                    analysis_data,
-                    functionlike_info.ignore_taint_path,
-                    functionlike_info.specialize_call,
-                    function_call_pos,
-                    function_name_pos,
-                );
-
-                context.inside_general_use = was_inside_call;
-            }
+        if matches!(functionlike_info.effects, FnEffect::Some(_)) {
+            context.inside_general_use = true;
         }
+
+        argument_analyzer::check_argument_matches(
+            statements_analyzer,
+            functionlike_id,
+            &method_call_info,
+            last_param,
+            &last_param_type.unwrap(),
+            args.len(),
+            &aast::Argument::Anormal(unpacked_arg.clone()),
+            true,
+            arg_value_type,
+            context,
+            analysis_data,
+            functionlike_info.ignore_taint_path,
+            functionlike_info.specialize_call,
+            function_call_pos,
+            function_name_pos,
+        );
+
+        context.inside_general_use = was_inside_call;
     }
 
     // for (_, map) in &template_result.lower_bounds {
@@ -821,17 +813,15 @@ fn adjust_param_type(
                 as_type,
                 ..
             }) = template_type
-            {
-                if (if let Some(bounds_by_param) = template_result.lower_bounds.get(&param_name) {
+                && (if let Some(bounds_by_param) = template_result.lower_bounds.get(&param_name) {
                     bounds_by_param.get(&defining_entity)
                 } else {
                     None
                 })
                 .is_none()
-                {
-                    let bound_type = if let Some(bounds_by_param) =
-                        template_result.upper_bounds.get(&param_name)
-                    {
+            {
+                let bound_type =
+                    if let Some(bounds_by_param) = template_result.upper_bounds.get(&param_name) {
                         if let Some(upper_bound) = bounds_by_param.get(&defining_entity) {
                             upper_bound.bound_type.clone()
                         } else {
@@ -841,15 +831,14 @@ fn adjust_param_type(
                         (*as_type).clone()
                     };
 
-                    template_result
-                        .upper_bounds
-                        .entry(param_name)
-                        .or_insert_with(FxHashMap::default)
-                        .insert(
-                            defining_entity,
-                            TemplateBound::new(bound_type, 0, None, None),
-                        );
-                }
+                template_result
+                    .upper_bounds
+                    .entry(param_name)
+                    .or_insert_with(FxHashMap::default)
+                    .insert(
+                        defining_entity,
+                        TemplateBound::new(bound_type, 0, None, None),
+                    );
             }
         }
     }
@@ -874,11 +863,7 @@ fn get_param_type(
                 &statements_analyzer.file_analyzer.file_source.file_path,
                 &mut param_type,
                 &TypeExpansionOptions {
-                    self_class: if let Some(classlike_storage) = class_storage {
-                        Some(classlike_storage.name)
-                    } else {
-                        None
-                    },
+                    self_class: class_storage.map(|classlike_storage| classlike_storage.name),
                     static_class_type: if let Some(calling_class_storage) =
                         calling_classlike_storage
                     {
@@ -1008,12 +993,11 @@ fn handle_closure_arg(
             }
         }
 
-        if matches!(
+        if (matches!(
             analysis_data.data_flow_graph.kind,
             GraphKind::WholeProgram(_)
-        ) || !statements_analyzer.get_config().in_migration
-        {
-            if let FunctionLikeIdentifier::Function(
+        ) || !statements_analyzer.get_config().in_migration)
+            && let FunctionLikeIdentifier::Function(
                 StrId::LIB_VEC_MAP
                 | StrId::LIB_DICT_MAP
                 | StrId::LIB_KEYSET_MAP
@@ -1035,20 +1019,17 @@ fn handle_closure_arg(
                 | StrId::LIB_DICT_FROM_KEYS
                 | StrId::LIB_DICT_FROM_KEYS_ASYNC,
             ) = functionlike_id
-            {
-                if param_offset == 0 {
-                    if let Some(ref mut signature_type) = param_storage.signature_type {
-                        add_array_fetch_dataflow(
-                            statements_analyzer,
-                            &args[0].to_expr_ref().1,
-                            analysis_data,
-                            None,
-                            signature_type,
-                            &mut get_arraykey(false),
-                        );
-                    }
-                }
-            }
+            && param_offset == 0
+            && let Some(ref mut signature_type) = param_storage.signature_type
+        {
+            add_array_fetch_dataflow(
+                statements_analyzer,
+                &args[0].to_expr_ref().1,
+                analysis_data,
+                None,
+                signature_type,
+                &mut get_arraykey(false),
+            );
         }
     }
 
@@ -1227,12 +1208,11 @@ fn handle_possibly_matching_inout_param(
             None,
             StandinOpts {
                 calling_class: context.function_context.calling_class,
-                calling_function: if let Some(m) = &context.function_context.calling_functionlike_id
-                {
-                    Some(*m)
-                } else {
-                    None
-                },
+                calling_function: context
+                    .function_context
+                    .calling_functionlike_id
+                    .as_ref()
+                    .map(|m| *m),
                 ..Default::default()
             },
         );
@@ -1249,11 +1229,7 @@ fn handle_possibly_matching_inout_param(
         &statements_analyzer.file_analyzer.file_source.file_path,
         &mut inout_type,
         &TypeExpansionOptions {
-            self_class: if let Some(classlike_storage) = classlike_storage {
-                Some(classlike_storage.name)
-            } else {
-                None
-            },
+            self_class: classlike_storage.map(|classlike_storage| classlike_storage.name),
             static_class_type: if let Some(calling_class_storage) = calling_classlike_storage {
                 StaticClassType::Name(calling_class_storage.name)
             } else {
@@ -1398,11 +1374,9 @@ fn refine_template_result_for_functionlike(
         analysis_data,
         file_path,
         classlike_storage,
-        if let Some(method_call_info) = method_call_info {
-            Some(method_call_info.self_fq_classlike_name)
-        } else {
-            None
-        },
+        method_call_info
+            .as_ref()
+            .map(|method_call_info| method_call_info.self_fq_classlike_name),
         calling_classlike_storage,
         &functionlike_storage.template_types,
         class_template_params,
@@ -1625,19 +1599,21 @@ fn check_named_arguments(
 
     // Check for missing required named parameters
     for (param_name, (_idx, param)) in &param_names {
-        if param.is_named && !param.is_optional && !param.is_variadic {
-            if !provided_named_params.contains_key(param_name.as_str()) {
-                analysis_data.maybe_add_issue(
-                    Issue::new(
-                        IssueKind::MissingRequiredNamedArgument,
-                        format!("Missing required named argument: {}", param_name),
-                        statements_analyzer.get_hpos(function_call_pos),
-                        &context.function_context.calling_functionlike_id,
-                    ),
-                    statements_analyzer.get_config(),
-                    statements_analyzer.get_file_path_actual(),
-                );
-            }
+        if param.is_named
+            && !param.is_optional
+            && !param.is_variadic
+            && !provided_named_params.contains_key(param_name.as_str())
+        {
+            analysis_data.maybe_add_issue(
+                Issue::new(
+                    IssueKind::MissingRequiredNamedArgument,
+                    format!("Missing required named argument: {}", param_name),
+                    statements_analyzer.get_hpos(function_call_pos),
+                    &context.function_context.calling_functionlike_id,
+                ),
+                statements_analyzer.get_config(),
+                statements_analyzer.get_file_path_actual(),
+            );
         }
     }
 }

--- a/src/analyzer/expr/call/atomic_method_call_analyzer.rs
+++ b/src/analyzer/expr/call/atomic_method_call_analyzer.rs
@@ -347,7 +347,7 @@ fn handle_nonexistent_method(
         let Some(classlike_info) = statements_analyzer
             .codebase
             .classlike_infos
-            .get(&classlike_name)
+            .get(classlike_name)
         else {
             return Err(AnalysisError::InternalError(
                 "Cannot load classlike storage".to_string(),

--- a/src/analyzer/expr/call/class_template_param_collector.rs
+++ b/src/analyzer/expr/call/class_template_param_collector.rs
@@ -53,27 +53,26 @@ pub(crate) fn collect(
                 continue;
             }
 
-            if class_storage.name != static_class_storage.name {
-                if let Some(input_type_extends) = e
+            if class_storage.name != static_class_storage.name
+                && let Some(input_type_extends) = e
                     .get(&class_storage.name)
                     .unwrap_or(&IndexMap::new())
                     .get(template_name)
-                {
-                    let output_type_extends = resolve_template_param(
-                        codebase,
-                        input_type_extends,
-                        static_class_storage,
-                        lhs_type_params,
-                    );
+            {
+                let output_type_extends = resolve_template_param(
+                    codebase,
+                    input_type_extends,
+                    static_class_storage,
+                    lhs_type_params,
+                );
 
-                    class_template_params
-                        .entry(*template_name)
-                        .or_insert_with(FxHashMap::default)
-                        .insert(
-                            GenericParent::ClassLike(class_storage.name),
-                            output_type_extends.unwrap_or(get_mixed_any()),
-                        );
-                }
+                class_template_params
+                    .entry(*template_name)
+                    .or_insert_with(FxHashMap::default)
+                    .insert(
+                        GenericParent::ClassLike(class_storage.name),
+                        output_type_extends.unwrap_or(get_mixed_any()),
+                    );
             }
 
             class_template_params
@@ -86,23 +85,22 @@ pub(crate) fn collect(
 
     for (template_name, type_map) in template_types {
         for (template_classname, type_) in type_map {
-            if class_storage.name != static_class_storage.name {
-                if let Some(extended_type) = e
+            if class_storage.name != static_class_storage.name
+                && let Some(extended_type) = e
                     .get(&class_storage.name)
                     .unwrap_or(&IndexMap::new())
                     .get(template_name)
-                {
-                    class_template_params
-                        .entry(*template_name)
-                        .or_insert_with(FxHashMap::default)
-                        .entry(GenericParent::ClassLike(class_storage.name))
-                        .or_insert(TUnion::new(expand_type(
-                            extended_type,
-                            e,
-                            &static_class_storage.name,
-                            &static_class_storage.template_types,
-                        )));
-                }
+            {
+                class_template_params
+                    .entry(*template_name)
+                    .or_insert_with(FxHashMap::default)
+                    .entry(GenericParent::ClassLike(class_storage.name))
+                    .or_insert(TUnion::new(expand_type(
+                        extended_type,
+                        e,
+                        &static_class_storage.name,
+                        &static_class_storage.template_types,
+                    )));
             }
 
             let self_call = if let Some(TAtomic::TNamedObject(TNamedObject {

--- a/src/analyzer/expr/call/existing_atomic_method_call_analyzer.rs
+++ b/src/analyzer/expr/call/existing_atomic_method_call_analyzer.rs
@@ -91,16 +91,15 @@ pub(crate) fn analyze(
     if statements_analyzer
         .get_config()
         .collect_goto_definition_locations
+        && let Some(method_name_pos) = method_name_pos
     {
-        if let Some(method_name_pos) = method_name_pos {
-            analysis_data.definition_locations.insert(
-                (
-                    method_name_pos.start_offset() as u32,
-                    method_name_pos.end_offset() as u32,
-                ),
-                (declaring_method_id.0, declaring_method_id.1),
-            );
-        }
+        analysis_data.definition_locations.insert(
+            (
+                method_name_pos.start_offset() as u32,
+                method_name_pos.end_offset() as u32,
+            ),
+            (declaring_method_id.0, declaring_method_id.1),
+        );
     }
 
     if method_id != declaring_method_id
@@ -194,33 +193,32 @@ pub(crate) fn analyze(
         class_template_params.clone().unwrap_or(IndexMap::new()),
     );
 
-    if !functionlike_storage.where_constraints.is_empty() {
-        if let Some(class_template_params) = &class_template_params {
-            for (template_name, where_type) in &functionlike_storage.where_constraints {
-                // Only process where constraints for class template parameters.
-                // Method template parameters (like TItem in `where TItem as T`) are
-                // handled during argument checking, not here.
-                if let Some(template_map) = class_template_params.get(template_name) {
-                    if let Some(template_type) =
-                        template_map.get(&GenericParent::ClassLike(declaring_method_id.0))
-                    {
-                        standin_type_replacer::replace(
-                            where_type,
-                            &mut template_result,
-                            statements_analyzer.codebase,
-                            statements_analyzer.interner,
-                            statements_analyzer.get_file_path(),
-                            &Some(template_type),
-                            None,
-                            None,
-                            StandinOpts {
-                                calling_class: None,
-                                calling_function: context.function_context.calling_functionlike_id,
-                                ..Default::default()
-                            },
-                        );
-                    }
-                }
+    if !functionlike_storage.where_constraints.is_empty()
+        && let Some(class_template_params) = &class_template_params
+    {
+        for (template_name, where_type) in &functionlike_storage.where_constraints {
+            // Only process where constraints for class template parameters.
+            // Method template parameters (like TItem in `where TItem as T`) are
+            // handled during argument checking, not here.
+            if let Some(template_map) = class_template_params.get(template_name)
+                && let Some(template_type) =
+                    template_map.get(&GenericParent::ClassLike(declaring_method_id.0))
+            {
+                standin_type_replacer::replace(
+                    where_type,
+                    &mut template_result,
+                    statements_analyzer.codebase,
+                    statements_analyzer.interner,
+                    statements_analyzer.get_file_path(),
+                    &Some(template_type),
+                    None,
+                    None,
+                    StandinOpts {
+                        calling_class: None,
+                        calling_function: context.function_context.calling_functionlike_id,
+                        ..Default::default()
+                    },
+                );
             }
         }
     }
@@ -241,22 +239,20 @@ pub(crate) fn analyze(
     // Check for ImplicitAsioJoin - methods that have async versions
     if let (Some(async_version), Some(method_name_pos)) =
         (functionlike_storage.async_version, method_name_pos)
+        && let TAtomic::TNamedObject(TNamedObject { name, .. }) = lhs_type_part
+        && !codebase.class_extends_or_implements(name, &StrId::XHP_CHILD)
     {
-        if let TAtomic::TNamedObject(TNamedObject { name, .. }) = lhs_type_part {
-            if !codebase.class_extends_or_implements(name, &StrId::XHP_CHILD) {
-                super::function_call_analyzer::check_implicit_asio_join(
-                    statements_analyzer,
-                    pos,
-                    method_name_pos,
-                    analysis_data,
-                    context,
-                    FunctionLikeIdentifier::Method(method_id.0, method_id.1),
-                    async_version,
-                    false, // methods are not sub-expressions by default
-                    lhs_expr,
-                );
-            }
-        }
+        super::function_call_analyzer::check_implicit_asio_join(
+            statements_analyzer,
+            pos,
+            method_name_pos,
+            analysis_data,
+            context,
+            FunctionLikeIdentifier::Method(method_id.0, method_id.1),
+            async_version,
+            false, // methods are not sub-expressions by default
+            lhs_expr,
+        );
     }
 
     check_service_calls(
@@ -270,13 +266,12 @@ pub(crate) fn analyze(
 
     // .hhi for NumberFormatter was incorrect
     // or if we're calling parent::__construct, make sure we set correct write props effect
-    if method_id.0 == StrId::NUMBER_FORMATTER || method_id.1 == StrId::CONSTRUCT {
-        if let Some(effects) = analysis_data
+    if (method_id.0 == StrId::NUMBER_FORMATTER || method_id.1 == StrId::CONSTRUCT)
+        && let Some(effects) = analysis_data
             .expr_effects
             .get_mut(&(pos.start_offset() as u32, pos.end_offset() as u32))
-        {
-            *effects |= EFFECT_WRITE_LOCAL;
-        }
+    {
+        *effects |= EFFECT_WRITE_LOCAL;
     }
 
     if functionlike_storage.ignore_taints_if_true {
@@ -286,8 +281,8 @@ pub(crate) fn analyze(
         );
     }
 
-    if method_id.0 == StrId::SHAPES {
-        if let Some(value) = handle_shapes_static_method(
+    if method_id.0 == StrId::SHAPES
+        && let Some(value) = handle_shapes_static_method(
             &method_id,
             call_expr,
             context,
@@ -295,9 +290,9 @@ pub(crate) fn analyze(
             analysis_data,
             pos,
             codebase,
-        ) {
-            return Ok(value);
-        }
+        )
+    {
+        return Ok(value);
     }
 
     let return_type_candidate = method_call_return_type_fetcher::fetch(
@@ -346,38 +341,38 @@ fn handle_shapes_static_method(
         StrId::KEY_EXISTS => {
             if call_expr.1.len() == 2 {
                 let expr_var_id = expression_identifier::get_var_id(
-                    &call_expr.1[0].to_expr_ref(),
+                    call_expr.1[0].to_expr_ref(),
                     context.function_context.calling_class,
                     statements_analyzer.file_analyzer.resolved_names,
                     Some((statements_analyzer.codebase, statements_analyzer.interner)),
                 );
 
                 let dim_var_id = expression_identifier::get_dim_id(
-                    &call_expr.1[1].to_expr_ref(),
+                    call_expr.1[1].to_expr_ref(),
                     None,
                     &FxHashMap::default(),
                 );
 
-                if let Some(expr_var_id) = expr_var_id {
-                    if let Some(mut dim_var_id) = dim_var_id {
-                        if dim_var_id.starts_with('\'') {
-                            dim_var_id = dim_var_id[1..(dim_var_id.len() - 1)].to_string();
-                            analysis_data.if_true_assertions.insert(
-                                (pos.start_offset() as u32, pos.end_offset() as u32),
-                                FxHashMap::from_iter([(
-                                    expr_var_id,
-                                    vec![Assertion::HasArrayKey(DictKey::String(dim_var_id))],
-                                )]),
-                            );
-                        } else {
-                            analysis_data.if_true_assertions.insert(
-                                (pos.start_offset() as u32, pos.end_offset() as u32),
-                                FxHashMap::from_iter([(
-                                    format!("{}[{}]", expr_var_id, dim_var_id),
-                                    vec![Assertion::ArrayKeyExists],
-                                )]),
-                            );
-                        }
+                if let Some(expr_var_id) = expr_var_id
+                    && let Some(mut dim_var_id) = dim_var_id
+                {
+                    if dim_var_id.starts_with('\'') {
+                        dim_var_id = dim_var_id[1..(dim_var_id.len() - 1)].to_string();
+                        analysis_data.if_true_assertions.insert(
+                            (pos.start_offset() as u32, pos.end_offset() as u32),
+                            FxHashMap::from_iter([(
+                                expr_var_id,
+                                vec![Assertion::HasArrayKey(DictKey::String(dim_var_id))],
+                            )]),
+                        );
+                    } else {
+                        analysis_data.if_true_assertions.insert(
+                            (pos.start_offset() as u32, pos.end_offset() as u32),
+                            FxHashMap::from_iter([(
+                                format!("{}[{}]", expr_var_id, dim_var_id),
+                                vec![Assertion::ArrayKeyExists],
+                            )]),
+                        );
                     }
                 }
             }
@@ -386,13 +381,13 @@ fn handle_shapes_static_method(
         StrId::REMOVE_KEY => {
             if call_expr.1.len() == 2 {
                 let expr_var_id = expression_identifier::get_var_id(
-                    &call_expr.1[0].to_expr_ref(),
+                    call_expr.1[0].to_expr_ref(),
                     context.function_context.calling_class,
                     statements_analyzer.file_analyzer.resolved_names,
                     Some((statements_analyzer.codebase, statements_analyzer.interner)),
                 );
                 let dim_var_id = expression_identifier::get_dim_id(
-                    &call_expr.1[1].to_expr_ref(),
+                    call_expr.1[1].to_expr_ref(),
                     None,
                     &FxHashMap::default(),
                 );
@@ -402,45 +397,45 @@ fn handle_shapes_static_method(
                     EFFECT_WRITE_LOCAL,
                 );
 
-                if let (Some(expr_var_id), Some(dim_var_id)) = (expr_var_id, dim_var_id) {
-                    if let Some(expr_type) = context.locals.get(expr_var_id.as_str()) {
-                        let mut new_type = (**expr_type).clone();
+                if let (Some(expr_var_id), Some(dim_var_id)) = (expr_var_id, dim_var_id)
+                    && let Some(expr_type) = context.locals.get(expr_var_id.as_str())
+                {
+                    let mut new_type = (**expr_type).clone();
 
-                        let dim_var_id = dim_var_id[1..dim_var_id.len() - 1].to_string();
+                    let dim_var_id = dim_var_id[1..dim_var_id.len() - 1].to_string();
 
-                        for atomic_type in new_type.types.iter_mut() {
-                            if let TAtomic::TDict(TDict {
-                                known_items: Some(known_items),
-                                ..
-                            }) = atomic_type
-                            {
-                                known_items.remove(&DictKey::String(dim_var_id.clone()));
-                            }
+                    for atomic_type in new_type.types.iter_mut() {
+                        if let TAtomic::TDict(TDict {
+                            known_items: Some(known_items),
+                            ..
+                        }) = atomic_type
+                        {
+                            known_items.remove(&DictKey::String(dim_var_id.clone()));
                         }
-
-                        let assignment_node = DataFlowNode::get_for_lvar(
-                            VarId(statements_analyzer.interner.get(&expr_var_id).unwrap()),
-                            statements_analyzer.get_hpos(call_expr.1[0].to_expr_ref().pos()),
-                        );
-
-                        for parent_node in &expr_type.parent_nodes {
-                            analysis_data.data_flow_graph.add_path(
-                                &parent_node.id,
-                                &assignment_node.id,
-                                PathKind::RemoveDictKey(dim_var_id.clone()),
-                                vec![],
-                                vec![],
-                            );
-                        }
-
-                        new_type.parent_nodes = vec![assignment_node.clone()];
-
-                        analysis_data.data_flow_graph.add_node(assignment_node);
-
-                        context
-                            .locals
-                            .insert(VarName::new(expr_var_id), Rc::new(new_type));
                     }
+
+                    let assignment_node = DataFlowNode::get_for_lvar(
+                        VarId(statements_analyzer.interner.get(&expr_var_id).unwrap()),
+                        statements_analyzer.get_hpos(call_expr.1[0].to_expr_ref().pos()),
+                    );
+
+                    for parent_node in &expr_type.parent_nodes {
+                        analysis_data.data_flow_graph.add_path(
+                            &parent_node.id,
+                            &assignment_node.id,
+                            PathKind::RemoveDictKey(dim_var_id.clone()),
+                            vec![],
+                            vec![],
+                        );
+                    }
+
+                    new_type.parent_nodes = vec![assignment_node.clone()];
+
+                    analysis_data.data_flow_graph.add_node(assignment_node);
+
+                    context
+                        .locals
+                        .insert(VarName::new(expr_var_id), Rc::new(new_type));
                 }
             }
         }
@@ -451,7 +446,7 @@ fn handle_shapes_static_method(
                     .get_rc_expr_type(call_expr.1[0].to_expr_ref().pos())
                     .cloned();
                 let dim_var_id = expression_identifier::get_dim_id(
-                    &call_expr.1[1].to_expr_ref(),
+                    call_expr.1[1].to_expr_ref(),
                     None,
                     &FxHashMap::default(),
                 );
@@ -627,8 +622,8 @@ fn handle_shapes_static_method(
                         statements_analyzer,
                         analysis_data,
                         (
-                            &call_expr.1[0].to_expr_ref(),
-                            Some(&call_expr.1[1].to_expr_ref()),
+                            call_expr.1[0].to_expr_ref(),
+                            Some(call_expr.1[1].to_expr_ref()),
                             pos,
                         ),
                         &dict_type,
@@ -729,14 +724,14 @@ fn handle_defined_shape_idx(
     }
 
     let expr_var_id = expression_identifier::get_var_id(
-        &call_expr.1[0].to_expr_ref(),
+        call_expr.1[0].to_expr_ref(),
         context.function_context.calling_class,
         statements_analyzer.file_analyzer.resolved_names,
         Some((statements_analyzer.codebase, statements_analyzer.interner)),
     );
 
     let dim_var_id = expression_identifier::get_dim_id(
-        &call_expr.1[1].to_expr_ref(),
+        call_expr.1[1].to_expr_ref(),
         None,
         &FxHashMap::default(),
     );

--- a/src/analyzer/expr/call/expression_call_analyzer.rs
+++ b/src/analyzer/expr/call/expression_call_analyzer.rs
@@ -67,12 +67,11 @@ pub(crate) fn analyze(
 
             let mut effects = closure.effects;
 
-            if let Some(existing_storage) = existing_storage {
-                if existing_storage.has_throw {
-                    if let Some(ref mut effects) = effects {
-                        *effects |= EFFECT_CAN_THROW;
-                    }
-                }
+            if let Some(existing_storage) = existing_storage
+                && existing_storage.has_throw
+                && let Some(ref mut effects) = effects
+            {
+                *effects |= EFFECT_CAN_THROW;
             }
 
             lambda_storage.effects = FnEffect::from_u8(&effects);

--- a/src/analyzer/expr/call/function_call_analyzer.rs
+++ b/src/analyzer/expr/call/function_call_analyzer.rs
@@ -188,10 +188,9 @@ pub(crate) fn analyze(
     if let Some(effects) = analysis_data
         .expr_effects
         .get(&(pos.start_offset() as u32, pos.end_offset() as u32))
+        && effects > &EFFECT_WRITE_PROPS
     {
-        if effects > &EFFECT_WRITE_PROPS {
-            context.remove_mutable_object_vars();
-        }
+        context.remove_mutable_object_vars();
     }
 
     if function_storage.ignore_taints_if_true {
@@ -286,7 +285,7 @@ pub(crate) fn analyze(
         }
         StrId::LIB_C_IS_EMPTY => {
             let expr_var_id = expression_identifier::get_var_id(
-                &expr.2[0].to_expr_ref(),
+                expr.2[0].to_expr_ref(),
                 context.function_context.calling_class,
                 resolved_names,
                 Some((statements_analyzer.codebase, statements_analyzer.interner)),
@@ -303,7 +302,7 @@ pub(crate) fn analyze(
         | StrId::LIB_DICT_CONTAINS
         | StrId::LIB_DICT_CONTAINS_KEY => {
             let expr_var_id = expression_identifier::get_var_id(
-                &expr.2[0].to_expr_ref(),
+                expr.2[0].to_expr_ref(),
                 context.function_context.calling_class,
                 resolved_names,
                 Some((statements_analyzer.codebase, statements_analyzer.interner)),
@@ -356,7 +355,7 @@ pub(crate) fn analyze(
                         );
                     } else {
                         if let Some(dim_var_id) = expression_identifier::get_dim_id(
-                            &expr.2[1].to_expr_ref(),
+                            expr.2[1].to_expr_ref(),
                             Some((statements_analyzer.codebase, statements_analyzer.interner)),
                             resolved_names,
                         ) {
@@ -390,130 +389,119 @@ pub(crate) fn analyze(
 
             if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {
                 let second_arg_var_id = expression_identifier::get_var_id(
-                    &expr.2[1].to_expr_ref(),
+                    expr.2[1].to_expr_ref(),
                     context.function_context.calling_class,
                     resolved_names,
                     Some((statements_analyzer.codebase, statements_analyzer.interner)),
                 );
 
-                if let Some(expr_var_id) = second_arg_var_id {
-                    if let Some(expr_var_interned_id) =
+                if let Some(expr_var_id) = second_arg_var_id
+                    && let Some(expr_var_interned_id) =
                         statements_analyzer.interner.get(&expr_var_id)
+                {
+                    analysis_data.if_true_assertions.insert(
+                        (pos.start_offset() as u32, pos.end_offset() as u32),
+                        FxHashMap::from_iter([(
+                            "hakana taints".to_string(),
+                            vec![Assertion::RemoveTaints(
+                                VarId(expr_var_interned_id),
+                                SinkType::user_controllable_taints(),
+                            )],
+                        )]),
+                    );
+                }
+            }
+        }
+        StrId::LIB_STR_STARTS_WITH => {
+            if expr.2.len() == 2
+                && let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind
+            {
+                let expr_var_id = expression_identifier::get_var_id(
+                    expr.2[0].to_expr_ref(),
+                    context.function_context.calling_class,
+                    resolved_names,
+                    Some((statements_analyzer.codebase, statements_analyzer.interner)),
+                );
+
+                let second_arg_type = analysis_data.get_expr_type(expr.2[1].to_expr_ref().pos());
+
+                // if we have a HH\Lib\Str\starts_with($foo, "/something") check
+                // we can remove url-specific taints
+                if let (Some(expr_var_id), Some(second_arg_type)) = (expr_var_id, second_arg_type)
+                    && let Some(str) = second_arg_type.get_single_literal_string_value()
+                    && str.len() > 1
+                    && str != "http://"
+                    && str != "https://"
+                    && let Some(id) = statements_analyzer.interner.get(&expr_var_id)
+                {
+                    analysis_data.if_true_assertions.insert(
+                        (pos.start_offset() as u32, pos.end_offset() as u32),
+                        FxHashMap::from_iter([(
+                            "hakana taints".to_string(),
+                            vec![Assertion::RemoveTaints(
+                                VarId(id),
+                                vec![
+                                    SinkType::HtmlAttributeUri,
+                                    SinkType::CurlUri,
+                                    SinkType::RedirectUri,
+                                ],
+                            )],
+                        )]),
+                    );
+                }
+            }
+        }
+        StrId::LIB_REGEX_MATCHES => {
+            if expr.2.len() == 2
+                && let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind
+            {
+                let expr_var_id = expression_identifier::get_var_id(
+                    expr.2[0].to_expr_ref(),
+                    context.function_context.calling_class,
+                    resolved_names,
+                    Some((statements_analyzer.codebase, statements_analyzer.interner)),
+                );
+
+                let second_arg_type = analysis_data.get_expr_type(expr.2[1].to_expr_ref().pos());
+
+                // if we have a HH\Lib\Str\starts_with($foo, "/something") check
+                // we can remove url-specific taints
+                if let (Some(expr_var_id), Some(second_arg_type)) = (expr_var_id, second_arg_type)
+                    && let Some(str) = second_arg_type.get_single_literal_string_value()
+                {
+                    let mut hashes_to_remove = vec![];
+
+                    if str.starts_with('^')
+                        && str != "^http:\\/\\/"
+                        && str != "^https:\\/\\/"
+                        && str != "^https?:\\/\\/"
+                    {
+                        hashes_to_remove.extend([
+                            SinkType::HtmlAttributeUri,
+                            SinkType::CurlUri,
+                            SinkType::RedirectUri,
+                        ]);
+
+                        if str.ends_with('$') && !str.contains(".*") && !str.contains(".+") {
+                            hashes_to_remove.extend([
+                                SinkType::HtmlTag,
+                                SinkType::CurlHeader,
+                                SinkType::CurlUri,
+                                SinkType::HtmlAttribute,
+                            ]);
+                        }
+                    }
+
+                    if !hashes_to_remove.is_empty()
+                        && let Some(id) = statements_analyzer.interner.get(&expr_var_id)
                     {
                         analysis_data.if_true_assertions.insert(
                             (pos.start_offset() as u32, pos.end_offset() as u32),
                             FxHashMap::from_iter([(
                                 "hakana taints".to_string(),
-                                vec![Assertion::RemoveTaints(
-                                    VarId(expr_var_interned_id),
-                                    SinkType::user_controllable_taints(),
-                                )],
+                                vec![Assertion::RemoveTaints(VarId(id), hashes_to_remove)],
                             )]),
                         );
-                    }
-                }
-            }
-        }
-        StrId::LIB_STR_STARTS_WITH => {
-            if expr.2.len() == 2 {
-                if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {
-                    let expr_var_id = expression_identifier::get_var_id(
-                        &expr.2[0].to_expr_ref(),
-                        context.function_context.calling_class,
-                        resolved_names,
-                        Some((statements_analyzer.codebase, statements_analyzer.interner)),
-                    );
-
-                    let second_arg_type =
-                        analysis_data.get_expr_type(expr.2[1].to_expr_ref().pos());
-
-                    // if we have a HH\Lib\Str\starts_with($foo, "/something") check
-                    // we can remove url-specific taints
-                    if let (Some(expr_var_id), Some(second_arg_type)) =
-                        (expr_var_id, second_arg_type)
-                    {
-                        if let Some(str) = second_arg_type.get_single_literal_string_value() {
-                            if str.len() > 1 && str != "http://" && str != "https://" {
-                                if let Some(id) = statements_analyzer.interner.get(&expr_var_id) {
-                                    analysis_data.if_true_assertions.insert(
-                                        (pos.start_offset() as u32, pos.end_offset() as u32),
-                                        FxHashMap::from_iter([(
-                                            "hakana taints".to_string(),
-                                            vec![Assertion::RemoveTaints(
-                                                VarId(id),
-                                                vec![
-                                                    SinkType::HtmlAttributeUri,
-                                                    SinkType::CurlUri,
-                                                    SinkType::RedirectUri,
-                                                ],
-                                            )],
-                                        )]),
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        StrId::LIB_REGEX_MATCHES => {
-            if expr.2.len() == 2 {
-                if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {
-                    let expr_var_id = expression_identifier::get_var_id(
-                        &expr.2[0].to_expr_ref(),
-                        context.function_context.calling_class,
-                        resolved_names,
-                        Some((statements_analyzer.codebase, statements_analyzer.interner)),
-                    );
-
-                    let second_arg_type =
-                        analysis_data.get_expr_type(expr.2[1].to_expr_ref().pos());
-
-                    // if we have a HH\Lib\Str\starts_with($foo, "/something") check
-                    // we can remove url-specific taints
-                    if let (Some(expr_var_id), Some(second_arg_type)) =
-                        (expr_var_id, second_arg_type)
-                    {
-                        if let Some(str) = second_arg_type.get_single_literal_string_value() {
-                            let mut hashes_to_remove = vec![];
-
-                            if str.starts_with('^')
-                                && str != "^http:\\/\\/"
-                                && str != "^https:\\/\\/"
-                                && str != "^https?:\\/\\/"
-                            {
-                                hashes_to_remove.extend([
-                                    SinkType::HtmlAttributeUri,
-                                    SinkType::CurlUri,
-                                    SinkType::RedirectUri,
-                                ]);
-
-                                if str.ends_with('$') && !str.contains(".*") && !str.contains(".+")
-                                {
-                                    hashes_to_remove.extend([
-                                        SinkType::HtmlTag,
-                                        SinkType::CurlHeader,
-                                        SinkType::CurlUri,
-                                        SinkType::HtmlAttribute,
-                                    ]);
-                                }
-                            }
-
-                            if !hashes_to_remove.is_empty() {
-                                if let Some(id) = statements_analyzer.interner.get(&expr_var_id) {
-                                    analysis_data.if_true_assertions.insert(
-                                        (pos.start_offset() as u32, pos.end_offset() as u32),
-                                        FxHashMap::from_iter([(
-                                            "hakana taints".to_string(),
-                                            vec![Assertion::RemoveTaints(
-                                                VarId(id),
-                                                hashes_to_remove,
-                                            )],
-                                        )]),
-                                    );
-                                }
-                            }
-                        }
                     }
                 }
             }
@@ -698,46 +686,46 @@ fn check_array_key_or_value_type(
     if let Some(container_type) = container_type {
         for atomic_type in &container_type.types {
             let arrayish_params = get_arrayish_params(atomic_type, codebase);
-            if let Some(ref arg_type) = arg_type {
-                if let Some((params_key, param_value)) = arrayish_params {
-                    let param = if is_key { params_key } else { param_value };
+            if let Some(ref arg_type) = arg_type
+                && let Some((params_key, param_value)) = arrayish_params
+            {
+                let param = if is_key { params_key } else { param_value };
 
-                    let offset_type_contained_by_expected =
-                        union_type_comparator::can_expression_types_be_identical(
-                            codebase,
-                            statements_analyzer.get_file_path(),
-                            arg_type,
-                            &param.clone(),
-                            true,
-                        );
+                let offset_type_contained_by_expected =
+                    union_type_comparator::can_expression_types_be_identical(
+                        codebase,
+                        statements_analyzer.get_file_path(),
+                        arg_type,
+                        &param.clone(),
+                        true,
+                    );
 
-                    if offset_type_contained_by_expected {
-                        has_valid_container_type = true;
-                    } else {
-                        error_message = Some(format!(
-                            "Second arg of {} expects type {}, saw {}",
-                            statements_analyzer.interner.lookup(&function_name),
-                            param.get_id(Some(statements_analyzer.interner)),
-                            arg_type.get_id(Some(statements_analyzer.interner))
-                        ));
-                    }
-                };
-            }
+                if offset_type_contained_by_expected {
+                    has_valid_container_type = true;
+                } else {
+                    error_message = Some(format!(
+                        "Second arg of {} expects type {}, saw {}",
+                        statements_analyzer.interner.lookup(&function_name),
+                        param.get_id(Some(statements_analyzer.interner)),
+                        arg_type.get_id(Some(statements_analyzer.interner))
+                    ));
+                }
+            };
         }
 
-        if let Some(error_message) = error_message {
-            if !has_valid_container_type {
-                analysis_data.maybe_add_issue(
-                    Issue::new(
-                        IssueKind::InvalidContainsCheck,
-                        error_message,
-                        statements_analyzer.get_hpos(pos),
-                        calling_functionlike_id,
-                    ),
-                    statements_analyzer.get_config(),
-                    statements_analyzer.get_file_path_actual(),
-                );
-            }
+        if let Some(error_message) = error_message
+            && !has_valid_container_type
+        {
+            analysis_data.maybe_add_issue(
+                Issue::new(
+                    IssueKind::InvalidContainsCheck,
+                    error_message,
+                    statements_analyzer.get_hpos(pos),
+                    calling_functionlike_id,
+                ),
+                statements_analyzer.get_config(),
+                statements_analyzer.get_file_path_actual(),
+            );
         }
     }
 }
@@ -866,21 +854,19 @@ fn get_async_version_name(
         FunctionLikeIdentifier::Method(mut class_name, method_name) => Some({
             // When autofixing instance method calls, we need to preserve the original LHS expression
             // that the method is being invoked on, so only return the target method name.
-            if let Some(_) = lhs_expr {
-                if localize_string {
-                    return Some(interner.lookup(&method_name).into());
-                }
+            if lhs_expr.is_some() && localize_string {
+                return Some(interner.lookup(&method_name).into());
             }
 
             let mut is_local = false;
 
-            if let FunctionLikeIdentifier::Method(existing_class_name, _) = functionlike_id {
-                if class_name == StrId::SELF || class_name == StrId::STATIC {
-                    if context.function_context.calling_class != Some(existing_class_name) {
-                        class_name = existing_class_name;
-                    } else {
-                        is_local = true;
-                    }
+            if let FunctionLikeIdentifier::Method(existing_class_name, _) = functionlike_id
+                && (class_name == StrId::SELF || class_name == StrId::STATIC)
+            {
+                if context.function_context.calling_class != Some(existing_class_name) {
+                    class_name = existing_class_name;
+                } else {
+                    is_local = true;
                 }
             }
 
@@ -942,11 +928,11 @@ fn can_call_async_version(
                 let calling_class = context.function_context.calling_class;
 
                 match method_info.visibility {
-                    MemberVisibility::Private => calling_class.map(|cls| cls.eq(&declaring_class)),
+                    MemberVisibility::Private => calling_class.map(|cls| cls.eq(declaring_class)),
                     MemberVisibility::Protected => calling_class.map(|cls| {
                         statements_analyzer
                             .codebase
-                            .class_extends_or_implements(&cls, &declaring_class)
+                            .class_extends_or_implements(&cls, declaring_class)
                     }),
                     MemberVisibility::Public => Some(true),
                 }

--- a/src/analyzer/expr/call/function_call_return_type_fetcher.rs
+++ b/src/analyzer/expr/call/function_call_return_type_fetcher.rs
@@ -63,8 +63,8 @@ pub(crate) fn fetch(
         .map(|info| &info.where_constraints)
         .filter(|c| !c.is_empty());
 
-    if let FunctionLikeIdentifier::Function(name) = functionlike_id {
-        if let Some(t) = handle_special_functions(
+    if let FunctionLikeIdentifier::Function(name) = functionlike_id
+        && let Some(t) = handle_special_functions(
             statements_analyzer,
             name,
             expr.2,
@@ -72,9 +72,9 @@ pub(crate) fn fetch(
             codebase,
             analysis_data,
             context,
-        ) {
-            stmt_type = Some(t);
-        }
+        )
+    {
+        stmt_type = Some(t);
     }
 
     // todo support custom return type providers for functions
@@ -621,12 +621,12 @@ fn handle_special_functions(
                     .get_rc_expr_type(args[0].to_expr_ref().pos())
                     .cloned();
 
-                if let Some(file_type) = file_type {
-                    if let Some(literal_value) = file_type.get_single_literal_string_value() {
-                        let path = Path::new(&literal_value);
-                        if let Some(dir) = path.parent() {
-                            return Some(get_literal_string(dir.to_str().unwrap().to_owned()));
-                        }
+                if let Some(file_type) = file_type
+                    && let Some(literal_value) = file_type.get_single_literal_string_value()
+                {
+                    let path = Path::new(&literal_value);
+                    if let Some(dir) = path.parent() {
+                        return Some(get_literal_string(dir.to_str().unwrap().to_owned()));
                     }
                 }
             }
@@ -780,7 +780,7 @@ fn handle_str_format(
     for (i, literal) in literals.iter().enumerate() {
         concat_args.push(literal);
         if let Some(arg) = args.get(i + 1) {
-            concat_args.push(&arg.to_expr_ref());
+            concat_args.push(arg.to_expr_ref());
         } else {
             break;
         }
@@ -844,19 +844,18 @@ fn get_type_structure_type(
 
             if let Some(classlike_info) =
                 statements_analyzer.codebase.classlike_infos.get(&classname)
+                && let Some(type_constant_info) = classlike_info.type_constants.get(&const_name)
             {
-                if let Some(type_constant_info) = classlike_info.type_constants.get(&const_name) {
-                    return Some(wrap_atomic(TAtomic::TTypeAlias {
-                        name: StrId::TYPE_STRUCTURE,
-                        type_params: Some(vec![match type_constant_info {
-                            ClassConstantType::Concrete(actual_type) => actual_type.clone(),
-                            ClassConstantType::Abstract(Some(as_type)) => as_type.clone(),
-                            _ => get_mixed_any(),
-                        }]),
-                        as_type: None,
-                        newtype: true,
-                    }));
-                }
+                return Some(wrap_atomic(TAtomic::TTypeAlias {
+                    name: StrId::TYPE_STRUCTURE,
+                    type_params: Some(vec![match type_constant_info {
+                        ClassConstantType::Concrete(actual_type) => actual_type.clone(),
+                        ClassConstantType::Abstract(Some(as_type)) => as_type.clone(),
+                        _ => get_mixed_any(),
+                    }]),
+                    as_type: None,
+                    newtype: true,
+                }));
             }
         }
     }
@@ -891,10 +890,10 @@ fn add_dataflow(
 
     let data_flow_graph = &mut analysis_data.data_flow_graph;
 
-    if let GraphKind::WholeProgram(_) = &data_flow_graph.kind {
-        if !context.allow_taints {
-            return stmt_type;
-        }
+    if let GraphKind::WholeProgram(_) = &data_flow_graph.kind
+        && !context.allow_taints
+    {
+        return stmt_type;
     }
 
     let mut stmt_type = stmt_type;
@@ -992,37 +991,37 @@ fn add_dataflow(
     }
 
     for (param_offset, param) in functionlike_storage.params.iter().enumerate() {
-        if param.propagate_taint {
-            if let Some(arg) = expr.2.get(param_offset) {
-                let arg_pos = statements_analyzer.get_hpos(arg.to_expr_ref().pos());
+        if param.propagate_taint
+            && let Some(arg) = expr.2.get(param_offset)
+        {
+            let arg_pos = statements_analyzer.get_hpos(arg.to_expr_ref().pos());
 
-                add_special_param_dataflow(
-                    statements_analyzer,
-                    functionlike_id,
-                    functionlike_storage.specialize_call,
-                    param_offset,
-                    arg_pos,
-                    pos,
-                    &added_removed_taints,
-                    data_flow_graph,
-                    &function_call_node,
-                    PathKind::Default,
-                );
-            }
+            add_special_param_dataflow(
+                statements_analyzer,
+                functionlike_id,
+                functionlike_storage.specialize_call,
+                param_offset,
+                arg_pos,
+                pos,
+                &added_removed_taints,
+                data_flow_graph,
+                &function_call_node,
+                PathKind::Default,
+            );
         }
     }
 
-    if let GraphKind::WholeProgram(_) = &data_flow_graph.kind {
-        if !functionlike_storage.taint_source_types.is_empty() {
-            let function_call_node_source = DataFlowNode {
-                id: function_call_node.id.clone(),
-                kind: DataFlowNodeKind::TaintSource {
-                    pos: function_call_node.get_pos(),
-                    types: functionlike_storage.taint_source_types.clone(),
-                },
-            };
-            data_flow_graph.add_node(function_call_node_source);
-        }
+    if let GraphKind::WholeProgram(_) = &data_flow_graph.kind
+        && !functionlike_storage.taint_source_types.is_empty()
+    {
+        let function_call_node_source = DataFlowNode {
+            id: function_call_node.id.clone(),
+            kind: DataFlowNodeKind::TaintSource {
+                pos: function_call_node.get_pos(),
+                types: functionlike_storage.taint_source_types.clone(),
+            },
+        };
+        data_flow_graph.add_node(function_call_node_source);
     }
 
     stmt_type.parent_nodes.push(function_call_node);
@@ -1602,22 +1601,19 @@ fn get_special_argument_nodes(
                 None,
             ),
             StrId::IDX_FN => {
-                if let Some(second_arg) = expr.2.get(1) {
-                    if let aast::Expr_::String(str) = &second_arg.to_expr_ref().2 {
-                        return (
-                            vec![
-                                (
-                                    0,
-                                    PathKind::ArrayFetch(
-                                        ArrayDataKind::ArrayValue,
-                                        str.to_string(),
-                                    ),
-                                ),
-                                (1, PathKind::Aggregate),
-                            ],
-                            None,
-                        );
-                    }
+                if let Some(second_arg) = expr.2.get(1)
+                    && let aast::Expr_::String(str) = &second_arg.to_expr_ref().2
+                {
+                    return (
+                        vec![
+                            (
+                                0,
+                                PathKind::ArrayFetch(ArrayDataKind::ArrayValue, str.to_string()),
+                            ),
+                            (1, PathKind::Aggregate),
+                        ],
+                        None,
+                    );
                 }
                 (
                     vec![

--- a/src/analyzer/expr/call/method_call_return_type_fetcher.rs
+++ b/src/analyzer/expr/call/method_call_return_type_fetcher.rs
@@ -210,14 +210,13 @@ fn get_special_method_return(method_id: &MethodIdentifier, interner: &Interner) 
             }
             _ => {}
         },
-        StrId::MESSAGE_FORMATTER => match method_id.1 {
-            StrId::FORMAT_MESSAGE => {
+        StrId::MESSAGE_FORMATTER => {
+            if method_id.1 == StrId::FORMAT_MESSAGE {
                 let mut u = TUnion::new(vec![TAtomic::TString, TAtomic::TFalse]);
                 u.ignore_falsable_issues = true;
                 return Some(u);
             }
-            _ => {}
-        },
+        }
         _ => {}
     }
 
@@ -246,10 +245,10 @@ fn add_dataflow(
     let added_taints = vec![];
     let removed_taints = vec![];
 
-    if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {
-        if !context.allow_taints {
-            return return_type_candidate;
-        }
+    if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind
+        && !context.allow_taints
+    {
+        return return_type_candidate;
     }
 
     let codebase = statements_analyzer.codebase;
@@ -282,40 +281,40 @@ fn add_dataflow(
             },
         );
 
-        if let Some(lhs_expr) = lhs_expr {
-            if let Some(expr_type) = analysis_data.expr_types.get(&(
+        if let Some(lhs_expr) = lhs_expr
+            && let Some(expr_type) = analysis_data.expr_types.get(&(
                 lhs_expr.pos().start_offset() as u32,
                 lhs_expr.pos().end_offset() as u32,
-            )) {
-                let lhs_expr_parent_nodes = &expr_type.parent_nodes;
+            ))
+        {
+            let lhs_expr_parent_nodes = &expr_type.parent_nodes;
 
-                if matches!(functionlike_storage.effects, FnEffect::Pure) {
-                    for parent_node in lhs_expr_parent_nodes {
-                        analysis_data.data_flow_graph.add_path(
-                            &parent_node.id,
-                            &method_call_node.id,
-                            PathKind::Default,
-                            vec![],
-                            vec![],
-                        );
-                    }
-                } else {
-                    let sink_node = DataFlowNode::get_for_unlabelled_sink(
-                        statements_analyzer.get_hpos(lhs_expr.pos()),
+            if matches!(functionlike_storage.effects, FnEffect::Pure) {
+                for parent_node in lhs_expr_parent_nodes {
+                    analysis_data.data_flow_graph.add_path(
+                        &parent_node.id,
+                        &method_call_node.id,
+                        PathKind::Default,
+                        vec![],
+                        vec![],
                     );
-
-                    for parent_node in lhs_expr_parent_nodes {
-                        analysis_data.data_flow_graph.add_path(
-                            &parent_node.id,
-                            &sink_node.id,
-                            PathKind::Default,
-                            vec![],
-                            vec![],
-                        );
-                    }
-
-                    analysis_data.data_flow_graph.add_node(sink_node);
                 }
+            } else {
+                let sink_node = DataFlowNode::get_for_unlabelled_sink(
+                    statements_analyzer.get_hpos(lhs_expr.pos()),
+                );
+
+                for parent_node in lhs_expr_parent_nodes {
+                    analysis_data.data_flow_graph.add_path(
+                        &parent_node.id,
+                        &sink_node.id,
+                        PathKind::Default,
+                        vec![],
+                        vec![],
+                    );
+                }
+
+                analysis_data.data_flow_graph.add_node(sink_node);
             }
         }
     }
@@ -375,23 +374,23 @@ fn add_dataflow(
     }
 
     for (param_offset, param) in functionlike_storage.params.iter().enumerate() {
-        if param.propagate_taint {
-            if let Some(arg) = call_expr.1.get(param_offset) {
-                let arg_pos = statements_analyzer.get_hpos(arg.to_expr_ref().pos());
+        if param.propagate_taint
+            && let Some(arg) = call_expr.1.get(param_offset)
+        {
+            let arg_pos = statements_analyzer.get_hpos(arg.to_expr_ref().pos());
 
-                add_special_param_dataflow(
-                    statements_analyzer,
-                    &FunctionLikeIdentifier::Method(method_id.0, method_id.1),
-                    functionlike_storage.specialize_call,
-                    param_offset,
-                    arg_pos,
-                    call_pos,
-                    &FxHashMap::default(),
-                    &mut analysis_data.data_flow_graph,
-                    &method_call_node,
-                    PathKind::Default,
-                );
-            }
+            add_special_param_dataflow(
+                statements_analyzer,
+                &FunctionLikeIdentifier::Method(method_id.0, method_id.1),
+                functionlike_storage.specialize_call,
+                param_offset,
+                arg_pos,
+                call_pos,
+                &FxHashMap::default(),
+                &mut analysis_data.data_flow_graph,
+                &method_call_node,
+                PathKind::Default,
+            );
         }
     }
 
@@ -488,111 +487,108 @@ fn get_tainted_method_node(
         }
     }
 
-    if method_id.1 == StrId::CONSTRUCT {
-        if let Some(var_type) = context.locals.get_mut("$this") {
-            let before_construct_node = DataFlowNode::get_for_this_before_method(
-                method_id,
-                functionlike_storage.return_type_location,
-                Some(statements_analyzer.get_hpos(call_pos)),
-            );
+    if method_id.1 == StrId::CONSTRUCT
+        && let Some(var_type) = context.locals.get_mut("$this")
+    {
+        let before_construct_node = DataFlowNode::get_for_this_before_method(
+            method_id,
+            functionlike_storage.return_type_location,
+            Some(statements_analyzer.get_hpos(call_pos)),
+        );
 
-            for this_parent_node in &var_type.parent_nodes {
-                data_flow_graph.add_path(
-                    &this_parent_node.id,
-                    &before_construct_node.id,
-                    PathKind::Default,
-                    vec![],
-                    vec![],
-                )
-            }
-
-            data_flow_graph.add_node(before_construct_node);
-
-            let after_construct_node = DataFlowNode::get_for_this_after_method(
-                method_id,
-                functionlike_storage.return_type_location,
-                Some(statements_analyzer.get_hpos(call_pos)),
-            );
-
-            let mut var_type_inner = (**var_type).clone();
-
-            var_type_inner.parent_nodes = vec![after_construct_node.clone()];
-
-            data_flow_graph.add_node(after_construct_node);
-
-            *var_type = Rc::new(var_type_inner);
+        for this_parent_node in &var_type.parent_nodes {
+            data_flow_graph.add_path(
+                &this_parent_node.id,
+                &before_construct_node.id,
+                PathKind::Default,
+                vec![],
+                vec![],
+            )
         }
+
+        data_flow_graph.add_node(before_construct_node);
+
+        let after_construct_node = DataFlowNode::get_for_this_after_method(
+            method_id,
+            functionlike_storage.return_type_location,
+            Some(statements_analyzer.get_hpos(call_pos)),
+        );
+
+        let mut var_type_inner = (**var_type).clone();
+
+        var_type_inner.parent_nodes = vec![after_construct_node.clone()];
+
+        data_flow_graph.add_node(after_construct_node);
+
+        *var_type = Rc::new(var_type_inner);
     }
 
-    if let (Some(lhs_expr), Some(lhs_var_id)) = (lhs_expr, lhs_var_id) {
-        if functionlike_storage.specialize_call {
-            if let Some(context_type) = &analysis_data
-                .expr_types
-                .get(&(
-                    lhs_expr.pos().start_offset() as u32,
-                    lhs_expr.pos().end_offset() as u32,
-                ))
-                .cloned()
-            {
-                let lhs_var_expr_id = get_expr_id(lhs_expr, statements_analyzer);
+    if let (Some(lhs_expr), Some(lhs_var_id)) = (lhs_expr, lhs_var_id)
+        && functionlike_storage.specialize_call
+        && let Some(context_type) = &analysis_data
+            .expr_types
+            .get(&(
+                lhs_expr.pos().start_offset() as u32,
+                lhs_expr.pos().end_offset() as u32,
+            ))
+            .cloned()
+    {
+        let lhs_var_expr_id = get_expr_id(lhs_expr, statements_analyzer);
 
-                let var_node = match lhs_var_expr_id {
-                    Some(ExprId::Var(id)) => DataFlowNode::get_for_lvar(
-                        VarId(id),
-                        statements_analyzer.get_hpos(lhs_expr.pos()),
-                    ),
-                    Some(ExprId::InstanceProperty(lhs_expr, name_pos, rhs_expr)) => {
-                        DataFlowNode::get_for_local_property_fetch(lhs_expr, rhs_expr, name_pos)
-                    }
-                    None => DataFlowNode::get_for_instance_method_call(
-                        statements_analyzer.get_hpos(lhs_expr.pos()),
-                    ),
-                };
-
-                let this_before_method_node = DataFlowNode::get_for_this_before_method(
-                    declaring_method_id,
-                    functionlike_storage.name_location,
-                    Some(statements_analyzer.get_hpos(call_pos)),
-                );
-
-                for parent_node in &context_type.parent_nodes {
-                    data_flow_graph.add_path(
-                        &parent_node.id,
-                        &this_before_method_node.id,
-                        PathKind::Default,
-                        vec![],
-                        vec![],
-                    );
-                }
-
-                let this_after_method_node = DataFlowNode::get_for_this_after_method(
-                    declaring_method_id,
-                    functionlike_storage.name_location,
-                    Some(statements_analyzer.get_hpos(call_pos)),
-                );
-
-                data_flow_graph.add_path(
-                    &this_after_method_node.id,
-                    &var_node.id,
-                    PathKind::Default,
-                    vec![],
-                    vec![],
-                );
-
-                let mut context_type_inner = (**context_type).clone();
-
-                context_type_inner.parent_nodes = vec![var_node.clone()];
-
-                context.locals.insert(
-                    VarName::new(lhs_var_id.clone()),
-                    Rc::new(context_type_inner),
-                );
-
-                data_flow_graph.add_node(var_node);
-                data_flow_graph.add_node(this_before_method_node);
-                data_flow_graph.add_node(this_after_method_node);
+        let var_node = match lhs_var_expr_id {
+            Some(ExprId::Var(id)) => {
+                DataFlowNode::get_for_lvar(VarId(id), statements_analyzer.get_hpos(lhs_expr.pos()))
             }
+            Some(ExprId::InstanceProperty(lhs_expr, name_pos, rhs_expr)) => {
+                DataFlowNode::get_for_local_property_fetch(lhs_expr, rhs_expr, name_pos)
+            }
+            None => DataFlowNode::get_for_instance_method_call(
+                statements_analyzer.get_hpos(lhs_expr.pos()),
+            ),
+        };
+
+        let this_before_method_node = DataFlowNode::get_for_this_before_method(
+            declaring_method_id,
+            functionlike_storage.name_location,
+            Some(statements_analyzer.get_hpos(call_pos)),
+        );
+
+        for parent_node in &context_type.parent_nodes {
+            data_flow_graph.add_path(
+                &parent_node.id,
+                &this_before_method_node.id,
+                PathKind::Default,
+                vec![],
+                vec![],
+            );
         }
+
+        let this_after_method_node = DataFlowNode::get_for_this_after_method(
+            declaring_method_id,
+            functionlike_storage.name_location,
+            Some(statements_analyzer.get_hpos(call_pos)),
+        );
+
+        data_flow_graph.add_path(
+            &this_after_method_node.id,
+            &var_node.id,
+            PathKind::Default,
+            vec![],
+            vec![],
+        );
+
+        let mut context_type_inner = (**context_type).clone();
+
+        context_type_inner.parent_nodes = vec![var_node.clone()];
+
+        context.locals.insert(
+            VarName::new(lhs_var_id.clone()),
+            Rc::new(context_type_inner),
+        );
+
+        data_flow_graph.add_node(var_node);
+        data_flow_graph.add_node(this_before_method_node);
+        data_flow_graph.add_node(this_after_method_node);
     }
 
     if !functionlike_storage.taint_source_types.is_empty() {

--- a/src/analyzer/expr/call/new_analyzer.rs
+++ b/src/analyzer/expr/call/new_analyzer.rs
@@ -425,15 +425,7 @@ fn analyze_named_constructor(
             analysis_data,
             &method_id,
             method_storage,
-            (
-                expr.1,
-                &expr
-                    .2
-                    .iter()
-                    .map(|arg_expr| arg_expr.clone())
-                    .collect::<Vec<_>>(),
-                expr.3,
-            ),
+            (expr.1, &expr.2.to_vec(), expr.3),
             None,
             &mut template_result,
             context,
@@ -464,60 +456,58 @@ fn analyze_named_constructor(
                 };
 
                 if param_type.is_placeholder() {
-                    if !storage.template_readonly.contains(template_name) {
-                        if let Some((template_name, map)) =
+                    if !storage.template_readonly.contains(template_name)
+                        && let Some((template_name, map)) =
                             template_result.template_types.get_index(i)
+                    {
+                        let placeholder_name =
+                            format!("`_{}", analysis_data.type_variable_bounds.len());
+
+                        let upper_bound = (*map.iter().next().unwrap().1).clone();
+
+                        let mut placeholder_lower_bounds = vec![];
+
+                        if let Some(bounds) = template_result.lower_bounds.get(template_name)
+                            && let Some(bounds) =
+                                bounds.get(&GenericParent::ClassLike(classlike_name))
                         {
-                            let placeholder_name =
-                                format!("`_{}", analysis_data.type_variable_bounds.len());
-
-                            let upper_bound = (*map.iter().next().unwrap().1).clone();
-
-                            let mut placeholder_lower_bounds = vec![];
-
-                            if let Some(bounds) = template_result.lower_bounds.get(template_name) {
-                                if let Some(bounds) =
-                                    bounds.get(&GenericParent::ClassLike(classlike_name))
-                                {
-                                    for bound in bounds {
-                                        placeholder_lower_bounds.push(bound.clone());
-                                    }
-                                }
+                            for bound in bounds {
+                                placeholder_lower_bounds.push(bound.clone());
                             }
-
-                            analysis_data.type_variable_bounds.insert(
-                                placeholder_name.clone(),
-                                TypeVariableBounds {
-                                    lower_bounds: placeholder_lower_bounds,
-                                    upper_bounds: vec![TemplateBound {
-                                        bound_type: upper_bound,
-                                        appearance_depth: 0,
-                                        arg_offset: None,
-                                        equality_bound_classlike: None,
-                                        pos: Some(statements_analyzer.get_hpos(pos)),
-                                    }],
-                                },
-                            );
-
-                            template_result.lower_bounds.insert(
-                                *template_name,
-                                map.iter()
-                                    .map(|(entity, _)| {
-                                        (
-                                            *entity,
-                                            vec![TemplateBound::new(
-                                                wrap_atomic(TAtomic::TTypeVariable {
-                                                    name: placeholder_name.clone(),
-                                                }),
-                                                0,
-                                                None,
-                                                None,
-                                            )],
-                                        )
-                                    })
-                                    .collect::<FxHashMap<_, _>>(),
-                            );
                         }
+
+                        analysis_data.type_variable_bounds.insert(
+                            placeholder_name.clone(),
+                            TypeVariableBounds {
+                                lower_bounds: placeholder_lower_bounds,
+                                upper_bounds: vec![TemplateBound {
+                                    bound_type: upper_bound,
+                                    appearance_depth: 0,
+                                    arg_offset: None,
+                                    equality_bound_classlike: None,
+                                    pos: Some(statements_analyzer.get_hpos(pos)),
+                                }],
+                            },
+                        );
+
+                        template_result.lower_bounds.insert(
+                            *template_name,
+                            map.iter()
+                                .map(|(entity, _)| {
+                                    (
+                                        *entity,
+                                        vec![TemplateBound::new(
+                                            wrap_atomic(TAtomic::TTypeVariable {
+                                                name: placeholder_name.clone(),
+                                            }),
+                                            0,
+                                            None,
+                                            None,
+                                        )],
+                                    )
+                                })
+                                .collect::<FxHashMap<_, _>>(),
+                        );
                     }
                 } else {
                     populate_union_type(

--- a/src/analyzer/expr/call/static_call_analyzer.rs
+++ b/src/analyzer/expr/call/static_call_analyzer.rs
@@ -64,27 +64,19 @@ fn resolve_id(
 
             *classlike_name = Some(parent_name);
 
-            let type_params = if let Some(type_params) = classlike_storage
+            let type_params = classlike_storage
                 .template_extended_offsets
                 .get(&parent_name)
-            {
-                Some(
+                .map(|type_params| {
                     type_params
                         .iter()
-                        .map(|t| {
-                            let t = (**t).clone();
-
-                            t
-                        })
-                        .collect::<Vec<_>>(),
-                )
-            } else {
-                None
-            };
+                        .map(|t| (**t).clone())
+                        .collect::<Vec<_>>()
+                });
 
             wrap_atomic(TAtomic::TNamedObject(TNamedObject {
                 name: *self_name,
-                type_params: type_params,
+                type_params,
                 is_this: !classlike_storage.is_final,
                 remapped_params: false,
             }))

--- a/src/analyzer/expr/call_analyzer.rs
+++ b/src/analyzer/expr/call_analyzer.rs
@@ -345,17 +345,15 @@ pub(crate) fn get_generic_param_for_offset(
                         defining_entity,
                         ..
                     }) = &extended_atomic_type
+                        && extended_param_name == template_name
+                        && defining_entity == &GenericParent::ClassLike(*classlike_name)
                     {
-                        if extended_param_name == template_name
-                            && defining_entity == &GenericParent::ClassLike(*classlike_name)
-                        {
-                            return get_generic_param_for_offset(
-                                extended_class_name,
-                                extended_template_name,
-                                template_extended_params,
-                                found_generic_params,
-                            );
-                        }
+                        return get_generic_param_for_offset(
+                            extended_class_name,
+                            extended_template_name,
+                            template_extended_params,
+                            found_generic_params,
+                        );
                     }
                 }
             }

--- a/src/analyzer/expr/collection_analyzer.rs
+++ b/src/analyzer/expr/collection_analyzer.rs
@@ -119,10 +119,9 @@ pub(crate) fn analyze_vals(
                         value: key_literal_value,
                         ..
                     } = key_type
+                        && (offset as i64) == key_literal_value
                     {
-                        if (offset as i64) == key_literal_value {
-                            known_items.insert(offset, (false, value_type));
-                        }
+                        known_items.insert(offset, (false, value_type));
                     }
                 }
             }

--- a/src/analyzer/expr/expression_identifier.rs
+++ b/src/analyzer/expr/expression_identifier.rs
@@ -25,14 +25,12 @@ pub fn get_var_id(
     match &conditional.2 {
         aast::Expr_::Lvar(var_expr) => Some(var_expr.1.1.clone()),
         aast::Expr_::ObjGet(boxed) => {
-            if let ast_defs::PropOrMethod::IsProp = boxed.3 {
-                if let Some(base_id) =
+            if let ast_defs::PropOrMethod::IsProp = boxed.3
+                && let Some(base_id) =
                     get_var_id(&boxed.0, this_class_name, resolved_names, codebase)
-                {
-                    if let aast::Expr_::Id(boxed) = &boxed.1.2 {
-                        return Some(format!("{}->{}", base_id, boxed.1));
-                    }
-                }
+                && let aast::Expr_::Id(boxed) = &boxed.1.2
+            {
+                return Some(format!("{}->{}", base_id, boxed.1));
             }
 
             None
@@ -88,18 +86,18 @@ pub fn get_var_id(
             None
         }
         aast::Expr_::ArrayGet(boxed) => {
-            if let Some(base_id) = get_var_id(&boxed.0, this_class_name, resolved_names, codebase) {
-                if let Some(dim) = &boxed.1 {
-                    if let Some(dim_id) = get_dim_id(dim, codebase, resolved_names) {
-                        return Some(format!("{}[{}]", base_id, dim_id));
-                    } else if let Some(dim_id) =
-                        get_var_id(dim, this_class_name, resolved_names, codebase)
-                    {
-                        if dim_id.contains('\'') {
-                            return None;
-                        }
-                        return Some(format!("{}[{}]", base_id, dim_id));
+            if let Some(base_id) = get_var_id(&boxed.0, this_class_name, resolved_names, codebase)
+                && let Some(dim) = &boxed.1
+            {
+                if let Some(dim_id) = get_dim_id(dim, codebase, resolved_names) {
+                    return Some(format!("{}[{}]", base_id, dim_id));
+                } else if let Some(dim_id) =
+                    get_var_id(dim, this_class_name, resolved_names, codebase)
+                {
+                    if dim_id.contains('\'') {
+                        return None;
                     }
+                    return Some(format!("{}[{}]", base_id, dim_id));
                 }
             }
 
@@ -133,37 +131,26 @@ pub(crate) fn get_dim_id(
         aast::Expr_::String(value) => Some(format!("'{}'", value)),
         aast::Expr_::Int(value) => Some(value.clone().to_string()),
         aast::Expr_::ClassConst(boxed) => {
-            if let Some((codebase, interner)) = codebase {
-                if let aast::ClassId_::CIexpr(lhs_expr) = &boxed.0.2 {
-                    if let aast::Expr_::Id(id) = &lhs_expr.2 {
-                        let mut is_static = false;
-                        let classlike_name = match get_id_name(
-                            id,
-                            &None,
-                            false,
-                            codebase,
-                            &mut is_static,
-                            resolved_names,
-                        ) {
-                            Some(value) => value,
-                            None => return None,
-                        };
+            if let Some((codebase, interner)) = codebase
+                && let aast::ClassId_::CIexpr(lhs_expr) = &boxed.0.2
+                && let aast::Expr_::Id(id) = &lhs_expr.2
+            {
+                let mut is_static = false;
+                let classlike_name =
+                    get_id_name(id, &None, false, codebase, &mut is_static, resolved_names)?;
 
-                        let constant_type = codebase.get_class_constant_type(
-                            &classlike_name,
-                            is_static,
-                            &interner.get(&boxed.1.1)?,
-                            FxHashSet::default(),
-                        );
+                let constant_type = codebase.get_class_constant_type(
+                    &classlike_name,
+                    is_static,
+                    &interner.get(&boxed.1.1)?,
+                    FxHashSet::default(),
+                );
 
-                        if let Some(constant_type) = constant_type {
-                            if let Some(constant_type_string) =
-                                constant_type.get_single_literal_string_value()
-                            {
-                                return Some(format!("'{}'", constant_type_string));
-                            }
-                        }
-                    }
+                if let Some(constant_type) = constant_type
+                    && let Some(constant_type_string) =
+                        constant_type.get_single_literal_string_value()
+                {
+                    return Some(format!("'{}'", constant_type_string));
                 }
             }
             None
@@ -278,18 +265,16 @@ pub fn get_expr_id(
             .get(&var_expr.1.1)
             .map(ExprId::Var),
         aast::Expr_::ObjGet(boxed) => {
-            if let ast_defs::PropOrMethod::IsProp = boxed.3 {
-                if let Some(ExprId::Var(base_id)) = get_expr_id(&boxed.0, statements_analyzer) {
-                    if let aast::Expr_::Id(boxed) = &boxed.1.2 {
-                        if let Some(prop_name) = statements_analyzer.interner.get(boxed.name()) {
-                            return Some(ExprId::InstanceProperty(
-                                VarId(base_id),
-                                statements_analyzer.get_hpos(boxed.pos()),
-                                prop_name,
-                            ));
-                        }
-                    }
-                }
+            if let ast_defs::PropOrMethod::IsProp = boxed.3
+                && let Some(ExprId::Var(base_id)) = get_expr_id(&boxed.0, statements_analyzer)
+                && let aast::Expr_::Id(boxed) = &boxed.1.2
+                && let Some(prop_name) = statements_analyzer.interner.get(boxed.name())
+            {
+                return Some(ExprId::InstanceProperty(
+                    VarId(base_id),
+                    statements_analyzer.get_hpos(boxed.pos()),
+                    prop_name,
+                ));
             }
 
             None

--- a/src/analyzer/expr/fetch/array_fetch_analyzer.rs
+++ b/src/analyzer/expr/fetch/array_fetch_analyzer.rs
@@ -70,31 +70,31 @@ pub(crate) fn analyze(
 
     expression_analyzer::analyze(statements_analyzer, expr.0, analysis_data, context, true)?;
 
-    if let Some(keyed_array_var_id) = &keyed_array_var_id {
-        if context.has_variable(keyed_array_var_id) {
-            let mut stmt_type = context.locals.remove(keyed_array_var_id.as_str()).unwrap();
+    if let Some(keyed_array_var_id) = &keyed_array_var_id
+        && context.has_variable(keyed_array_var_id)
+    {
+        let mut stmt_type = context.locals.remove(keyed_array_var_id.as_str()).unwrap();
 
-            add_array_fetch_dataflow_rc(
-                statements_analyzer,
-                expr.0,
-                analysis_data,
-                Some(keyed_array_var_id.to_string()),
-                &mut stmt_type,
-                &mut used_key_type,
-            );
+        add_array_fetch_dataflow_rc(
+            statements_analyzer,
+            expr.0,
+            analysis_data,
+            Some(keyed_array_var_id.to_string()),
+            &mut stmt_type,
+            &mut used_key_type,
+        );
 
-            analysis_data.set_rc_expr_type(pos, stmt_type.clone());
+        analysis_data.set_rc_expr_type(pos, stmt_type.clone());
 
-            context
-                .locals
-                .insert(keyed_array_var_id.clone(), stmt_type.clone());
+        context
+            .locals
+            .insert(keyed_array_var_id.clone(), stmt_type.clone());
 
-            if context.inside_unset {
-                unset_array_item(statements_analyzer, expr.0, context);
-            }
-
-            return Ok(());
+        if context.inside_unset {
+            unset_array_item(statements_analyzer, expr.0, context);
         }
+
+        return Ok(());
     }
 
     let stmt_var_type = analysis_data.get_rc_expr_type(expr.0.pos()).cloned();
@@ -175,93 +175,92 @@ pub(crate) fn add_array_fetch_dataflow(
     value_type: &mut TUnion,
     key_type: &mut TUnion,
 ) {
-    if let GraphKind::WholeProgram(WholeProgramKind::Taint) = &analysis_data.data_flow_graph.kind {
-        if !value_type.has_taintable_value() {
-            return;
-        }
+    if let GraphKind::WholeProgram(WholeProgramKind::Taint) = &analysis_data.data_flow_graph.kind
+        && !value_type.has_taintable_value()
+    {
+        return;
     }
 
     if let Some(stmt_var_type) = analysis_data.expr_types.get(&(
         array_expr_pos.start_offset() as u32,
         array_expr_pos.end_offset() as u32,
-    )) {
-        if !stmt_var_type.parent_nodes.is_empty() {
-            // TODO Add events dispatchers
+    )) && !stmt_var_type.parent_nodes.is_empty()
+    {
+        // TODO Add events dispatchers
 
-            let node_name = if let Some(keyed_array_var_id) = &keyed_array_var_id {
-                keyed_array_var_id.to_string()
+        let node_name = if let Some(keyed_array_var_id) = &keyed_array_var_id {
+            keyed_array_var_id.to_string()
+        } else {
+            "arrayvalue-fetch".to_string()
+        };
+        let new_parent_node = DataFlowNode::get_for_local_string(
+            node_name,
+            statements_analyzer.get_hpos(array_expr_pos),
+        );
+        analysis_data
+            .data_flow_graph
+            .add_node(new_parent_node.clone());
+
+        let key_type_single = if key_type.is_single() {
+            Some(key_type.get_single())
+        } else {
+            None
+        };
+
+        let dim_value = if let Some(key_type_single) = key_type_single {
+            if let TAtomic::TLiteralString { value, .. } = key_type_single {
+                Some(value.clone())
+            } else if let TAtomic::TLiteralInt { value, .. } = key_type_single {
+                Some(value.to_string())
             } else {
-                "arrayvalue-fetch".to_string()
-            };
-            let new_parent_node = DataFlowNode::get_for_local_string(
-                node_name,
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut array_key_node = None;
+
+        if keyed_array_var_id.is_none() && dim_value.is_none() {
+            let fetch_node = DataFlowNode::get_for_local_string(
+                "arraykey-fetch".to_string(),
                 statements_analyzer.get_hpos(array_expr_pos),
             );
+            analysis_data.data_flow_graph.add_node(fetch_node.clone());
+            array_key_node = Some(fetch_node);
             analysis_data
                 .data_flow_graph
                 .add_node(new_parent_node.clone());
+        }
 
-            let key_type_single = if key_type.is_single() {
-                Some(key_type.get_single())
-            } else {
-                None
-            };
-
-            let dim_value = if let Some(key_type_single) = key_type_single {
-                if let TAtomic::TLiteralString { value, .. } = key_type_single {
-                    Some(value.clone())
-                } else if let TAtomic::TLiteralInt { value, .. } = key_type_single {
-                    Some(value.to_string())
+        for parent_node in stmt_var_type.parent_nodes.iter() {
+            analysis_data.data_flow_graph.add_path(
+                &parent_node.id,
+                &new_parent_node.id,
+                if let Some(dim_value) = dim_value.clone() {
+                    PathKind::ArrayFetch(ArrayDataKind::ArrayValue, dim_value.to_string())
                 } else {
-                    None
-                }
-            } else {
-                None
-            };
+                    PathKind::UnknownArrayFetch(ArrayDataKind::ArrayValue)
+                },
+                vec![],
+                vec![],
+            );
 
-            let mut array_key_node = None;
-
-            if keyed_array_var_id.is_none() && dim_value.is_none() {
-                let fetch_node = DataFlowNode::get_for_local_string(
-                    "arraykey-fetch".to_string(),
-                    statements_analyzer.get_hpos(array_expr_pos),
-                );
-                analysis_data.data_flow_graph.add_node(fetch_node.clone());
-                array_key_node = Some(fetch_node);
-                analysis_data
-                    .data_flow_graph
-                    .add_node(new_parent_node.clone());
-            }
-
-            for parent_node in stmt_var_type.parent_nodes.iter() {
+            if let Some(array_key_node) = array_key_node.clone() {
                 analysis_data.data_flow_graph.add_path(
                     &parent_node.id,
-                    &new_parent_node.id,
-                    if let Some(dim_value) = dim_value.clone() {
-                        PathKind::ArrayFetch(ArrayDataKind::ArrayValue, dim_value.to_string())
-                    } else {
-                        PathKind::UnknownArrayFetch(ArrayDataKind::ArrayValue)
-                    },
+                    &array_key_node.id,
+                    PathKind::UnknownArrayFetch(ArrayDataKind::ArrayKey),
                     vec![],
                     vec![],
                 );
-
-                if let Some(array_key_node) = array_key_node.clone() {
-                    analysis_data.data_flow_graph.add_path(
-                        &parent_node.id,
-                        &array_key_node.id,
-                        PathKind::UnknownArrayFetch(ArrayDataKind::ArrayKey),
-                        vec![],
-                        vec![],
-                    );
-                }
             }
+        }
 
-            value_type.parent_nodes.push(new_parent_node.clone());
+        value_type.parent_nodes.push(new_parent_node.clone());
 
-            if let Some(array_key_node) = &array_key_node {
-                key_type.parent_nodes.push(array_key_node.clone());
-            }
+        if let Some(array_key_node) = &array_key_node {
+            key_type.parent_nodes.push(array_key_node.clone());
         }
     }
 }
@@ -440,21 +439,21 @@ pub(crate) fn get_array_access_type_given_offset(
                 name, type_params, ..
             }) => match *name {
                 StrId::KEYED_CONTAINER | StrId::ANY_ARRAY => {
-                    if let Some(type_params) = type_params {
-                        if type_params.len() > 1 {
-                            if let Some(existing_type) = stmt_type {
-                                stmt_type = Some(add_union_type(
-                                    existing_type,
-                                    &type_params[1],
-                                    codebase,
-                                    false,
-                                ));
-                            } else {
-                                stmt_type = Some(type_params[1].clone());
-                            }
-
-                            has_valid_expected_offset = true;
+                    if let Some(type_params) = type_params
+                        && type_params.len() > 1
+                    {
+                        if let Some(existing_type) = stmt_type {
+                            stmt_type = Some(add_union_type(
+                                existing_type,
+                                &type_params[1],
+                                codebase,
+                                false,
+                            ));
+                        } else {
+                            stmt_type = Some(type_params[1].clone());
                         }
+
+                        has_valid_expected_offset = true;
                     }
                 }
                 StrId::CONTAINER => {
@@ -565,26 +564,25 @@ fn unset_array_item(
     context: &mut BlockContext,
 ) {
     if let Some(expr_var_id) = expression_identifier::get_var_id(
-        &lhs,
+        lhs,
         context.function_context.calling_class,
         statements_analyzer.file_analyzer.resolved_names,
         Some((statements_analyzer.codebase, statements_analyzer.interner)),
-    ) {
-        if let Some(var_type) = context.locals.get_mut(&VarName::new(expr_var_id)) {
-            let mut var_type_inner = (**var_type).clone();
+    ) && let Some(var_type) = context.locals.get_mut(&VarName::new(expr_var_id))
+    {
+        let mut var_type_inner = (**var_type).clone();
 
-            for atomic_type in var_type_inner.types.iter_mut() {
-                if let TAtomic::TDict(TDict { non_empty, .. }) = atomic_type {
-                    *non_empty = false;
-                } else if let TAtomic::TVec(TVec { non_empty, .. })
-                | TAtomic::TKeyset { non_empty, .. } = atomic_type
-                {
-                    *non_empty = false;
-                }
+        for atomic_type in var_type_inner.types.iter_mut() {
+            if let TAtomic::TDict(TDict { non_empty, .. }) = atomic_type {
+                *non_empty = false;
+            } else if let TAtomic::TVec(TVec { non_empty, .. })
+            | TAtomic::TKeyset { non_empty, .. } = atomic_type
+            {
+                *non_empty = false;
             }
-
-            *var_type = Rc::new(var_type_inner);
         }
+
+        *var_type = Rc::new(var_type_inner);
     }
 }
 
@@ -712,12 +710,10 @@ pub(crate) fn handle_array_access_on_dict(
 
     let key_param = if in_assignment || context.inside_isset {
         get_arraykey(false)
+    } else if let Some(params) = &dict.params {
+        (*params.0).clone()
     } else {
-        if let Some(params) = &dict.params {
-            (*params.0).clone()
-        } else {
-            get_nothing()
-        }
+        get_nothing()
     };
 
     let mut union_comparison_result = TypeComparisonResult::new();
@@ -859,45 +855,44 @@ pub(crate) fn handle_array_access_on_dict(
             *has_valid_expected_offset = true;
         }
 
-        return value_param;
+        value_param
     } else {
         // TODO Handle Assignments
         // if (context.inside_assignment && replacement_type) {
 
         // }
-        return if let Some(params) = &dict.params {
-            if let Some(dict_key) = dim_type.get_single_dict_key() {
-                if !in_assignment {
-                    if !allow_possibly_undefined {
-                        // oh no!
-                        analysis_data.maybe_add_issue(
-                            Issue::new(
-                                match &dict_key {
-                                    DictKey::Int(_) => IssueKind::PossiblyUndefinedIntArrayOffset,
-                                    _ => IssueKind::PossiblyUndefinedStringArrayOffset,
-                                },
-                                format!(
-                                    "Fetch on {} using possibly-undefined key {}",
-                                    dict.get_id(Some(statements_analyzer.interner)),
-                                    dict_key.to_string(Some(statements_analyzer.interner))
-                                ),
-                                statements_analyzer.get_hpos(pos),
-                                &context.function_context.calling_functionlike_id,
+        if let Some(params) = &dict.params {
+            if let Some(dict_key) = dim_type.get_single_dict_key()
+                && !in_assignment
+            {
+                if !allow_possibly_undefined {
+                    // oh no!
+                    analysis_data.maybe_add_issue(
+                        Issue::new(
+                            match &dict_key {
+                                DictKey::Int(_) => IssueKind::PossiblyUndefinedIntArrayOffset,
+                                _ => IssueKind::PossiblyUndefinedStringArrayOffset,
+                            },
+                            format!(
+                                "Fetch on {} using possibly-undefined key {}",
+                                dict.get_id(Some(statements_analyzer.interner)),
+                                dict_key.to_string(Some(statements_analyzer.interner))
                             ),
-                            statements_analyzer.get_config(),
-                            statements_analyzer.get_file_path_actual(),
-                        );
-                    } else {
-                        if context.inside_unset {}
-                        *has_possibly_undefined = true;
-                    }
+                            statements_analyzer.get_hpos(pos),
+                            &context.function_context.calling_functionlike_id,
+                        ),
+                        statements_analyzer.get_config(),
+                        statements_analyzer.get_file_path_actual(),
+                    );
+                } else {
+                    *has_possibly_undefined = true;
                 }
             }
 
             (*params.1).clone()
         } else {
             get_nothing()
-        };
+        }
     }
 }
 
@@ -1013,29 +1008,28 @@ pub(crate) fn handle_array_access_on_mixed(
     if let Some(stmt_var_type) = analysis_data
         .expr_types
         .get(&(pos.start_offset() as u32, pos.end_offset() as u32))
+        && !stmt_var_type.parent_nodes.is_empty()
     {
-        if !stmt_var_type.parent_nodes.is_empty() {
-            let new_parent_node = DataFlowNode::get_for_local_string(
-                "mixed-var-array-access".to_string(),
-                statements_analyzer.get_hpos(pos),
-            );
-            analysis_data
-                .data_flow_graph
-                .add_node(new_parent_node.clone());
+        let new_parent_node = DataFlowNode::get_for_local_string(
+            "mixed-var-array-access".to_string(),
+            statements_analyzer.get_hpos(pos),
+        );
+        analysis_data
+            .data_flow_graph
+            .add_node(new_parent_node.clone());
 
-            for parent_node in stmt_var_type.parent_nodes.iter() {
-                analysis_data.data_flow_graph.add_path(
-                    &parent_node.id,
-                    &new_parent_node.id,
-                    PathKind::Default,
-                    vec![],
-                    vec![],
-                );
-            }
-            if let Some(stmt_type) = stmt_type {
-                let mut stmt_type_new = stmt_type.clone();
-                stmt_type_new.parent_nodes = vec![new_parent_node.clone()];
-            }
+        for parent_node in stmt_var_type.parent_nodes.iter() {
+            analysis_data.data_flow_graph.add_path(
+                &parent_node.id,
+                &new_parent_node.id,
+                PathKind::Default,
+                vec![],
+                vec![],
+            );
+        }
+        if let Some(stmt_type) = stmt_type {
+            let mut stmt_type_new = stmt_type.clone();
+            stmt_type_new.parent_nodes = vec![new_parent_node.clone()];
         }
     }
 

--- a/src/analyzer/expr/fetch/atomic_property_fetch_analyzer.rs
+++ b/src/analyzer/expr/fetch/atomic_property_fetch_analyzer.rs
@@ -243,7 +243,7 @@ fn get_class_property_type(
             &TypeExpansionOptions {
                 self_class: Some(declaring_class_storage.name),
                 static_class_type: StaticClassType::Object(&lhs_type_part),
-                parent_class: parent_class,
+                parent_class,
                 ..Default::default()
             },
             &mut analysis_data.data_flow_graph,
@@ -268,29 +268,28 @@ fn get_class_property_type(
                 );
             }
 
-            if let Some(functionlike_storage) = statements_analyzer.get_functionlike_info() {
-                if !functionlike_storage.where_constraints.is_empty() {
-                    type_expander::expand_union(
-                        codebase,
-                        &Some(statements_analyzer.interner),
-                        &statements_analyzer.file_analyzer.file_source.file_path,
-                        &mut class_property_type,
-                        &TypeExpansionOptions {
-                            self_class: Some(declaring_class_storage.name),
-                            static_class_type: StaticClassType::Object(&lhs_type_part),
-                            parent_class: parent_class,
-                            where_constraints: if functionlike_storage.where_constraints.is_empty()
-                            {
-                                None
-                            } else {
-                                Some(&functionlike_storage.where_constraints)
-                            },
-                            ..Default::default()
+            if let Some(functionlike_storage) = statements_analyzer.get_functionlike_info()
+                && !functionlike_storage.where_constraints.is_empty()
+            {
+                type_expander::expand_union(
+                    codebase,
+                    &Some(statements_analyzer.interner),
+                    &statements_analyzer.file_analyzer.file_source.file_path,
+                    &mut class_property_type,
+                    &TypeExpansionOptions {
+                        self_class: Some(declaring_class_storage.name),
+                        static_class_type: StaticClassType::Object(&lhs_type_part),
+                        parent_class,
+                        where_constraints: if functionlike_storage.where_constraints.is_empty() {
+                            None
+                        } else {
+                            Some(&functionlike_storage.where_constraints)
                         },
-                        &mut analysis_data.data_flow_graph,
-                        &mut 0,
-                    );
-                }
+                        ..Default::default()
+                    },
+                    &mut analysis_data.data_flow_graph,
+                    &mut 0,
+                );
             }
         }
 
@@ -399,13 +398,13 @@ fn update_template_types(
                         .map(|(i, _)| i)
                         .next();
 
-                    if let Some(position) = position {
-                        if let Some(mapped_param) = lhs_type_params.get(position) {
-                            v.insert(
-                                GenericParent::ClassLike(property_declaring_class_storage.name),
-                                mapped_param.clone(),
-                            );
-                        }
+                    if let Some(position) = position
+                        && let Some(mapped_param) = lhs_type_params.get(position)
+                    {
+                        v.insert(
+                            GenericParent::ClassLike(property_declaring_class_storage.name),
+                            mapped_param.clone(),
+                        );
                     }
                 }
             }

--- a/src/analyzer/expr/fetch/class_constant_fetch_analyzer.rs
+++ b/src/analyzer/expr/fetch/class_constant_fetch_analyzer.rs
@@ -102,7 +102,7 @@ pub(crate) fn analyze(
                                     let descendants = codebase
                                         .all_classlike_descendants
                                         .get(name)
-                                        .map(|i| i.clone())
+                                        .cloned()
                                         .unwrap_or_default();
 
                                     let mut potential_constant_types = add_optional_union_type(

--- a/src/analyzer/expr/fetch/instance_property_fetch_analyzer.rs
+++ b/src/analyzer/expr/fetch/instance_property_fetch_analyzer.rs
@@ -64,13 +64,13 @@ pub(crate) fn analyze(
         None
     };
 
-    if let Some(var_id) = &var_id {
-        if context.has_variable(var_id) {
-            // short circuit if the type is known in scope
-            handle_scoped_property(context, analysis_data, pos, var_id);
+    if let Some(var_id) = &var_id
+        && context.has_variable(var_id)
+    {
+        // short circuit if the type is known in scope
+        handle_scoped_property(context, analysis_data, pos, var_id);
 
-            return Ok(());
-        }
+        return Ok(());
     }
 
     let stmt_var_type = if let Some(stmt_var_id) = &stmt_var_id {
@@ -148,20 +148,20 @@ pub(crate) fn analyze(
     let mut stmt_type = analysis_data.get_rc_expr_type(pos).cloned();
 
     if has_nullsafe_null {
-        if let Some(ref mut stmt_type) = stmt_type {
-            if !stmt_type.is_nullable_mixed() {
-                let mut stmt_type_inner = (**stmt_type).clone();
-                stmt_type_inner = add_union_type(
-                    stmt_type_inner,
-                    &get_null(),
-                    statements_analyzer.codebase,
-                    false,
-                );
+        if let Some(ref mut stmt_type) = stmt_type
+            && !stmt_type.is_nullable_mixed()
+        {
+            let mut stmt_type_inner = (**stmt_type).clone();
+            stmt_type_inner = add_union_type(
+                stmt_type_inner,
+                &get_null(),
+                statements_analyzer.codebase,
+                false,
+            );
 
-                *stmt_type = Rc::new(stmt_type_inner);
+            *stmt_type = Rc::new(stmt_type_inner);
 
-                analysis_data.set_rc_expr_type(pos, stmt_type.clone());
-            }
+            analysis_data.set_rc_expr_type(pos, stmt_type.clone());
         }
     } else if nullsafe {
         // todo emit issue

--- a/src/analyzer/expr/fetch/static_property_fetch_analyzer.rs
+++ b/src/analyzer/expr/fetch/static_property_fetch_analyzer.rs
@@ -245,7 +245,7 @@ pub(crate) fn analyze(
             &TypeExpansionOptions {
                 self_class: Some(declaring_class_storage.name),
                 static_class_type: StaticClassType::Name(declaring_class_storage.name),
-                parent_class: parent_class,
+                parent_class,
                 ..Default::default()
             },
             &mut analysis_data.data_flow_graph,
@@ -458,7 +458,7 @@ fn analyze_variable_static_property_fetch_fallback(
 ) -> Result<(), AnalysisError> {
     let fake_var_name = "__fake_var_".to_string() + &pos.line().to_string();
     context.locals.insert(
-        VarName::new(fake_var_name.to_owned()),
+        VarName::new(&fake_var_name),
         Rc::new(stmt_class_type.clone()),
     );
 

--- a/src/analyzer/expr/include_analyzer.rs
+++ b/src/analyzer/expr/include_analyzer.rs
@@ -53,21 +53,21 @@ pub(crate) fn analyze(
         call_pos,
     );
 
-    if let Some(first_arg_type) = analysis_data.get_rc_expr_type(expr.pos()).cloned() {
-        if let Some(value) = first_arg_type.get_single_literal_string_value() {
-            let path = Path::new(&value);
-            if !path.exists() {
-                analysis_data.maybe_add_issue(
-                    Issue::new(
-                        IssueKind::NonExistentFile,
-                        format!("File {} does not exist", value),
-                        statements_analyzer.get_hpos(expr.pos()),
-                        &context.function_context.calling_functionlike_id,
-                    ),
-                    statements_analyzer.get_config(),
-                    statements_analyzer.get_file_path_actual(),
-                );
-            }
+    if let Some(first_arg_type) = analysis_data.get_rc_expr_type(expr.pos()).cloned()
+        && let Some(value) = first_arg_type.get_single_literal_string_value()
+    {
+        let path = Path::new(&value);
+        if !path.exists() {
+            analysis_data.maybe_add_issue(
+                Issue::new(
+                    IssueKind::NonExistentFile,
+                    format!("File {} does not exist", value),
+                    statements_analyzer.get_hpos(expr.pos()),
+                    &context.function_context.calling_functionlike_id,
+                ),
+                statements_analyzer.get_config(),
+                statements_analyzer.get_file_path_actual(),
+            );
         }
     }
 

--- a/src/analyzer/expr/pipe_analyzer.rs
+++ b/src/analyzer/expr/pipe_analyzer.rs
@@ -44,7 +44,7 @@ pub(crate) fn analyze(
 
     context
         .locals
-        .insert(VarName::new("$$".to_string()), Rc::new(pipe_expr_type));
+        .insert(VarName::new("$$"), Rc::new(pipe_expr_type));
 
     context.pipe_var_effects = *analysis_data
         .expr_effects

--- a/src/analyzer/expr/shape_analyzer.rs
+++ b/src/analyzer/expr/shape_analyzer.rs
@@ -41,15 +41,15 @@ pub(crate) fn analyze(
             ShapeFieldName::SFclassname(_) => todo!(),
         };
 
-        if let Some(ref mut current_stmt_offset) = analysis_data.current_stmt_offset {
-            if current_stmt_offset.line != start_pos.line() as u32 {
-                *current_stmt_offset = StmtStart {
-                    offset: start_pos.start_offset() as u32,
-                    line: start_pos.line() as u32,
-                    column: start_pos.to_raw_span().start.column() as u16,
-                    add_newline: true,
-                };
-            }
+        if let Some(ref mut current_stmt_offset) = analysis_data.current_stmt_offset
+            && current_stmt_offset.line != start_pos.line() as u32
+        {
+            *current_stmt_offset = StmtStart {
+                offset: start_pos.start_offset() as u32,
+                line: start_pos.line() as u32,
+                column: start_pos.to_raw_span().start.column() as u16,
+                add_newline: true,
+            };
         }
 
         let name = match name {

--- a/src/analyzer/expr/variable_fetch_analyzer.rs
+++ b/src/analyzer/expr/variable_fetch_analyzer.rs
@@ -78,9 +78,9 @@ pub(crate) fn analyze(
                         pos: parent_node_pos,
                         ..
                     } = parent_node.kind
+                        && parent_node_pos.start_offset < loop_init_pos.start_offset
                     {
-                        if parent_node_pos.start_offset < loop_init_pos.start_offset {
-                            analysis_data.maybe_add_issue(
+                        analysis_data.maybe_add_issue(
                                 Issue::new(
                                     IssueKind::ShadowedLoopVar,
                                     format!(
@@ -93,8 +93,7 @@ pub(crate) fn analyze(
                                 statements_analyzer.get_config(),
                                 statements_analyzer.get_file_path_actual(),
                             );
-                            break;
-                        }
+                        break;
                     }
                 }
             }

--- a/src/analyzer/expr/xml_analyzer.rs
+++ b/src/analyzer/expr/xml_analyzer.rs
@@ -295,46 +295,45 @@ fn handle_attribute_spread(
                 name: spread_xhp_class,
                 ..
             }) = expr_type_atomic
+                && let Some(spread_class_info) = codebase.classlike_infos.get(spread_xhp_class)
             {
-                if let Some(spread_class_info) = codebase.classlike_infos.get(spread_xhp_class) {
-                    let all_attributes = spread_class_info
-                        .properties
-                        .iter()
-                        .filter(|p| matches!(p.1.kind, PropertyKind::XhpAttribute { .. }));
+                let all_attributes = spread_class_info
+                    .properties
+                    .iter()
+                    .filter(|p| matches!(p.1.kind, PropertyKind::XhpAttribute { .. }));
 
-                    for spread_attribute in all_attributes {
-                        atomic_property_fetch_analyzer::analyze(
-                            statements_analyzer,
-                            (xhp_expr, xhp_expr),
-                            xhp_expr.pos(),
+                for spread_attribute in all_attributes {
+                    atomic_property_fetch_analyzer::analyze(
+                        statements_analyzer,
+                        (xhp_expr, xhp_expr),
+                        xhp_expr.pos(),
+                        analysis_data,
+                        context,
+                        false,
+                        expr_type_atomic.clone(),
+                        statements_analyzer.interner.lookup(spread_attribute.0),
+                        &None,
+                    )?;
+
+                    used_attributes.insert(*spread_attribute.0);
+
+                    if let Some(property_fetch_type) = analysis_data
+                        .expr_types
+                        .get(&(
+                            xhp_expr.pos().start_offset() as u32,
+                            xhp_expr.pos().end_offset() as u32,
+                        ))
+                        .cloned()
+                    {
+                        add_all_dataflow(
                             analysis_data,
-                            context,
-                            false,
-                            expr_type_atomic.clone(),
+                            statements_analyzer,
+                            (*element_name, *spread_attribute.0),
+                            xhp_expr.pos(),
+                            xhp_expr.pos(),
+                            property_fetch_type,
                             statements_analyzer.interner.lookup(spread_attribute.0),
-                            &None,
-                        )?;
-
-                        used_attributes.insert(*spread_attribute.0);
-
-                        if let Some(property_fetch_type) = analysis_data
-                            .expr_types
-                            .get(&(
-                                xhp_expr.pos().start_offset() as u32,
-                                xhp_expr.pos().end_offset() as u32,
-                            ))
-                            .cloned()
-                        {
-                            add_all_dataflow(
-                                analysis_data,
-                                statements_analyzer,
-                                (*element_name, *spread_attribute.0),
-                                xhp_expr.pos(),
-                                xhp_expr.pos(),
-                                property_fetch_type,
-                                statements_analyzer.interner.lookup(spread_attribute.0),
-                            );
-                        }
+                        );
                     }
                 }
             }
@@ -381,28 +380,27 @@ fn analyze_xhp_attribute_assignment(
     let attribute_name_pos = &attribute_info.name.0;
     let codebase = statements_analyzer.codebase;
 
-    if let Some(classlike_info) = codebase.classlike_infos.get(element_name) {
-        if attribute_name != StrId::DATA_ATTRIBUTE
-            && attribute_name != StrId::ARIA_ATTRIBUTE
-            && !classlike_info
-                .appearing_property_ids
-                .contains_key(&attribute_name)
-        {
-            analysis_data.maybe_add_issue(
-                Issue::new(
-                    IssueKind::NonExistentXhpAttribute,
-                    format!(
-                        "XHP attribute {} is not defined on {}",
-                        statements_analyzer.interner.lookup(&attribute_name),
-                        statements_analyzer.interner.lookup(element_name)
-                    ),
-                    statements_analyzer.get_hpos(attribute_name_pos),
-                    &context.function_context.calling_functionlike_id,
+    if let Some(classlike_info) = codebase.classlike_infos.get(element_name)
+        && attribute_name != StrId::DATA_ATTRIBUTE
+        && attribute_name != StrId::ARIA_ATTRIBUTE
+        && !classlike_info
+            .appearing_property_ids
+            .contains_key(&attribute_name)
+    {
+        analysis_data.maybe_add_issue(
+            Issue::new(
+                IssueKind::NonExistentXhpAttribute,
+                format!(
+                    "XHP attribute {} is not defined on {}",
+                    statements_analyzer.interner.lookup(&attribute_name),
+                    statements_analyzer.interner.lookup(element_name)
                 ),
-                statements_analyzer.get_config(),
-                statements_analyzer.get_file_path_actual(),
-            );
-        }
+                statements_analyzer.get_hpos(attribute_name_pos),
+                &context.function_context.calling_functionlike_id,
+            ),
+            statements_analyzer.get_config(),
+            statements_analyzer.get_file_path_actual(),
+        );
     }
 
     let attribute_value_pos = attribute_info.expr.pos();

--- a/src/analyzer/expression_analyzer.rs
+++ b/src/analyzer/expression_analyzer.rs
@@ -52,26 +52,26 @@ pub(crate) fn analyze(
     context: &mut BlockContext,
     is_sub_expression: bool,
 ) -> Result<(), AnalysisError> {
-    if statements_analyzer.get_config().add_fixmes {
-        if let Some(ref mut current_stmt_offset) = analysis_data.current_stmt_offset {
-            if current_stmt_offset.line != expr.1.line() as u32 {
-                if !matches!(expr.2, aast::Expr_::Xml(..)) {
-                    *current_stmt_offset = StmtStart {
-                        offset: expr.1.start_offset() as u32,
-                        line: expr.1.line() as u32,
-                        column: expr.1.to_raw_span().start.column() as u16,
-                        add_newline: true,
-                    };
-                } else {
-                    current_stmt_offset.line = expr.1.line() as u32;
-                }
+    if statements_analyzer.get_config().add_fixmes
+        && let Some(ref mut current_stmt_offset) = analysis_data.current_stmt_offset
+    {
+        if current_stmt_offset.line != expr.1.line() as u32 {
+            if !matches!(expr.2, aast::Expr_::Xml(..)) {
+                *current_stmt_offset = StmtStart {
+                    offset: expr.1.start_offset() as u32,
+                    line: expr.1.line() as u32,
+                    column: expr.1.to_raw_span().start.column() as u16,
+                    add_newline: true,
+                };
+            } else {
+                current_stmt_offset.line = expr.1.line() as u32;
             }
-
-            analysis_data.expr_fixme_positions.insert(
-                (expr.1.start_offset() as u32, expr.1.end_offset() as u32),
-                *current_stmt_offset,
-            );
         }
+
+        analysis_data.expr_fixme_positions.insert(
+            (expr.1.start_offset() as u32, expr.1.end_offset() as u32),
+            *current_stmt_offset,
+        );
     }
 
     match &expr.2 {
@@ -133,25 +133,24 @@ pub(crate) fn analyze(
             if statements_analyzer
                 .get_config()
                 .collect_goto_definition_locations
-            {
-                if let Some(hint_type) = hakana_reflector::typehint_resolver::get_type_from_hint(
+                && let Some(hint_type) = hakana_reflector::typehint_resolver::get_type_from_hint(
                     &hint.1,
                     context.function_context.calling_class,
                     statements_analyzer.get_type_resolution_context(),
                     statements_analyzer.file_analyzer.resolved_names,
                     *statements_analyzer.get_file_path(),
                     hint.0.start_offset() as u32,
-                ) {
-                    for t in &hint_type.types {
-                        if let TAtomic::TReference { name, .. }
-                        | TAtomic::TNamedObject(TNamedObject { name, .. })
-                        | TAtomic::TTypeAlias { name, .. } = t
-                        {
-                            analysis_data.definition_locations.insert(
-                                (hint.0.start_offset() as u32, hint.0.end_offset() as u32),
-                                (*name, StrId::EMPTY),
-                            );
-                        }
+                )
+            {
+                for t in &hint_type.types {
+                    if let TAtomic::TReference { name, .. }
+                    | TAtomic::TNamedObject(TNamedObject { name, .. })
+                    | TAtomic::TTypeAlias { name, .. } = t
+                    {
+                        analysis_data.definition_locations.insert(
+                            (hint.0.start_offset() as u32, hint.0.end_offset() as u32),
+                            (*name, StrId::EMPTY),
+                        );
                     }
                 }
             }
@@ -200,7 +199,7 @@ pub(crate) fn analyze(
                 &expr.1,
                 analysis_data,
                 context,
-                keyed_array_var_id.map(|t| VarName::new(t)),
+                keyed_array_var_id.map(VarName::new),
             )?;
         }
         aast::Expr_::Eif(boxed) => {
@@ -942,22 +941,22 @@ pub(crate) fn add_decision_dataflow(
         }
     }
 
-    if let Some(rhs_expr) = rhs_expr {
-        if let Some(rhs_type) = analysis_data.expr_types.get(&(
+    if let Some(rhs_expr) = rhs_expr
+        && let Some(rhs_type) = analysis_data.expr_types.get(&(
             rhs_expr.1.start_offset() as u32,
             rhs_expr.1.end_offset() as u32,
-        )) {
-            cond_type.parent_nodes.push(decision_node.clone());
+        ))
+    {
+        cond_type.parent_nodes.push(decision_node.clone());
 
-            for old_parent_node in &rhs_type.parent_nodes {
-                analysis_data.data_flow_graph.add_path(
-                    &old_parent_node.id,
-                    &decision_node.id,
-                    PathKind::Default,
-                    vec![],
-                    vec![],
-                );
-            }
+        for old_parent_node in &rhs_type.parent_nodes {
+            analysis_data.data_flow_graph.add_path(
+                &old_parent_node.id,
+                &decision_node.id,
+                PathKind::Default,
+                vec![],
+                vec![],
+            );
         }
     }
     analysis_data.expr_types.insert(

--- a/src/analyzer/file_analyzer.rs
+++ b/src/analyzer/file_analyzer.rs
@@ -75,7 +75,7 @@ impl<'a> FileAnalyzer<'a> {
             self.namespace_name = namespace_declaration.map(|(id, _)| id.1.to_string());
 
             let statements_analyzer =
-                StatementsAnalyzer::new(&self, &type_resolution_context, &comments);
+                StatementsAnalyzer::new(self, &type_resolution_context, &comments);
 
             if namespace_declaration.is_some() {
                 let (_, statements) = namespace_declaration.unwrap();
@@ -103,7 +103,7 @@ impl<'a> FileAnalyzer<'a> {
                 )?;
             }
 
-            if namespace_declaration.map_or(false, |(_, statements)| !statements.is_empty()) {
+            if namespace_declaration.is_some_and(|(_, statements)| !statements.is_empty()) {
                 self.namespace_name = None;
             }
         }

--- a/src/analyzer/formula_generator.rs
+++ b/src/analyzer/formula_generator.rs
@@ -38,8 +38,8 @@ pub(crate) fn get_formula(
     cache: bool,
     inside_negation: bool,
 ) -> Result<Vec<Clause>, String> {
-    if let aast::Expr_::Binop(expr) = &conditional.2 {
-        if let Some(clauses) = handle_binop(
+    if let aast::Expr_::Binop(expr) = &conditional.2
+        && let Some(clauses) = handle_binop(
             conditional_object_id,
             &expr.bop,
             &expr.lhs,
@@ -48,13 +48,13 @@ pub(crate) fn get_formula(
             analysis_data,
             cache,
             inside_negation,
-        ) {
-            return clauses;
-        }
+        )
+    {
+        return clauses;
     }
 
-    if let aast::Expr_::Unop(expr) = &conditional.2 {
-        if let Some(clauses) = handle_uop(
+    if let aast::Expr_::Unop(expr) = &conditional.2
+        && let Some(clauses) = handle_uop(
             conditional_object_id,
             &expr.0,
             &expr.1,
@@ -62,9 +62,9 @@ pub(crate) fn get_formula(
             analysis_data,
             cache,
             inside_negation,
-        ) {
-            return clauses;
-        }
+        )
+    {
+        return clauses;
     }
 
     let anded_assertions = assertion_finder::scrape_assertions(

--- a/src/analyzer/function_analysis_data.rs
+++ b/src/analyzer/function_analysis_data.rs
@@ -243,10 +243,10 @@ impl FunctionAnalysisData {
     fn can_output_issue(&mut self, issue: &Issue) -> bool {
         *self.issue_counts.entry(issue.kind.clone()).or_insert(0) += 1;
 
-        if let Some(issue_filter) = &self.issue_filter {
-            if !issue_filter.contains(&issue.kind) {
-                return false;
-            }
+        if let Some(issue_filter) = &self.issue_filter
+            && !issue_filter.contains(&issue.kind)
+        {
+            return false;
         }
         true
     }
@@ -288,10 +288,10 @@ impl FunctionAnalysisData {
                     fixme_pos.start_offset() as u32,
                     fixme_pos.end_offset() as u32,
                 );
-                if let Some(offset) = self.previously_used_fixme_positions.get(&fixme_offsets) {
-                    if *offset != (issue_start_offset, issue_end_offset) {
-                        continue;
-                    }
+                if let Some(offset) = self.previously_used_fixme_positions.get(&fixme_offsets)
+                    && *offset != (issue_start_offset, issue_end_offset)
+                {
+                    continue;
                 }
 
                 if matches!(

--- a/src/analyzer/functionlike_analyzer.rs
+++ b/src/analyzer/functionlike_analyzer.rs
@@ -324,16 +324,16 @@ impl<'a> FunctionLikeAnalyzer<'a> {
                 remapped_params: false,
             }));
 
-            if let GraphKind::WholeProgram(_) = &analysis_result.program_dataflow_graph.kind {
-                if classlike_storage.specialize_instance {
-                    let new_call_node = DataFlowNode::get_for_this_before_method(
-                        &MethodIdentifier(classlike_storage.name, method_name),
-                        functionlike_storage.return_type_location,
-                        None,
-                    );
+            if let GraphKind::WholeProgram(_) = &analysis_result.program_dataflow_graph.kind
+                && classlike_storage.specialize_instance
+            {
+                let new_call_node = DataFlowNode::get_for_this_before_method(
+                    &MethodIdentifier(classlike_storage.name, method_name),
+                    functionlike_storage.return_type_location,
+                    None,
+                );
 
-                    this_type.parent_nodes = vec![new_call_node];
-                }
+                this_type.parent_nodes = vec![new_call_node];
             }
 
             context
@@ -490,7 +490,7 @@ impl<'a> FunctionLikeAnalyzer<'a> {
         let mut analysis_data = FunctionAnalysisData::new(
             DataFlowGraph::new(statements_analyzer.get_config().graph_kind),
             &statements_analyzer.file_analyzer.file_source,
-            &statements_analyzer.comments,
+            statements_analyzer.comments,
             &self.get_config().all_custom_issues,
             if let Some(parent_analysis_data) = &parent_analysis_data {
                 parent_analysis_data.current_stmt_offset
@@ -552,54 +552,53 @@ impl<'a> FunctionLikeAnalyzer<'a> {
             return Err(AnalysisError::InternalError(error, pos));
         }
 
-        if let Some(name_location) = functionlike_storage.name_location {
-            if cost > 50_000 {
+        if let Some(name_location) = functionlike_storage.name_location
+            && cost > 50_000
+        {
+            analysis_data.maybe_add_issue(
+                Issue::new(
+                    IssueKind::LargeTypeExpansion,
+                    format!("Very large param types used — {cost} elements loaded"),
+                    name_location,
+                    &context.function_context.calling_functionlike_id,
+                ),
+                statements_analyzer.get_config(),
+                statements_analyzer.get_file_path_actual(),
+            );
+        }
+
+        if let Some(calling_class) = &context.function_context.calling_class
+            && let Some(classlike_storage) = self
+                .file_analyzer
+                .codebase
+                .classlike_infos
+                .get(calling_class)
+        {
+            cost = 0;
+
+            if let Err(error) = self.add_properties_to_context(
+                classlike_storage,
+                &mut analysis_data,
+                functionlike_storage,
+                &mut context,
+                &mut cost,
+            ) {
+                return Err(AnalysisError::InternalError(error.0, error.1));
+            }
+
+            if let Some(name_location) = functionlike_storage.name_location
+                && cost > 50_000
+            {
                 analysis_data.maybe_add_issue(
                     Issue::new(
                         IssueKind::LargeTypeExpansion,
-                        format!("Very large param types used — {cost} elements loaded"),
+                        format!("Very large property types used — {cost} elements loaded"),
                         name_location,
                         &context.function_context.calling_functionlike_id,
                     ),
                     statements_analyzer.get_config(),
                     statements_analyzer.get_file_path_actual(),
                 );
-            }
-        }
-
-        if let Some(calling_class) = &context.function_context.calling_class {
-            if let Some(classlike_storage) = self
-                .file_analyzer
-                .codebase
-                .classlike_infos
-                .get(calling_class)
-            {
-                cost = 0;
-
-                if let Err(error) = self.add_properties_to_context(
-                    classlike_storage,
-                    &mut analysis_data,
-                    functionlike_storage,
-                    &mut context,
-                    &mut cost,
-                ) {
-                    return Err(AnalysisError::InternalError(error.0, error.1));
-                }
-
-                if let Some(name_location) = functionlike_storage.name_location {
-                    if cost > 50_000 {
-                        analysis_data.maybe_add_issue(
-                            Issue::new(
-                                IssueKind::LargeTypeExpansion,
-                                format!("Very large property types used — {cost} elements loaded"),
-                                name_location,
-                                &context.function_context.calling_functionlike_id,
-                            ),
-                            statements_analyzer.get_config(),
-                            statements_analyzer.get_file_path_actual(),
-                        );
-                    }
-                }
             }
         }
 
@@ -639,38 +638,36 @@ impl<'a> FunctionLikeAnalyzer<'a> {
             );
         }
 
-        if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {
-            if let Some(method_storage) = &functionlike_storage.method_info {
-                if !method_storage.is_static {
-                    if let Some(this_type) = context.locals.get("$this") {
-                        let new_call_node = DataFlowNode::get_for_this_after_method(
-                            &MethodIdentifier(
-                                context.function_context.calling_class.unwrap(),
-                                match functionlike_id {
-                                    FunctionLikeIdentifier::Method(_, method_name) => method_name,
-                                    _ => {
-                                        panic!()
-                                    }
-                                },
-                            ),
-                            functionlike_storage.name_location,
-                            None,
-                        );
-
-                        for parent_node in &this_type.parent_nodes {
-                            analysis_data.data_flow_graph.add_path(
-                                &parent_node.id,
-                                &new_call_node.id,
-                                PathKind::Default,
-                                vec![],
-                                vec![],
-                            );
+        if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind
+            && let Some(method_storage) = &functionlike_storage.method_info
+            && !method_storage.is_static
+            && let Some(this_type) = context.locals.get("$this")
+        {
+            let new_call_node = DataFlowNode::get_for_this_after_method(
+                &MethodIdentifier(
+                    context.function_context.calling_class.unwrap(),
+                    match functionlike_id {
+                        FunctionLikeIdentifier::Method(_, method_name) => method_name,
+                        _ => {
+                            panic!()
                         }
+                    },
+                ),
+                functionlike_storage.name_location,
+                None,
+            );
 
-                        analysis_data.data_flow_graph.add_node(new_call_node);
-                    }
-                }
+            for parent_node in &this_type.parent_nodes {
+                analysis_data.data_flow_graph.add_path(
+                    &parent_node.id,
+                    &new_call_node.id,
+                    PathKind::Default,
+                    vec![],
+                    vec![],
+                );
             }
+
+            analysis_data.data_flow_graph.add_node(new_call_node);
         }
 
         let config = statements_analyzer.get_config();
@@ -733,34 +730,32 @@ impl<'a> FunctionLikeAnalyzer<'a> {
             if !analysis_data.has_await
                 && functionlike_storage.is_async
                 && functionlike_storage.is_production_code
-            {
-                if functionlike_storage
+                && functionlike_storage
                     .is_simple_fn(&context.function_context, statements_analyzer.codebase)
-                    && !functionlike_storage
-                        .suppressed_issues
-                        .iter()
-                        .any(|(i, _)| i == &IssueKind::UnnecessaryAsyncAnnotation)
-                {
-                    let mut issue = Issue::new(
-                        IssueKind::UnnecessaryAsyncAnnotation,
-                        format!("This function is marked async but has no async behaviour"),
-                        functionlike_storage
-                            .name_location
-                            .unwrap_or(functionlike_storage.def_location),
-                        &context.function_context.calling_functionlike_id,
-                    );
-                    issue.insertion_start = Some(StmtStart {
-                        offset: functionlike_storage.def_location.start_offset,
-                        line: functionlike_storage.def_location.start_line,
-                        column: functionlike_storage.def_location.start_column - 1,
-                        add_newline: true,
-                    });
-                    analysis_data.maybe_add_issue(
-                        issue,
-                        statements_analyzer.get_config(),
-                        statements_analyzer.get_file_path_actual(),
-                    );
-                }
+                && !functionlike_storage
+                    .suppressed_issues
+                    .iter()
+                    .any(|(i, _)| i == &IssueKind::UnnecessaryAsyncAnnotation)
+            {
+                let mut issue = Issue::new(
+                    IssueKind::UnnecessaryAsyncAnnotation,
+                    "This function is marked async but has no async behaviour".to_string(),
+                    functionlike_storage
+                        .name_location
+                        .unwrap_or(functionlike_storage.def_location),
+                    &context.function_context.calling_functionlike_id,
+                );
+                issue.insertion_start = Some(StmtStart {
+                    offset: functionlike_storage.def_location.start_offset,
+                    line: functionlike_storage.def_location.start_line,
+                    column: functionlike_storage.def_location.start_column - 1,
+                    add_newline: true,
+                });
+                analysis_data.maybe_add_issue(
+                    issue,
+                    statements_analyzer.get_config(),
+                    statements_analyzer.get_file_path_actual(),
+                );
             }
 
             if config.remove_fixmes {
@@ -821,19 +816,19 @@ impl<'a> FunctionLikeAnalyzer<'a> {
                 &mut cost,
             );
 
-            if let Some(name_location) = functionlike_storage.name_location {
-                if cost > 50_000 {
-                    analysis_data.maybe_add_issue(
-                        Issue::new(
-                            IssueKind::LargeTypeExpansion,
-                            format!("Very large return type used — {cost} elements loaded"),
-                            name_location,
-                            &context.function_context.calling_functionlike_id,
-                        ),
-                        statements_analyzer.get_config(),
-                        statements_analyzer.get_file_path_actual(),
-                    );
-                }
+            if let Some(name_location) = functionlike_storage.name_location
+                && cost > 50_000
+            {
+                analysis_data.maybe_add_issue(
+                    Issue::new(
+                        IssueKind::LargeTypeExpansion,
+                        format!("Very large return type used — {cost} elements loaded"),
+                        name_location,
+                        &context.function_context.calling_functionlike_id,
+                    ),
+                    statements_analyzer.get_config(),
+                    statements_analyzer.get_file_path_actual(),
+                );
             }
 
             let config = statements_analyzer.get_config();
@@ -1527,10 +1522,9 @@ fn report_unused_expressions(
             } => {
                 if let DataFlowNodeId::Var(var_id, ..) | DataFlowNodeId::Param(var_id, ..) =
                     &node.id
+                    && interner.lookup(&var_id.0).starts_with("$_")
                 {
-                    if interner.lookup(&var_id.0).starts_with("$_") {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if kind == &VariableSourceKind::Default {
@@ -1564,10 +1558,9 @@ fn report_unused_expressions(
             } => {
                 if let DataFlowNodeId::Var(var_id, ..) | DataFlowNodeId::Param(var_id, ..) =
                     &node.id
+                    && interner.lookup(&var_id.0).starts_with("$_")
                 {
-                    if interner.lookup(&var_id.0).starts_with("$_") {
-                        continue;
-                    }
+                    continue;
                 }
 
                 match &kind {

--- a/src/analyzer/reconciler/assertion_reconciler.rs
+++ b/src/analyzer/reconciler/assertion_reconciler.rs
@@ -132,9 +132,9 @@ pub fn reconcile(
                     suppressed_issues,
                 );
             }
-            TAtomic::TBool { .. } => {
+            TAtomic::TBool => {
                 return intersect_simple!(
-                    TAtomic::TBool { .. } | TAtomic::TFalse | TAtomic::TTrue,
+                    TAtomic::TBool | TAtomic::TFalse | TAtomic::TTrue,
                     TAtomic::TMixed
                         | TAtomic::TMixedWithFlags(..)
                         | TAtomic::TScalar
@@ -152,9 +152,9 @@ pub fn reconcile(
                     suppressed_issues,
                 );
             }
-            TAtomic::TFalse { .. } => {
+            TAtomic::TFalse => {
                 return intersect_simple!(
-                    TAtomic::TFalse { .. },
+                    TAtomic::TFalse,
                     TAtomic::TMixed
                         | TAtomic::TMixedWithFlags(_, false, _, _)
                         | TAtomic::TScalar
@@ -173,9 +173,9 @@ pub fn reconcile(
                     suppressed_issues,
                 );
             }
-            TAtomic::TTrue { .. } => {
+            TAtomic::TTrue => {
                 return intersect_simple!(
-                    TAtomic::TTrue { .. },
+                    TAtomic::TTrue,
                     TAtomic::TMixed
                         | TAtomic::TMixedWithFlags(_, _, false, _)
                         | TAtomic::TScalar
@@ -194,9 +194,9 @@ pub fn reconcile(
                     suppressed_issues,
                 );
             }
-            TAtomic::TFloat { .. } => {
+            TAtomic::TFloat => {
                 return intersect_simple!(
-                    TAtomic::TFloat { .. },
+                    TAtomic::TFloat,
                     TAtomic::TMixed
                         | TAtomic::TMixedWithFlags(..)
                         | TAtomic::TScalar
@@ -234,42 +234,38 @@ pub fn reconcile(
             &mut did_remove_type,
         );
 
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                if can_report_issues {
-                    if existing_var_type.types == refined_type.types {
-                        if !assertion.has_equality()
-                            && !assertion_type.is_mixed()
-                            && !did_remove_type
-                        {
-                            trigger_issue_for_impossible(
-                                analysis_data,
-                                statements_analyzer,
-                                &old_var_type_string,
-                                key,
-                                assertion,
-                                true,
-                                negated,
-                                pos,
-                                calling_functionlike_id,
-                                suppressed_issues,
-                            );
-                        }
-                    } else if refined_type.is_nothing() {
-                        trigger_issue_for_impossible(
-                            analysis_data,
-                            statements_analyzer,
-                            &old_var_type_string,
-                            key,
-                            assertion,
-                            false,
-                            negated,
-                            pos,
-                            calling_functionlike_id,
-                            suppressed_issues,
-                        );
-                    }
+        if let Some(key) = key
+            && let Some(pos) = pos
+            && can_report_issues
+        {
+            if existing_var_type.types == refined_type.types {
+                if !assertion.has_equality() && !assertion_type.is_mixed() && !did_remove_type {
+                    trigger_issue_for_impossible(
+                        analysis_data,
+                        statements_analyzer,
+                        &old_var_type_string,
+                        key,
+                        assertion,
+                        true,
+                        negated,
+                        pos,
+                        calling_functionlike_id,
+                        suppressed_issues,
+                    );
                 }
+            } else if refined_type.is_nothing() {
+                trigger_issue_for_impossible(
+                    analysis_data,
+                    statements_analyzer,
+                    &old_var_type_string,
+                    key,
+                    assertion,
+                    false,
+                    negated,
+                    pos,
+                    calling_functionlike_id,
+                    suppressed_issues,
+                );
             }
         }
 
@@ -553,14 +549,13 @@ pub(crate) fn intersect_atomic_with_atomic(
             }
         }
         (TAtomic::TTypeVariable { name }, TAtomic::TNull) => {
-            if let Some(pos) = pos {
-                if let Some(TypeVariableBounds { lower_bounds, .. }) =
+            if let Some(pos) = pos
+                && let Some(TypeVariableBounds { lower_bounds, .. }) =
                     analysis_data.type_variable_bounds.get_mut(name)
-                {
-                    let mut bound = TemplateBound::new(get_null(), 0, None, None);
-                    bound.pos = Some(statements_analyzer.get_hpos(pos));
-                    lower_bounds.push(bound);
-                }
+            {
+                let mut bound = TemplateBound::new(get_null(), 0, None, None);
+                bound.pos = Some(statements_analyzer.get_hpos(pos));
+                lower_bounds.push(bound);
             }
 
             *did_remove_type = true;
@@ -590,7 +585,7 @@ pub(crate) fn intersect_atomic_with_atomic(
             return None;
         }
         (
-            TAtomic::TObject { .. }
+            TAtomic::TObject
             | TAtomic::TClosure(_)
             | TAtomic::TAwaitable { .. }
             | TAtomic::TNamedObject(TNamedObject { .. }),
@@ -655,7 +650,7 @@ pub(crate) fn intersect_atomic_with_atomic(
         (type_1_atomic, TAtomic::TNum) => {
             if type_1_atomic.is_mixed() {
                 return Some(TAtomic::TNum);
-            } else if type_1_atomic.is_int() || matches!(type_1_atomic, TAtomic::TFloat { .. }) {
+            } else if type_1_atomic.is_int() || matches!(type_1_atomic, TAtomic::TFloat) {
                 return Some(type_1_atomic.clone());
             } else if let TAtomic::TClassTypeConstant { .. } = type_1_atomic {
                 *did_remove_type = true;
@@ -674,7 +669,7 @@ pub(crate) fn intersect_atomic_with_atomic(
             | TAtomic::TClassPtr { .. }
             | TAtomic::TTypename { .. }
             | TAtomic::TStringWithFlags(..)
-            | TAtomic::TString { .. },
+            | TAtomic::TString,
             TAtomic::TString,
         ) => {
             return Some(type_1_atomic.clone());
@@ -717,26 +712,24 @@ pub(crate) fn intersect_atomic_with_atomic(
                 } else {
                     return None;
                 }
+            } else if atomic_type_comparator::is_contained_by(
+                statements_analyzer.codebase,
+                statements_analyzer.get_file_path(),
+                underlying_type,
+                &TAtomic::TString,
+                false,
+                &mut TypeComparisonResult::new(),
+            ) {
+                *did_remove_type = true;
+                return Some(TAtomic::TEnumLiteralCase {
+                    enum_name: *enum_name,
+                    member_name: *member_name,
+                    as_type: Some(Arc::new(TAtomic::TString)),
+                    underlying_type: Some(underlying_type.clone()),
+                });
             } else {
-                if atomic_type_comparator::is_contained_by(
-                    statements_analyzer.codebase,
-                    statements_analyzer.get_file_path(),
-                    underlying_type,
-                    &TAtomic::TString,
-                    false,
-                    &mut TypeComparisonResult::new(),
-                ) {
-                    *did_remove_type = true;
-                    return Some(TAtomic::TEnumLiteralCase {
-                        enum_name: *enum_name,
-                        member_name: *member_name,
-                        as_type: Some(Arc::new(TAtomic::TString)),
-                        underlying_type: Some(underlying_type.clone()),
-                    });
-                } else {
-                    *did_remove_type = true;
-                    return Some(TAtomic::TString);
-                }
+                *did_remove_type = true;
+                return Some(TAtomic::TString);
             }
         }
         (
@@ -809,14 +802,13 @@ pub(crate) fn intersect_atomic_with_atomic(
             });
         }
         (TAtomic::TTypeVariable { name }, TAtomic::TString) => {
-            if let Some(pos) = pos {
-                if let Some(TypeVariableBounds { lower_bounds, .. }) =
+            if let Some(pos) = pos
+                && let Some(TypeVariableBounds { lower_bounds, .. }) =
                     analysis_data.type_variable_bounds.get_mut(name)
-                {
-                    let mut bound = TemplateBound::new(get_string(), 0, None, None);
-                    bound.pos = Some(statements_analyzer.get_hpos(pos));
-                    lower_bounds.push(bound);
-                }
+            {
+                let mut bound = TemplateBound::new(get_string(), 0, None, None);
+                bound.pos = Some(statements_analyzer.get_hpos(pos));
+                lower_bounds.push(bound);
             }
 
             *did_remove_type = true;
@@ -895,14 +887,13 @@ pub(crate) fn intersect_atomic_with_atomic(
         (TAtomic::TTypeVariable { name }, TAtomic::TInt) => {
             *did_remove_type = true;
 
-            if let Some(pos) = pos {
-                if let Some(TypeVariableBounds { lower_bounds, .. }) =
+            if let Some(pos) = pos
+                && let Some(TypeVariableBounds { lower_bounds, .. }) =
                     analysis_data.type_variable_bounds.get_mut(name)
-                {
-                    let mut bound = TemplateBound::new(get_int(), 0, None, None);
-                    bound.pos = Some(statements_analyzer.get_hpos(pos));
-                    lower_bounds.push(bound);
-                }
+            {
+                let mut bound = TemplateBound::new(get_int(), 0, None, None);
+                bound.pos = Some(statements_analyzer.get_hpos(pos));
+                lower_bounds.push(bound);
             }
             return Some(type_1_atomic.clone());
         }
@@ -1280,15 +1271,14 @@ pub(crate) fn intersect_atomic_with_atomic(
             if let (Some(storage_1), Some(storage_2)) = (
                 codebase.classlike_infos.get(type_1_name),
                 codebase.classlike_infos.get(type_2_name),
-            ) {
-                if let Some(c1) = &storage_1.constants.get(member_name) {
-                    for (_, c2) in &storage_2.constants {
-                        let c1_value = expand_constant_value(c1, codebase);
-                        let c2_value = expand_constant_value(c2, codebase);
+            ) && let Some(c1) = &storage_1.constants.get(member_name)
+            {
+                for (_, c2) in &storage_2.constants {
+                    let c1_value = expand_constant_value(c1, codebase);
+                    let c2_value = expand_constant_value(c2, codebase);
 
-                        if c1_value == c2_value {
-                            return Some(type_2_atomic.clone());
-                        }
+                    if c1_value == c2_value {
+                        return Some(type_2_atomic.clone());
                     }
                 }
             }
@@ -1306,15 +1296,14 @@ pub(crate) fn intersect_atomic_with_atomic(
             if let (Some(storage_1), Some(storage_2)) = (
                 codebase.classlike_infos.get(type_1_name),
                 codebase.classlike_infos.get(type_2_name),
-            ) {
-                if let Some(c2) = &storage_2.constants.get(member_name) {
-                    for (_, c1) in &storage_1.constants {
-                        let c1_value = expand_constant_value(c1, codebase);
-                        let c2_value = expand_constant_value(c2, codebase);
+            ) && let Some(c2) = &storage_2.constants.get(member_name)
+            {
+                for (_, c1) in &storage_1.constants {
+                    let c1_value = expand_constant_value(c1, codebase);
+                    let c2_value = expand_constant_value(c2, codebase);
 
-                        if c1_value == c2_value {
-                            return Some(type_1_atomic.clone());
-                        }
+                    if c1_value == c2_value {
+                        return Some(type_1_atomic.clone());
                     }
                 }
             }
@@ -1408,7 +1397,7 @@ pub(crate) fn intersect_atomic_with_atomic(
                 statements_analyzer.codebase,
                 statements_analyzer.get_file_path(),
                 type_1_name,
-                &underlying_type,
+                underlying_type,
                 type_2_atomic.clone(),
             );
         }
@@ -1424,7 +1413,7 @@ pub(crate) fn intersect_atomic_with_atomic(
                 statements_analyzer.codebase,
                 statements_analyzer.get_file_path(),
                 type_2_name,
-                &underlying_type,
+                underlying_type,
                 type_1_atomic.clone(),
             );
         }
@@ -1618,8 +1607,8 @@ pub(crate) fn intersect_atomic_with_atomic(
             return intersect_union_with_union(
                 statements_analyzer,
                 analysis_data,
-                &type_1_param,
-                &type_2_param,
+                type_1_param,
+                type_2_param,
                 pos,
                 did_remove_type,
             )
@@ -1661,10 +1650,10 @@ pub(crate) fn intersect_atomic_with_atomic(
 
             let mut params = type_2_params.clone();
 
-            if let Some(ref mut params) = params {
-                if params.0.is_arraykey() {
-                    params.0 = Box::new(type_1_key_param);
-                }
+            if let Some(ref mut params) = params
+                && params.0.is_arraykey()
+            {
+                *params.0 = type_1_key_param;
             }
 
             return Some(TAtomic::TDict(TDict {
@@ -1695,7 +1684,7 @@ pub(crate) fn intersect_atomic_with_atomic(
                     ref mut as_type, ..
                 }) = type_1_atomic
                 {
-                    *as_type = Box::new(new_as);
+                    **as_type = new_as;
                 }
 
                 return Some(type_1_atomic);
@@ -1721,7 +1710,7 @@ pub(crate) fn intersect_atomic_with_atomic(
                     ref mut as_type, ..
                 }) = type_2_atomic
                 {
-                    *as_type = Box::new(new_as);
+                    **as_type = new_as;
                 }
 
                 return Some(type_2_atomic);
@@ -2042,7 +2031,7 @@ pub(crate) fn intersect_union_with_union(
         return Some(type_1_param.clone());
     }
 
-    let type_param = match (type_1_param.is_single(), type_2_param.is_single()) {
+    match (type_1_param.is_single(), type_2_param.is_single()) {
         (true, true) => intersect_atomic_with_atomic(
             statements_analyzer,
             analysis_data,
@@ -2098,8 +2087,7 @@ pub(crate) fn intersect_union_with_union(
                 Some(combined_union)
             }
         }
-    };
-    type_param
+    }
 }
 
 fn intersect_enumcase_with_string(
@@ -2109,17 +2097,15 @@ fn intersect_enumcase_with_string(
     type_2_atomic: &TAtomic,
 ) -> Option<TAtomic> {
     let enum_storage = codebase.classlike_infos.get(type_1_name).unwrap();
-    if let Some(member_storage) = enum_storage.constants.get(type_1_member_name) {
-        if let Some(inferred_type) = &member_storage.inferred_type {
-            if let TAtomic::TLiteralString {
-                value: inferred_value,
-            } = inferred_type
-            {
-                return Some(TAtomic::TLiteralString {
-                    value: inferred_value.clone(),
-                });
-            }
-        }
+    if let Some(member_storage) = enum_storage.constants.get(type_1_member_name)
+        && let Some(inferred_type) = &member_storage.inferred_type
+        && let TAtomic::TLiteralString {
+            value: inferred_value,
+        } = inferred_type
+    {
+        return Some(TAtomic::TLiteralString {
+            value: inferred_value.clone(),
+        });
     }
     Some(type_2_atomic.clone())
 }
@@ -2131,17 +2117,15 @@ fn intersect_enum_case_with_int(
     type_2_atomic: &TAtomic,
 ) -> Option<TAtomic> {
     let enum_storage = codebase.classlike_infos.get(type_1_name).unwrap();
-    if let Some(member_storage) = enum_storage.constants.get(type_1_member_name) {
-        if let Some(inferred_type) = &member_storage.inferred_type {
-            if let TAtomic::TLiteralInt {
-                value: inferred_value,
-            } = inferred_type
-            {
-                return Some(TAtomic::TLiteralInt {
-                    value: *inferred_value,
-                });
-            }
-        }
+    if let Some(member_storage) = enum_storage.constants.get(type_1_member_name)
+        && let Some(inferred_type) = &member_storage.inferred_type
+        && let TAtomic::TLiteralInt {
+            value: inferred_value,
+        } = inferred_type
+    {
+        return Some(TAtomic::TLiteralInt {
+            value: *inferred_value,
+        });
     }
     Some(type_2_atomic.clone())
 }
@@ -2214,29 +2198,25 @@ fn intersect_contained_atomic_with_another(
     pos: Option<&Pos>,
     did_remove_type: &mut bool,
 ) -> Option<TAtomic> {
-    if generic_coercion {
-        if let TAtomic::TNamedObject(TNamedObject {
+    if generic_coercion
+        && let TAtomic::TNamedObject(TNamedObject {
             name: sub_atomic_name,
             type_params: None,
             ..
         }) = sub_atomic
-        {
-            if let TAtomic::TNamedObject(TNamedObject {
-                name: super_atomic_name,
-                type_params: Some(super_params),
-                ..
-            }) = super_atomic
-            {
-                if super_atomic_name == sub_atomic_name {
-                    return Some(TAtomic::TNamedObject(TNamedObject {
-                        name: *sub_atomic_name,
-                        type_params: Some(super_params.clone()),
-                        is_this: false,
-                        remapped_params: false,
-                    }));
-                }
-            }
-        }
+        && let TAtomic::TNamedObject(TNamedObject {
+            name: super_atomic_name,
+            type_params: Some(super_params),
+            ..
+        }) = super_atomic
+        && super_atomic_name == sub_atomic_name
+    {
+        return Some(TAtomic::TNamedObject(TNamedObject {
+            name: *sub_atomic_name,
+            type_params: Some(super_params.clone()),
+            is_this: false,
+            remapped_params: false,
+        }));
     }
 
     if let TAtomic::TNamedObject(TNamedObject { .. }) = sub_atomic {
@@ -2245,25 +2225,24 @@ fn intersect_contained_atomic_with_another(
             as_type: ref mut type_1_as_type,
             ..
         }) = type_1_atomic
+            && type_1_as_type.has_object_type()
         {
-            if type_1_as_type.has_object_type() {
-                let type_1_as = intersect_union_with_atomic(
-                    statements_analyzer,
-                    analysis_data,
-                    type_1_as_type,
-                    sub_atomic,
-                    pos,
-                    did_remove_type,
-                );
+            let type_1_as = intersect_union_with_atomic(
+                statements_analyzer,
+                analysis_data,
+                type_1_as_type,
+                sub_atomic,
+                pos,
+                did_remove_type,
+            );
 
-                if let Some(type_1_as) = type_1_as {
-                    *type_1_as_type = Box::new(type_1_as);
-                } else {
-                    return None;
-                }
-
-                return Some(type_1_atomic);
+            if let Some(type_1_as) = type_1_as {
+                **type_1_as_type = type_1_as;
+            } else {
+                return None;
             }
+
+            return Some(type_1_atomic);
         }
     }
 

--- a/src/analyzer/reconciler/mod.rs
+++ b/src/analyzer/reconciler/mod.rs
@@ -169,10 +169,10 @@ pub(crate) fn reconcile_keyed_types(
             )
         };
 
-        if let Some(maybe_result_type) = &result_type {
-            if maybe_result_type.types.is_empty() {
-                panic!();
-            }
+        if let Some(maybe_result_type) = &result_type
+            && maybe_result_type.types.is_empty()
+        {
+            panic!();
         }
 
         let before_adjustment = result_type.clone();
@@ -241,10 +241,10 @@ pub(crate) fn reconcile_keyed_types(
                     if new_type_part_parts.len() == 1 {
                         let assertion = &new_type_part_parts[0];
 
-                        if let Assertion::IsType(t) | Assertion::IsEqual(t) = assertion {
-                            if t.is_some_scalar() {
-                                has_scalar_restriction = true;
-                            }
+                        if let Assertion::IsType(t) | Assertion::IsEqual(t) = assertion
+                            && t.is_some_scalar()
+                        {
+                            has_scalar_restriction = true;
                         }
                     }
                 }
@@ -443,15 +443,15 @@ fn adjust_array_type(
 
         changed_var_ids.insert(VarName::new(format!("{}[{}]", base_key, array_key.clone())));
 
-        if let Some(last_part) = key_parts.last() {
-            if last_part == "]" {
-                adjust_array_type(
-                    key_parts.clone(),
-                    context,
-                    changed_var_ids,
-                    &wrap_atomic(base_atomic_type.clone()),
-                );
-            }
+        if let Some(last_part) = key_parts.last()
+            && last_part == "]"
+        {
+            adjust_array_type(
+                key_parts.clone(),
+                context,
+                changed_var_ids,
+                &wrap_atomic(base_atomic_type.clone()),
+            );
         }
     }
 
@@ -977,12 +977,12 @@ fn get_value_for_key(
 
                     let class_property_type: TUnion;
 
-                    if let TAtomic::TNull { .. } = existing_key_type_part {
+                    if let TAtomic::TNull = existing_key_type_part {
                         class_property_type = get_null();
                     } else if let TAtomic::TMixed
                     | TAtomic::TMixedWithFlags(..)
                     | TAtomic::TGenericParam(TGenericParam { .. })
-                    | TAtomic::TObject { .. } = existing_key_type_part
+                    | TAtomic::TObject = existing_key_type_part
                     {
                         class_property_type = get_mixed_any();
                     } else if let TAtomic::TNamedObject(TNamedObject {

--- a/src/analyzer/reconciler/negated_assertion_reconciler.rs
+++ b/src/analyzer/reconciler/negated_assertion_reconciler.rs
@@ -90,41 +90,17 @@ pub(crate) fn reconcile(
                     pos,
                 );
 
-                if !has_changes || existing_var_type.is_nothing() {
-                    if let Some(key) = &key {
-                        if let Some(pos) = pos {
-                            trigger_issue_for_impossible(
-                                analysis_data,
-                                statements_analyzer,
-                                &old_var_type_string,
-                                key,
-                                assertion,
-                                !has_changes,
-                                negated,
-                                pos,
-                                calling_functionlike_id,
-                                suppressed_issues,
-                            );
-                        }
-                    }
-                }
-            }
-        } else if let Some(key) = &key {
-            if let Some(pos) = pos {
-                if !union_type_comparator::can_expression_types_be_identical(
-                    codebase,
-                    statements_analyzer.get_file_path(),
-                    &existing_var_type,
-                    &wrap_atomic(assertion_type.clone()),
-                    true,
-                ) {
+                if (!has_changes || existing_var_type.is_nothing())
+                    && let Some(key) = &key
+                    && let Some(pos) = pos
+                {
                     trigger_issue_for_impossible(
                         analysis_data,
                         statements_analyzer,
                         &old_var_type_string,
                         key,
                         assertion,
-                        true,
+                        !has_changes,
                         negated,
                         pos,
                         calling_functionlike_id,
@@ -132,6 +108,28 @@ pub(crate) fn reconcile(
                     );
                 }
             }
+        } else if let Some(key) = &key
+            && let Some(pos) = pos
+            && !union_type_comparator::can_expression_types_be_identical(
+                codebase,
+                statements_analyzer.get_file_path(),
+                &existing_var_type,
+                &wrap_atomic(assertion_type.clone()),
+                true,
+            )
+        {
+            trigger_issue_for_impossible(
+                analysis_data,
+                statements_analyzer,
+                &old_var_type_string,
+                key,
+                assertion,
+                true,
+                negated,
+                pos,
+                calling_functionlike_id,
+                suppressed_issues,
+            );
         }
     }
 
@@ -139,21 +137,21 @@ pub(crate) fn reconcile(
         // todo prevent complaining about $this assertions in traits
 
         if !is_equality {
-            if let Some(key) = &key {
-                if let Some(pos) = pos {
-                    trigger_issue_for_impossible(
-                        analysis_data,
-                        statements_analyzer,
-                        &old_var_type_string,
-                        key,
-                        assertion,
-                        false,
-                        negated,
-                        pos,
-                        calling_functionlike_id,
-                        suppressed_issues,
-                    );
-                }
+            if let Some(key) = &key
+                && let Some(pos) = pos
+            {
+                trigger_issue_for_impossible(
+                    analysis_data,
+                    statements_analyzer,
+                    &old_var_type_string,
+                    key,
+                    assertion,
+                    false,
+                    negated,
+                    pos,
+                    calling_functionlike_id,
+                    suppressed_issues,
+                );
             }
 
             return get_nothing();
@@ -224,22 +222,22 @@ fn subtract_complex_type(
                     .get(existing_classlike_name)
                 {
                     // handle __Sealed classes, negating where possible
-                    if let Some(child_classlikes) = &classlike_storage.child_classlikes {
-                        if child_classlikes.contains(assertion_classlike_name) {
-                            handle_negated_class(
-                                statements_analyzer,
-                                analysis_data,
-                                child_classlikes,
-                                &existing_atomic,
-                                assertion_classlike_name,
-                                &mut acceptable_types,
-                                pos,
-                            );
+                    if let Some(child_classlikes) = &classlike_storage.child_classlikes
+                        && child_classlikes.contains(assertion_classlike_name)
+                    {
+                        handle_negated_class(
+                            statements_analyzer,
+                            analysis_data,
+                            child_classlikes,
+                            &existing_atomic,
+                            assertion_classlike_name,
+                            &mut acceptable_types,
+                            pos,
+                        );
 
-                            *can_be_disjunct = true;
+                        *can_be_disjunct = true;
 
-                            continue;
-                        }
+                        continue;
                     }
                 }
 
@@ -420,7 +418,7 @@ pub(crate) fn handle_literal_negated_equality(
 
     for existing_atomic_type in existing_var_types {
         match existing_atomic_type {
-            TAtomic::TInt { .. } | TAtomic::TNum => {
+            TAtomic::TInt | TAtomic::TNum => {
                 if let TAtomic::TLiteralInt { .. } | TAtomic::TEnumLiteralCase { .. } =
                     assertion_type
                 {
@@ -554,25 +552,24 @@ pub(crate) fn handle_literal_negated_equality(
 
                     let mut member_enum_literals = vec![];
                     for (cname, const_info) in &enum_storage.constants {
-                        if let Some(inferred_type) = &const_info.inferred_type {
-                            if let TAtomic::TLiteralString {
+                        if let Some(inferred_type) = &const_info.inferred_type
+                            && let TAtomic::TLiteralString {
                                 value: const_inferred_value,
                             } = inferred_type
-                            {
-                                if const_inferred_value != assertion_value {
-                                    if let Some(constant_type) = codebase.get_class_constant_type(
-                                        &existing_name,
-                                        false,
-                                        cname,
-                                        FxHashSet::default(),
-                                    ) {
-                                        member_enum_literals.push(constant_type.get_single_owned());
-                                    } else {
-                                        panic!("unrecognised constant type");
-                                    }
+                        {
+                            if const_inferred_value != assertion_value {
+                                if let Some(constant_type) = codebase.get_class_constant_type(
+                                    &existing_name,
+                                    false,
+                                    cname,
+                                    FxHashSet::default(),
+                                ) {
+                                    member_enum_literals.push(constant_type.get_single_owned());
                                 } else {
-                                    matched_string = true;
+                                    panic!("unrecognised constant type");
                                 }
+                            } else {
+                                matched_string = true;
                             }
                         }
                     }
@@ -593,25 +590,24 @@ pub(crate) fn handle_literal_negated_equality(
 
                     let mut member_enum_literals = vec![];
                     for (cname, const_info) in &enum_storage.constants {
-                        if let Some(inferred_type) = &const_info.inferred_type {
-                            if let TAtomic::TLiteralInt {
+                        if let Some(inferred_type) = &const_info.inferred_type
+                            && let TAtomic::TLiteralInt {
                                 value: const_inferred_value,
                             } = inferred_type
-                            {
-                                if const_inferred_value != assertion_value {
-                                    if let Some(constant_type) = codebase.get_class_constant_type(
-                                        &existing_name,
-                                        false,
-                                        cname,
-                                        FxHashSet::default(),
-                                    ) {
-                                        member_enum_literals.push(constant_type.get_single_owned());
-                                    } else {
-                                        panic!("unrecognised constant type");
-                                    }
+                        {
+                            if const_inferred_value != assertion_value {
+                                if let Some(constant_type) = codebase.get_class_constant_type(
+                                    &existing_name,
+                                    false,
+                                    cname,
+                                    FxHashSet::default(),
+                                ) {
+                                    member_enum_literals.push(constant_type.get_single_owned());
                                 } else {
-                                    matched_string = true;
+                                    panic!("unrecognised constant type");
                                 }
+                            } else {
+                                matched_string = true;
                             }
                         }
                     }
@@ -648,17 +644,14 @@ pub(crate) fn handle_literal_negated_equality(
 
                     let mut matched_string = false;
 
-                    if let Some(const_info) = enum_storage.constants.get(&existing_member_name) {
-                        if let Some(const_inferred_type) = &const_info.inferred_type {
-                            if let TAtomic::TLiteralString {
-                                value: const_inferred_value,
-                            } = const_inferred_type
-                            {
-                                if const_inferred_value == value {
-                                    matched_string = true;
-                                }
-                            }
-                        }
+                    if let Some(const_info) = enum_storage.constants.get(&existing_member_name)
+                        && let Some(const_inferred_type) = &const_info.inferred_type
+                        && let TAtomic::TLiteralString {
+                            value: const_inferred_value,
+                        } = const_inferred_type
+                        && const_inferred_value == value
+                    {
+                        matched_string = true;
                     }
 
                     if !matched_string {
@@ -688,7 +681,7 @@ pub(crate) fn handle_literal_negated_equality(
                 did_remove_type = true;
                 acceptable_types.push(existing_atomic_type);
             }
-            TAtomic::TMixed {} | TAtomic::TMixedWithFlags(..) | TAtomic::TMixedFromLoopIsset => {
+            TAtomic::TMixed | TAtomic::TMixedWithFlags(..) | TAtomic::TMixedFromLoopIsset => {
                 did_remove_type = true;
                 acceptable_types.push(existing_atomic_type);
             }
@@ -725,23 +718,22 @@ pub(crate) fn handle_literal_negated_equality(
         }
     }
 
-    if let Some(key) = &key {
-        if let Some(pos) = pos {
-            if !did_remove_type || acceptable_types.is_empty() {
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
-        }
+    if let Some(key) = &key
+        && let Some(pos) = pos
+        && (!did_remove_type || acceptable_types.is_empty())
+    {
+        trigger_issue_for_impossible(
+            analysis_data,
+            statements_analyzer,
+            &old_var_type_string,
+            key,
+            assertion,
+            !did_remove_type,
+            negated,
+            pos,
+            calling_functionlike_id,
+            suppressed_issues,
+        );
     }
 
     new_var_type.types = acceptable_types;

--- a/src/analyzer/reconciler/simple_assertion_reconciler.rs
+++ b/src/analyzer/reconciler/simple_assertion_reconciler.rs
@@ -38,24 +38,20 @@ pub(crate) fn reconcile(
 ) -> Option<TUnion> {
     let assertion_type = assertion.get_type();
 
-    if let Some(assertion_type) = assertion_type {
-        match assertion_type {
-            TAtomic::TMixedWithFlags(_, _, _, true) => {
-                return Some(subtract_null(
-                    assertion,
-                    existing_var_type,
-                    key,
-                    !negated,
-                    analysis_data,
-                    statements_analyzer,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                ));
-            }
-
-            _ => {}
-        }
+    if let Some(assertion_type) = assertion_type
+        && let TAtomic::TMixedWithFlags(_, _, _, true) = assertion_type
+    {
+        return Some(subtract_null(
+            assertion,
+            existing_var_type,
+            key,
+            !negated,
+            analysis_data,
+            statements_analyzer,
+            pos,
+            calling_functionlike_id,
+            suppressed_issues,
+        ));
     }
 
     match assertion {
@@ -233,7 +229,7 @@ fn reconcile_truthy(
                     did_remove_type = true;
                     acceptable_types.push(atomic);
                 }
-                TAtomic::TBool { .. } => {
+                TAtomic::TBool => {
                     acceptable_types.push(TAtomic::TTrue);
                 }
                 TAtomic::TVec(TVec { .. }) => {
@@ -314,7 +310,7 @@ fn reconcile_isset(
     let mut acceptable_types = vec![];
 
     for atomic in existing_var_types {
-        if let TAtomic::TNull { .. } = atomic {
+        if let TAtomic::TNull = atomic {
             did_remove_type = true;
         } else if let TAtomic::TMixed = atomic {
             acceptable_types.push(TAtomic::TMixedWithFlags(false, false, false, true));
@@ -329,24 +325,23 @@ fn reconcile_isset(
 
     if !did_remove_type || acceptable_types.is_empty() {
         // every type was removed, this is an impossible assertion
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                let old_var_type_string =
-                    existing_var_type.get_id(Some(statements_analyzer.interner));
+        if let Some(key) = key
+            && let Some(pos) = pos
+        {
+            let old_var_type_string = existing_var_type.get_id(Some(statements_analyzer.interner));
 
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
+            trigger_issue_for_impossible(
+                analysis_data,
+                statements_analyzer,
+                &old_var_type_string,
+                key,
+                assertion,
+                !did_remove_type,
+                negated,
+                pos,
+                calling_functionlike_id,
+                suppressed_issues,
+            );
         }
 
         if acceptable_types.is_empty() {
@@ -466,26 +461,24 @@ fn reconcile_non_empty_countable(
 
     if !did_remove_type || acceptable_types.is_empty() {
         // every type was removed, this is an impossible assertion
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                if !recursive_check {
-                    let old_var_type_string =
-                        existing_var_type.get_id(Some(statements_analyzer.interner));
+        if let Some(key) = key
+            && let Some(pos) = pos
+            && !recursive_check
+        {
+            let old_var_type_string = existing_var_type.get_id(Some(statements_analyzer.interner));
 
-                    trigger_issue_for_impossible(
-                        analysis_data,
-                        statements_analyzer,
-                        &old_var_type_string,
-                        key,
-                        assertion,
-                        !did_remove_type,
-                        negated,
-                        pos,
-                        calling_functionlike_id,
-                        suppressed_issues,
-                    );
-                }
-            }
+            trigger_issue_for_impossible(
+                analysis_data,
+                statements_analyzer,
+                &old_var_type_string,
+                key,
+                assertion,
+                !did_remove_type,
+                negated,
+                pos,
+                calling_functionlike_id,
+                suppressed_issues,
+            );
         }
 
         if acceptable_types.is_empty() {
@@ -571,23 +564,22 @@ fn reconcile_exactly_countable(
 
     if !did_remove_type || existing_var_type.types.is_empty() {
         // every type was removed, this is an impossible assertion
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                if !recursive_check {
-                    trigger_issue_for_impossible(
-                        analysis_data,
-                        statements_analyzer,
-                        &old_var_type_string,
-                        key,
-                        assertion,
-                        !did_remove_type,
-                        negated,
-                        pos,
-                        calling_functionlike_id,
-                        suppressed_issues,
-                    );
-                }
-            }
+        if let Some(key) = key
+            && let Some(pos) = pos
+            && !recursive_check
+        {
+            trigger_issue_for_impossible(
+                analysis_data,
+                statements_analyzer,
+                &old_var_type_string,
+                key,
+                assertion,
+                !did_remove_type,
+                negated,
+                pos,
+                calling_functionlike_id,
+                suppressed_issues,
+            );
         }
 
         if existing_var_type.types.is_empty() {
@@ -627,24 +619,23 @@ fn reconcile_array_access(
 
     if new_var_type.types.is_empty() {
         // every type was removed, this is an impossible assertion
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                let old_var_type_string =
-                    existing_var_type.get_id(Some(statements_analyzer.interner));
+        if let Some(key) = key
+            && let Some(pos) = pos
+        {
+            let old_var_type_string = existing_var_type.get_id(Some(statements_analyzer.interner));
 
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    false,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
+            trigger_issue_for_impossible(
+                analysis_data,
+                statements_analyzer,
+                &old_var_type_string,
+                key,
+                assertion,
+                false,
+                negated,
+                pos,
+                calling_functionlike_id,
+                suppressed_issues,
+            );
         }
 
         if new_var_type.types.is_empty() {
@@ -674,21 +665,21 @@ fn reconcile_in_array(
         return intersection;
     }
 
-    if let Some(key) = key {
-        if let Some(pos) = pos {
-            trigger_issue_for_impossible(
-                analysis_data,
-                statements_analyzer,
-                &existing_var_type.get_id(Some(statements_analyzer.interner)),
-                key,
-                assertion,
-                true,
-                negated,
-                pos,
-                calling_functionlike_id,
-                suppressed_issues,
-            );
-        }
+    if let Some(key) = key
+        && let Some(pos) = pos
+    {
+        trigger_issue_for_impossible(
+            analysis_data,
+            statements_analyzer,
+            &existing_var_type.get_id(Some(statements_analyzer.interner)),
+            key,
+            assertion,
+            true,
+            negated,
+            pos,
+            calling_functionlike_id,
+            suppressed_issues,
+        );
     }
 
     get_mixed_any()
@@ -851,24 +842,23 @@ fn reconcile_has_array_key(
 
     if !did_remove_type || acceptable_types.is_empty() {
         // every type was removed, this is an impossible assertion
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                let old_var_type_string =
-                    existing_var_type.get_id(Some(statements_analyzer.interner));
+        if let Some(key) = key
+            && let Some(pos) = pos
+        {
+            let old_var_type_string = existing_var_type.get_id(Some(statements_analyzer.interner));
 
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
+            trigger_issue_for_impossible(
+                analysis_data,
+                statements_analyzer,
+                &old_var_type_string,
+                key,
+                assertion,
+                !did_remove_type,
+                negated,
+                pos,
+                calling_functionlike_id,
+                suppressed_issues,
+            );
         }
 
         if acceptable_types.is_empty() {
@@ -1115,24 +1105,23 @@ fn reconcile_has_nonnull_entry_for_key(
 
     if !did_remove_type || acceptable_types.is_empty() {
         // every type was removed, this is an impossible assertion
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                let old_var_type_string =
-                    existing_var_type.get_id(Some(statements_analyzer.interner));
+        if let Some(key) = key
+            && let Some(pos) = pos
+        {
+            let old_var_type_string = existing_var_type.get_id(Some(statements_analyzer.interner));
 
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
+            trigger_issue_for_impossible(
+                analysis_data,
+                statements_analyzer,
+                &old_var_type_string,
+                key,
+                assertion,
+                !did_remove_type,
+                negated,
+                pos,
+                calling_functionlike_id,
+                suppressed_issues,
+            );
         }
 
         if acceptable_types.is_empty() {
@@ -1159,26 +1148,24 @@ pub(crate) fn get_acceptable_type(
     suppressed_issues: &FxHashMap<String, usize>,
     mut new_var_type: TUnion,
 ) -> TUnion {
-    if acceptable_types.is_empty() || !did_remove_type {
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                let old_var_type_string =
-                    existing_var_type.get_id(Some(statements_analyzer.interner));
+    if (acceptable_types.is_empty() || !did_remove_type)
+        && let Some(key) = key
+        && let Some(pos) = pos
+    {
+        let old_var_type_string = existing_var_type.get_id(Some(statements_analyzer.interner));
 
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
-        }
+        trigger_issue_for_impossible(
+            analysis_data,
+            statements_analyzer,
+            &old_var_type_string,
+            key,
+            assertion,
+            !did_remove_type,
+            negated,
+            pos,
+            calling_functionlike_id,
+            suppressed_issues,
+        );
     }
 
     if acceptable_types.is_empty() {

--- a/src/analyzer/reconciler/simple_negated_assertion_reconciler.rs
+++ b/src/analyzer/reconciler/simple_negated_assertion_reconciler.rs
@@ -51,7 +51,7 @@ pub(crate) fn reconcile(
                     suppressed_issues,
                 ));
             }
-            TAtomic::TBool { .. } => {
+            TAtomic::TBool => {
                 return Some(subtract_bool(
                     assertion,
                     existing_var_type,
@@ -65,7 +65,7 @@ pub(crate) fn reconcile(
                     suppressed_issues,
                 ));
             }
-            TAtomic::TNum { .. } => {
+            TAtomic::TNum => {
                 return Some(subtract_num(
                     assertion,
                     existing_var_type,
@@ -79,7 +79,7 @@ pub(crate) fn reconcile(
                     suppressed_issues,
                 ));
             }
-            TAtomic::TFloat { .. } => {
+            TAtomic::TFloat => {
                 return Some(subtract_float(
                     assertion,
                     existing_var_type,
@@ -93,7 +93,7 @@ pub(crate) fn reconcile(
                     suppressed_issues,
                 ));
             }
-            TAtomic::TInt { .. } => {
+            TAtomic::TInt => {
                 return Some(subtract_int(
                     assertion,
                     existing_var_type,
@@ -107,7 +107,7 @@ pub(crate) fn reconcile(
                     suppressed_issues,
                 ));
             }
-            TAtomic::TString { .. } => {
+            TAtomic::TString => {
                 return Some(subtract_string(
                     assertion,
                     existing_var_type,
@@ -183,7 +183,7 @@ pub(crate) fn reconcile(
                     suppressed_issues,
                 ));
             }
-            TAtomic::TNull { .. } => {
+            TAtomic::TNull => {
                 return Some(subtract_null(
                     assertion,
                     existing_var_type,
@@ -209,7 +209,7 @@ pub(crate) fn reconcile(
                     .unwrap_or(get_nothing()),
                 );
             }
-            TAtomic::TFalse { .. } => {
+            TAtomic::TFalse => {
                 return Some(subtract_false(
                     assertion,
                     existing_var_type,
@@ -223,7 +223,7 @@ pub(crate) fn reconcile(
                     suppressed_issues,
                 ));
             }
-            TAtomic::TTrue { .. } => {
+            TAtomic::TTrue => {
                 return Some(subtract_true(
                     assertion,
                     existing_var_type,
@@ -241,7 +241,7 @@ pub(crate) fn reconcile(
         }
     }
 
-    return match assertion {
+    match assertion {
         Assertion::Falsy => Some(reconcile_falsy(
             assertion,
             existing_var_type,
@@ -258,9 +258,7 @@ pub(crate) fn reconcile(
             possibly_undefined,
             key,
         )),
-        Assertion::ArrayKeyDoesNotExist => {
-            return Some(get_nothing());
-        }
+        Assertion::ArrayKeyDoesNotExist => Some(get_nothing()),
         Assertion::DoesNotHaveArrayKey(key_name) => Some(reconcile_no_array_key(
             assertion,
             existing_var_type,
@@ -311,7 +309,7 @@ pub(crate) fn reconcile(
             count,
         )),
         _ => None,
-    };
+    }
 }
 
 fn subtract_object(
@@ -687,10 +685,8 @@ fn subtract_string(
                 acceptable_types.push(atomic);
             }
         } else {
-            if is_equality {
-                if let TAtomic::TTypeAlias { .. } | TAtomic::TEnum { .. } = &atomic {
-                    did_remove_type = true;
-                }
+            if is_equality && let TAtomic::TTypeAlias { .. } | TAtomic::TEnum { .. } = &atomic {
+                did_remove_type = true;
             }
 
             acceptable_types.push(atomic);
@@ -894,7 +890,7 @@ fn subtract_float(
             }
 
             did_remove_type = true;
-        } else if let TAtomic::TFloat { .. } = atomic {
+        } else if let TAtomic::TFloat = atomic {
             did_remove_type = true;
 
             if is_equality {
@@ -989,8 +985,7 @@ fn subtract_num(
             }
 
             did_remove_type = true;
-        } else if let TAtomic::TFloat { .. } | TAtomic::TInt { .. } | TAtomic::TNum { .. } = atomic
-        {
+        } else if let TAtomic::TFloat | TAtomic::TInt | TAtomic::TNum = atomic {
             did_remove_type = true;
 
             if !is_equality {
@@ -999,23 +994,22 @@ fn subtract_num(
         }
     }
 
-    if existing_var_type.types.is_empty() || !did_remove_type {
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
-        }
+    if (existing_var_type.types.is_empty() || !did_remove_type)
+        && let Some(key) = key
+        && let Some(pos) = pos
+    {
+        trigger_issue_for_impossible(
+            analysis_data,
+            statements_analyzer,
+            &old_var_type_string,
+            key,
+            assertion,
+            !did_remove_type,
+            negated,
+            pos,
+            calling_functionlike_id,
+            suppressed_issues,
+        );
     }
 
     if existing_var_type.types.is_empty() {
@@ -1098,23 +1092,22 @@ fn subtract_arraykey(
         }
     }
 
-    if existing_var_type.types.is_empty() || !did_remove_type {
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
-        }
+    if (existing_var_type.types.is_empty() || !did_remove_type)
+        && let Some(key) = key
+        && let Some(pos) = pos
+    {
+        trigger_issue_for_impossible(
+            analysis_data,
+            statements_analyzer,
+            &old_var_type_string,
+            key,
+            assertion,
+            !did_remove_type,
+            negated,
+            pos,
+            calling_functionlike_id,
+            suppressed_issues,
+        );
     }
 
     if existing_var_type.types.is_empty() {
@@ -1188,23 +1181,22 @@ fn subtract_bool(
         }
     }
 
-    if existing_var_type.types.is_empty() || !did_remove_type {
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
-        }
+    if (existing_var_type.types.is_empty() || !did_remove_type)
+        && let Some(key) = key
+        && let Some(pos) = pos
+    {
+        trigger_issue_for_impossible(
+            analysis_data,
+            statements_analyzer,
+            &old_var_type_string,
+            key,
+            assertion,
+            !did_remove_type,
+            negated,
+            pos,
+            calling_functionlike_id,
+            suppressed_issues,
+        );
     }
 
     if existing_var_type.types.is_empty() {
@@ -1348,30 +1340,29 @@ fn subtract_false(
             existing_var_type.remove_type(atomic);
             existing_var_type.types.push(TAtomic::TTrue);
             did_remove_type = true;
-        } else if let TAtomic::TFalse { .. } = atomic {
+        } else if let TAtomic::TFalse = atomic {
             did_remove_type = true;
 
             existing_var_type.remove_type(atomic);
         }
     }
 
-    if existing_var_type.types.is_empty() || !did_remove_type {
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
-        }
+    if (existing_var_type.types.is_empty() || !did_remove_type)
+        && let Some(key) = key
+        && let Some(pos) = pos
+    {
+        trigger_issue_for_impossible(
+            analysis_data,
+            statements_analyzer,
+            &old_var_type_string,
+            key,
+            assertion,
+            !did_remove_type,
+            negated,
+            pos,
+            calling_functionlike_id,
+            suppressed_issues,
+        );
     }
 
     if existing_var_type.types.is_empty() {
@@ -1436,7 +1427,7 @@ fn subtract_true(
                 existing_var_type.types.push(TAtomic::TFalse);
                 did_remove_type = true;
             }
-            TAtomic::TTrue { .. } => {
+            TAtomic::TTrue => {
                 did_remove_type = true;
 
                 existing_var_type.remove_type(atomic);
@@ -1445,23 +1436,22 @@ fn subtract_true(
         }
     }
 
-    if existing_var_type.types.is_empty() || !did_remove_type {
-        if let Some(key) = key {
-            if let Some(pos) = pos {
-                trigger_issue_for_impossible(
-                    analysis_data,
-                    statements_analyzer,
-                    &old_var_type_string,
-                    key,
-                    assertion,
-                    !did_remove_type,
-                    negated,
-                    pos,
-                    calling_functionlike_id,
-                    suppressed_issues,
-                );
-            }
-        }
+    if (existing_var_type.types.is_empty() || !did_remove_type)
+        && let Some(key) = key
+        && let Some(pos) = pos
+    {
+        trigger_issue_for_impossible(
+            analysis_data,
+            statements_analyzer,
+            &old_var_type_string,
+            key,
+            assertion,
+            !did_remove_type,
+            negated,
+            pos,
+            calling_functionlike_id,
+            suppressed_issues,
+        );
     }
 
     if existing_var_type.types.is_empty() {
@@ -1519,7 +1509,7 @@ fn reconcile_falsy(
                 TAtomic::TTypeVariable { .. } => {
                     acceptable_types.push(atomic);
                 }
-                TAtomic::TBool { .. } => {
+                TAtomic::TBool => {
                     acceptable_types.push(TAtomic::TFalse);
                 }
                 TAtomic::TVec(TVec { .. }) => {
@@ -1551,7 +1541,7 @@ fn reconcile_falsy(
                 TAtomic::TMixedFromLoopIsset => {
                     acceptable_types.push(TAtomic::TMixedWithFlags(false, false, true, false));
                 }
-                TAtomic::TString { .. } => {
+                TAtomic::TString => {
                     let empty_string = TAtomic::TLiteralString {
                         value: "".to_string(),
                     };
@@ -1561,7 +1551,7 @@ fn reconcile_falsy(
                     acceptable_types.push(empty_string);
                     acceptable_types.push(falsy_string);
                 }
-                TAtomic::TInt { .. } => {
+                TAtomic::TInt => {
                     let zero = TAtomic::TLiteralInt { value: 0 };
                     acceptable_types.push(zero);
                 }
@@ -1601,14 +1591,12 @@ fn reconcile_not_isset(
         return get_nothing();
     }
 
-    if !existing_var_type.is_nullable() {
-        if let Some(key) = key {
-            if !key.contains('[')
-                && (!existing_var_type.is_mixed() || existing_var_type.is_always_truthy())
-            {
-                return get_nothing();
-            }
-        }
+    if !existing_var_type.is_nullable()
+        && let Some(key) = key
+        && !key.contains('[')
+        && (!existing_var_type.is_mixed() || existing_var_type.is_always_truthy())
+    {
+        return get_nothing();
     }
 
     get_null()
@@ -1805,10 +1793,10 @@ fn reconcile_not_exactly_countable(
             } else if !atomic.is_falsy() {
                 did_remove_type = true;
             }
-        } else if let TAtomic::TDict(TDict { .. }) = atomic {
-            if !atomic.is_falsy() {
-                did_remove_type = true;
-            }
+        } else if let TAtomic::TDict(TDict { .. }) = atomic
+            && !atomic.is_falsy()
+        {
+            did_remove_type = true;
         }
 
         acceptable_types.push(atomic);
@@ -1900,8 +1888,8 @@ fn reconcile_no_array_key(
                             known_items.remove(key_name);
                             did_remove_type = true;
                         }
-                    } else if let Some((key_param, _)) = params {
-                        if union_type_comparator::can_expression_types_be_identical(
+                    } else if let Some((key_param, _)) = params
+                        && union_type_comparator::can_expression_types_be_identical(
                             statements_analyzer.codebase,
                             statements_analyzer.get_file_path(),
                             &wrap_atomic(match key_name {
@@ -1916,12 +1904,12 @@ fn reconcile_no_array_key(
                             }),
                             key_param,
                             false,
-                        ) {
-                            did_remove_type = true;
-                        }
+                        )
+                    {
+                        did_remove_type = true;
                     }
-                } else if let Some((key_param, _)) = params {
-                    if union_type_comparator::can_expression_types_be_identical(
+                } else if let Some((key_param, _)) = params
+                    && union_type_comparator::can_expression_types_be_identical(
                         statements_analyzer.codebase,
                         statements_analyzer.get_file_path(),
                         &wrap_atomic(match key_name {
@@ -1936,9 +1924,9 @@ fn reconcile_no_array_key(
                         }),
                         key_param,
                         false,
-                    ) {
-                        did_remove_type = true;
-                    }
+                    )
+                {
+                    did_remove_type = true;
                 }
 
                 acceptable_types.push(atomic);

--- a/src/analyzer/scope/mod.rs
+++ b/src/analyzer/scope/mod.rs
@@ -295,11 +295,11 @@ impl BlockContext {
 
             for key in c.possibilities.keys() {
                 for changed_var_id in changed_var_ids {
-                    if let ClauseKey::Name(var_name) = key {
-                        if changed_var_id == var_name || var_has_root(&var_name, changed_var_id) {
-                            rejected_clauses.push(c.clone());
-                            continue 'outer;
-                        }
+                    if let ClauseKey::Name(var_name) = key
+                        && (changed_var_id == var_name || var_has_root(var_name, changed_var_id))
+                    {
+                        rejected_clauses.push(c.clone());
+                        continue 'outer;
                     }
                 }
             }
@@ -324,11 +324,11 @@ impl BlockContext {
             }
 
             for key in c.possibilities.keys() {
-                if let ClauseKey::Name(var_name) = key {
-                    if changed_var_ids.contains(var_name) {
-                        rejected_clauses.push(c.clone());
-                        continue 'outer;
-                    }
+                if let ClauseKey::Name(var_name) = key
+                    && changed_var_ids.contains(var_name)
+                {
+                    rejected_clauses.push(c.clone());
+                    continue 'outer;
                 }
             }
 
@@ -351,10 +351,10 @@ impl BlockContext {
 
         'outer: for clause in clauses {
             for var_id in clause.possibilities.keys() {
-                if let ClauseKey::Name(var_name) = var_id {
-                    if var_has_root(var_name, remove_var_id) {
-                        break 'outer;
-                    }
+                if let ClauseKey::Name(var_name) = var_id
+                    && var_has_root(var_name, remove_var_id)
+                {
+                    break 'outer;
                 }
             }
 
@@ -367,48 +367,47 @@ impl BlockContext {
             }
         }
 
-        if let Some(statements_analyzer) = statements_analyzer {
-            if let Some(new_type) = new_type {
-                if !new_type.is_mixed() {
-                    let clause_key = ClauseKey::Name(VarName::new(remove_var_id.to_string()));
+        if let Some(statements_analyzer) = statements_analyzer
+            && let Some(new_type) = new_type
+            && !new_type.is_mixed()
+        {
+            let clause_key = ClauseKey::Name(VarName::new(remove_var_id));
 
-                    for clause in other_clauses {
-                        let mut type_changed = false;
+            for clause in other_clauses {
+                let mut type_changed = false;
 
-                        // if the clause contains any possibilities that would be altered
-                        // by the new type
-                        for (_, assertion) in clause.possibilities.get(&clause_key).unwrap() {
-                            // if we're negating a type, we generally don't need the clause anymore
-                            if assertion.has_negation() {
-                                type_changed = true;
-                                break;
-                            }
-
-                            let result_type = assertion_reconciler::reconcile(
-                                assertion,
-                                Some(&new_type.clone()),
-                                false,
-                                None,
-                                statements_analyzer,
-                                analysis_data,
-                                false,
-                                None,
-                                &None,
-                                false,
-                                false,
-                                &FxHashMap::default(),
-                            );
-
-                            if result_type != *new_type {
-                                type_changed = true;
-                                break;
-                            }
-                        }
-
-                        if !type_changed {
-                            clauses_to_keep.push(clause.clone());
-                        }
+                // if the clause contains any possibilities that would be altered
+                // by the new type
+                for (_, assertion) in clause.possibilities.get(&clause_key).unwrap() {
+                    // if we're negating a type, we generally don't need the clause anymore
+                    if assertion.has_negation() {
+                        type_changed = true;
+                        break;
                     }
+
+                    let result_type = assertion_reconciler::reconcile(
+                        assertion,
+                        Some(&new_type.clone()),
+                        false,
+                        None,
+                        statements_analyzer,
+                        analysis_data,
+                        false,
+                        None,
+                        &None,
+                        false,
+                        false,
+                        &FxHashMap::default(),
+                    );
+
+                    if result_type != *new_type {
+                        type_changed = true;
+                        break;
+                    }
+                }
+
+                if !type_changed {
+                    clauses_to_keep.push(clause.clone());
                 }
             }
         }
@@ -431,7 +430,7 @@ impl BlockContext {
             analysis_data,
         );
         self.parent_conflicting_clause_vars
-            .insert(VarName::new(remove_var_id.to_string()));
+            .insert(VarName::new(remove_var_id));
     }
 
     pub(crate) fn remove_descendants(
@@ -483,10 +482,10 @@ impl BlockContext {
             let mut retain_clause = true;
 
             for var_id in clause.possibilities.keys() {
-                if let ClauseKey::Name(var_id) = var_id {
-                    if var_id.contains("->") || var_id.contains("::") {
-                        retain_clause = false;
-                    }
+                if let ClauseKey::Name(var_id) = var_id
+                    && (var_id.contains("->") || var_id.contains("::"))
+                {
+                    retain_clause = false;
                 }
             }
 
@@ -495,8 +494,7 @@ impl BlockContext {
     }
 
     pub(crate) fn has_variable(&mut self, var_name: &str) -> bool {
-        self.cond_referenced_var_ids
-            .insert(VarName::new(var_name.to_string()));
+        self.cond_referenced_var_ids.insert(VarName::new(var_name));
 
         self.locals.contains_key(var_name)
     }
@@ -505,17 +503,16 @@ impl BlockContext {
 fn should_keep_clause(clause: &Rc<Clause>, remove_var_id: &str, new_type: Option<&TUnion>) -> bool {
     clause
         .possibilities
-        .get(&ClauseKey::Name(VarName::new(remove_var_id.to_string())))
-        .map_or(true, |possibilities| {
+        .get(&ClauseKey::Name(VarName::new(remove_var_id)))
+        .is_none_or(|possibilities| {
             if possibilities.len() == 1 {
                 let assertion = possibilities.values().next().unwrap();
 
-                if let Assertion::IsType(assertion_type) = assertion {
-                    if let Some(new_type) = new_type {
-                        if new_type.is_single() {
-                            return new_type.get_single() == assertion_type;
-                        }
-                    }
+                if let Assertion::IsType(assertion_type) = assertion
+                    && let Some(new_type) = new_type
+                    && new_type.is_single()
+                {
+                    return new_type.get_single() == assertion_type;
                 }
             }
 

--- a/src/analyzer/statements_analyzer.rs
+++ b/src/analyzer/statements_analyzer.rs
@@ -41,7 +41,7 @@ impl<'a> StatementsAnalyzer<'a> {
             type_resolution_context,
             in_migratable_function: false,
             interner: file_analyzer.interner,
-            codebase: &file_analyzer.codebase,
+            codebase: file_analyzer.codebase,
         }
     }
 
@@ -164,7 +164,7 @@ impl<'a> StatementsAnalyzer<'a> {
         let config = self.get_config();
         if config.issues_to_fix.contains(&issue.kind) && !config.add_fixmes {
             return !context.function_context.is_production(self.codebase)
-                || analysis_data.get_matching_hakana_fixme(&issue).is_none();
+                || analysis_data.get_matching_hakana_fixme(issue).is_none();
         }
 
         false
@@ -173,7 +173,7 @@ impl<'a> StatementsAnalyzer<'a> {
 
 impl ScopeAnalyzer for StatementsAnalyzer<'_> {
     fn get_namespace(&self) -> &Option<String> {
-        return self.file_analyzer.get_namespace();
+        self.file_analyzer.get_namespace()
     }
 
     fn get_file_analyzer(&self) -> &FileAnalyzer<'_> {

--- a/src/analyzer/stmt/break_analyzer.rs
+++ b/src/analyzer/stmt/break_analyzer.rs
@@ -55,7 +55,7 @@ pub(crate) fn analyze(
             for (var_id, var_type) in &context.locals {
                 if !loop_scope.parent_context_vars.contains_key(var_id) {
                     loop_scope.possibly_defined_loop_parent_vars.insert(
-                        VarName::new(var_id.to_string()),
+                        VarName::new(var_id),
                         combine_optional_union_types(
                             Some(var_type),
                             loop_scope.possibly_defined_loop_parent_vars.get(var_id),
@@ -85,26 +85,22 @@ pub(crate) fn analyze(
 
     let case_scope = analysis_data.case_scopes.last_mut();
 
-    if let Some(case_scope) = case_scope {
-        if leaving_switch {
-            let mut new_break_vars = case_scope
-                .break_vars
-                .clone()
-                .unwrap_or(FxHashMap::default());
+    if let Some(case_scope) = case_scope
+        && leaving_switch
+    {
+        let mut new_break_vars = case_scope
+            .break_vars
+            .clone()
+            .unwrap_or(FxHashMap::default());
 
-            for (var_id, var_type) in &context.locals {
-                new_break_vars.insert(
-                    var_id.clone(),
-                    combine_optional_union_types(
-                        Some(var_type),
-                        new_break_vars.get(var_id),
-                        codebase,
-                    ),
-                );
-            }
-
-            case_scope.break_vars = Some(new_break_vars);
+        for (var_id, var_type) in &context.locals {
+            new_break_vars.insert(
+                var_id.clone(),
+                combine_optional_union_types(Some(var_type), new_break_vars.get(var_id), codebase),
+            );
         }
+
+        case_scope.break_vars = Some(new_break_vars);
     }
 
     context.has_returned = true;

--- a/src/analyzer/stmt/control_analyzer.rs
+++ b/src/analyzer/stmt/control_analyzer.rs
@@ -30,10 +30,10 @@ pub(crate) fn get_control_actions(
     'outer: for stmt in stmts {
         match &stmt.1 {
             aast::Stmt_::Expr(boxed) => {
-                if let Some(t) = analysis_data.get_expr_type(boxed.pos()) {
-                    if t.is_nothing() {
-                        return control_end(control_actions);
-                    }
+                if let Some(t) = analysis_data.get_expr_type(boxed.pos())
+                    && t.is_nothing()
+                {
+                    return control_end(control_actions);
                 }
             }
             aast::Stmt_::Break => {
@@ -147,21 +147,21 @@ pub(crate) fn get_control_actions(
                 // check for infinite loop behaviour
                 match &stmt.1 {
                     aast::Stmt_::While(boxed) => {
-                        if let Some(expr_type) = analysis_data.get_expr_type(&boxed.0.2.1) {
-                            if expr_type.is_always_truthy() {
-                                //infinite while loop that only return don't have an exit path
-                                let loop_only_ends = control_actions
-                                    .iter()
-                                    .filter(|action| {
-                                        *action != &ControlAction::End
-                                            && *action != &ControlAction::Return
-                                    })
-                                    .count()
-                                    == 0;
+                        if let Some(expr_type) = analysis_data.get_expr_type(&boxed.0.2.1)
+                            && expr_type.is_always_truthy()
+                        {
+                            //infinite while loop that only return don't have an exit path
+                            let loop_only_ends = control_actions
+                                .iter()
+                                .filter(|action| {
+                                    *action != &ControlAction::End
+                                        && *action != &ControlAction::Return
+                                })
+                                .count()
+                                == 0;
 
-                                if loop_only_ends {
-                                    return control_actions;
-                                }
+                            if loop_only_ends {
+                                return control_actions;
                             }
                         }
                     }

--- a/src/analyzer/stmt/else_analyzer.rs
+++ b/src/analyzer/stmt/else_analyzer.rs
@@ -79,14 +79,14 @@ pub(crate) fn analyze(
     else_context.possibly_assigned_var_ids.clear();
 
     // Track else block boundaries for variable scoping analysis
-    if let Some(first_stmt) = stmts.0.first() {
-        if let Some(last_stmt) = stmts.0.last() {
-            let else_block_start = first_stmt.0.start_offset() as u32;
-            let else_block_end = last_stmt.0.end_offset() as u32;
-            analysis_data
-                .if_block_boundaries
-                .push((else_block_start, else_block_end));
-        }
+    if let Some(first_stmt) = stmts.0.first()
+        && let Some(last_stmt) = stmts.0.last()
+    {
+        let else_block_start = first_stmt.0.start_offset() as u32;
+        let else_block_end = last_stmt.0.end_offset() as u32;
+        analysis_data
+            .if_block_boundaries
+            .push((else_block_start, else_block_end));
     }
 
     statements_analyzer.analyze(&stmts.0, analysis_data, else_context, loop_scope)?;

--- a/src/analyzer/stmt/foreach_analyzer.rs
+++ b/src/analyzer/stmt/foreach_analyzer.rs
@@ -288,7 +288,7 @@ fn check_iterator_type(
             _ => {}
         }
 
-        if let TAtomic::TNull { .. } | TAtomic::TFalse { .. } = iterator_atomic_type {
+        if let TAtomic::TNull | TAtomic::TFalse = iterator_atomic_type {
             always_non_empty_array = false;
             continue;
         }
@@ -546,19 +546,18 @@ fn check_iterator_type(
         }
     }
 
-    if has_valid_iterator {
-        if let Some(ref mut key_type) = key_type {
-            if let Some(ref mut value_type) = value_type {
-                add_array_fetch_dataflow(
-                    statements_analyzer,
-                    expr.pos(),
-                    analysis_data,
-                    None,
-                    value_type,
-                    key_type,
-                )
-            }
-        }
+    if has_valid_iterator
+        && let Some(ref mut key_type) = key_type
+        && let Some(ref mut value_type) = value_type
+    {
+        add_array_fetch_dataflow(
+            statements_analyzer,
+            expr.pos(),
+            analysis_data,
+            None,
+            value_type,
+            key_type,
+        )
     }
 
     if analysis_data.data_flow_graph.kind == GraphKind::FunctionBody {

--- a/src/analyzer/stmt/if_analyzer.rs
+++ b/src/analyzer/stmt/if_analyzer.rs
@@ -115,14 +115,14 @@ pub(crate) fn analyze(
     if_context.possibly_assigned_var_ids.clear();
 
     // Track if block boundaries for variable scoping analysis
-    if let Some(first_stmt) = stmt.1.0.first() {
-        if let Some(last_stmt) = stmt.1.0.last() {
-            let if_block_start = first_stmt.0.start_offset() as u32;
-            let if_block_end = last_stmt.0.end_offset() as u32;
-            analysis_data
-                .if_block_boundaries
-                .push((if_block_start, if_block_end));
-        }
+    if let Some(first_stmt) = stmt.1.0.first()
+        && let Some(last_stmt) = stmt.1.0.last()
+    {
+        let if_block_start = first_stmt.0.start_offset() as u32;
+        let if_block_end = last_stmt.0.end_offset() as u32;
+        analysis_data
+            .if_block_boundaries
+            .push((if_block_start, if_block_end));
     }
 
     statements_analyzer.analyze(&stmt.1.0, analysis_data, if_context, loop_scope)?;
@@ -270,10 +270,10 @@ pub(crate) fn update_if_scope(
                     ),
                 );
 
-                if let Some(outer_context_type) = outer_context.locals.get(&redefined_var_id) {
-                    if scope_redefined_type == **outer_context_type {
-                        scope_redefined_vars.remove(&redefined_var_id);
-                    }
+                if let Some(outer_context_type) = outer_context.locals.get(&redefined_var_id)
+                    && scope_redefined_type == **outer_context_type
+                {
+                    scope_redefined_vars.remove(&redefined_var_id);
                 }
             } else {
                 scope_redefined_vars.remove(&redefined_var_id);

--- a/src/analyzer/stmt/if_conditional_analyzer.rs
+++ b/src/analyzer/stmt/if_conditional_analyzer.rs
@@ -287,23 +287,23 @@ pub(crate) fn add_branch_dataflow(
         .expr_types
         .get(&(cond.1.start_offset() as u32, cond.1.end_offset() as u32));
 
-    if let Some(conditional_type) = conditional_type {
-        if !conditional_type.parent_nodes.is_empty() {
-            let branch_node =
-                DataFlowNode::get_for_unlabelled_sink(statements_analyzer.get_hpos(cond.pos()));
+    if let Some(conditional_type) = conditional_type
+        && !conditional_type.parent_nodes.is_empty()
+    {
+        let branch_node =
+            DataFlowNode::get_for_unlabelled_sink(statements_analyzer.get_hpos(cond.pos()));
 
-            for parent_node in &conditional_type.parent_nodes {
-                analysis_data.data_flow_graph.add_path(
-                    &parent_node.id,
-                    &branch_node.id,
-                    PathKind::Default,
-                    vec![],
-                    vec![],
-                );
-            }
-
-            analysis_data.data_flow_graph.add_node(branch_node);
+        for parent_node in &conditional_type.parent_nodes {
+            analysis_data.data_flow_graph.add_path(
+                &parent_node.id,
+                &branch_node.id,
+                PathKind::Default,
+                vec![],
+                vec![],
+            );
         }
+
+        analysis_data.data_flow_graph.add_node(branch_node);
     }
 }
 

--- a/src/analyzer/stmt/loop_/assignment_map_visitor.rs
+++ b/src/analyzer/stmt/loop_/assignment_map_visitor.rs
@@ -55,7 +55,7 @@ impl<'ast> Visitor<'ast> for Scanner {
             aast::Expr_::Call(boxed) => {
                 for arg_expr in &boxed.args {
                     if let Argument::Ainout(_, arg_expr) = arg_expr {
-                        let arg_var_id = expression_identifier::get_root_var_id(&arg_expr);
+                        let arg_var_id = expression_identifier::get_root_var_id(arg_expr);
 
                         if let Some(arg_var_id) = &arg_var_id {
                             if self.first_var_id.is_none() {

--- a/src/analyzer/stmt/loop_analyzer.rs
+++ b/src/analyzer/stmt/loop_analyzer.rs
@@ -500,17 +500,16 @@ pub(crate) fn analyze<'a>(
                 );
             } else if let Some(loop_parent_context_type) =
                 loop_parent_context.locals.get_mut(var_id)
+                && loop_parent_context_type != loop_context_type
             {
-                if loop_parent_context_type != loop_context_type {
-                    *loop_parent_context_type = Rc::new({
-                        let mut first = (**loop_context_type).clone();
-                        extend_dataflow_uniquely(
-                            &mut first.parent_nodes,
-                            loop_parent_context_type.parent_nodes.clone(),
-                        );
-                        first
-                    });
-                }
+                *loop_parent_context_type = Rc::new({
+                    let mut first = (**loop_context_type).clone();
+                    extend_dataflow_uniquely(
+                        &mut first.parent_nodes,
+                        loop_parent_context_type.parent_nodes.clone(),
+                    );
+                    first
+                });
             }
         }
     }

--- a/src/analyzer/stmt/return_analyzer.rs
+++ b/src/analyzer/stmt/return_analyzer.rs
@@ -136,25 +136,23 @@ pub(crate) fn analyze(
         &mut 0,
     );
 
-    if let Some(return_expr) = return_expr {
-        if functionlike_storage.is_async {
-            if inferred_return_type
-                .types
-                .iter()
-                .any(|t| matches!(t, TAtomic::TAwaitable { .. }))
-            {
-                analysis_data.maybe_add_issue(
-                    Issue::new(
-                        IssueKind::UnusedAwaitable,
-                        "This awaitable is not awaited in an async context".to_string(),
-                        statements_analyzer.get_hpos(&return_expr.pos()),
-                        &context.function_context.calling_functionlike_id,
-                    ),
-                    statements_analyzer.get_config(),
-                    statements_analyzer.get_file_path_actual(),
-                );
-            }
-        }
+    if let Some(return_expr) = return_expr
+        && functionlike_storage.is_async
+        && inferred_return_type
+            .types
+            .iter()
+            .any(|t| matches!(t, TAtomic::TAwaitable { .. }))
+    {
+        analysis_data.maybe_add_issue(
+            Issue::new(
+                IssueKind::UnusedAwaitable,
+                "This awaitable is not awaited in an async context".to_string(),
+                statements_analyzer.get_hpos(return_expr.pos()),
+                &context.function_context.calling_functionlike_id,
+            ),
+            statements_analyzer.get_config(),
+            statements_analyzer.get_file_path_actual(),
+        );
     }
 
     if functionlike_storage.is_async {
@@ -546,34 +544,34 @@ pub(crate) fn handle_inout_at_return(
     interner: &Interner,
 ) {
     for (i, param) in functionlike_storage.params.iter().enumerate() {
-        if param.is_inout {
-            if let Some(context_type) = context.locals.get(interner.lookup(&param.name.0)) {
-                if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {}
-                let new_parent_node =
-                    if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {
-                        DataFlowNode::get_for_method_argument_out(
-                            &context.function_context.calling_functionlike_id.unwrap(),
-                            i,
-                            Some(param.name_location),
-                            None,
-                        )
-                    } else {
-                        DataFlowNode::get_for_unlabelled_sink(param.name_location)
-                    };
+        if param.is_inout
+            && let Some(context_type) = context.locals.get(interner.lookup(&param.name.0))
+        {
+            if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {}
+            let new_parent_node =
+                if let GraphKind::WholeProgram(_) = &analysis_data.data_flow_graph.kind {
+                    DataFlowNode::get_for_method_argument_out(
+                        &context.function_context.calling_functionlike_id.unwrap(),
+                        i,
+                        Some(param.name_location),
+                        None,
+                    )
+                } else {
+                    DataFlowNode::get_for_unlabelled_sink(param.name_location)
+                };
 
-                analysis_data
-                    .data_flow_graph
-                    .add_node(new_parent_node.clone());
+            analysis_data
+                .data_flow_graph
+                .add_node(new_parent_node.clone());
 
-                for parent_node in &context_type.parent_nodes {
-                    analysis_data.data_flow_graph.add_path(
-                        &parent_node.id,
-                        &new_parent_node.id,
-                        PathKind::Default,
-                        vec![],
-                        vec![],
-                    );
-                }
+            for parent_node in &context_type.parent_nodes {
+                analysis_data.data_flow_graph.add_path(
+                    &parent_node.id,
+                    &new_parent_node.id,
+                    PathKind::Default,
+                    vec![],
+                    vec![],
+                );
             }
         }
     }
@@ -615,12 +613,11 @@ fn handle_dataflow(
         let codebase = statements_analyzer.codebase;
 
         for at in &inferred_type.types {
-            if let Some(shape_name) = at.get_shape_name() {
-                if let Some(t) = codebase.type_definitions.get(&shape_name) {
-                    if t.shape_field_taints.is_some() {
-                        return;
-                    }
-                }
+            if let Some(shape_name) = at.get_shape_name()
+                && let Some(t) = codebase.type_definitions.get(&shape_name)
+                && t.shape_field_taints.is_some()
+            {
+                return;
             }
         }
 
@@ -651,34 +648,33 @@ fn handle_dataflow(
             vec![],
         );
 
-        if let FunctionLikeIdentifier::Method(classlike_name, method_name) = functionlike_id {
-            if let Some(classlike_info) = codebase.classlike_infos.get(classlike_name) {
-                if *method_name != StrId::CONSTRUCT {
-                    let mut all_parents = classlike_info
-                        .all_parent_classes
-                        .iter()
-                        .collect::<FxHashSet<_>>();
-                    all_parents.extend(classlike_info.all_parent_interfaces.iter());
+        if let FunctionLikeIdentifier::Method(classlike_name, method_name) = functionlike_id
+            && let Some(classlike_info) = codebase.classlike_infos.get(classlike_name)
+            && *method_name != StrId::CONSTRUCT
+        {
+            let mut all_parents = classlike_info
+                .all_parent_classes
+                .iter()
+                .collect::<FxHashSet<_>>();
+            all_parents.extend(classlike_info.all_parent_interfaces.iter());
 
-                    for parent_classlike in all_parents {
-                        if codebase.declaring_method_exists(parent_classlike, method_name) {
-                            let new_sink = DataFlowNode::get_for_method_return(
-                                &FunctionLikeIdentifier::Method(*parent_classlike, *method_name),
-                                None,
-                                None,
-                            );
+            for parent_classlike in all_parents {
+                if codebase.declaring_method_exists(parent_classlike, method_name) {
+                    let new_sink = DataFlowNode::get_for_method_return(
+                        &FunctionLikeIdentifier::Method(*parent_classlike, *method_name),
+                        None,
+                        None,
+                    );
 
-                            data_flow_graph.add_node(new_sink.clone());
+                    data_flow_graph.add_node(new_sink.clone());
 
-                            data_flow_graph.add_path(
-                                &method_node.id,
-                                &new_sink.id,
-                                PathKind::Default,
-                                vec![],
-                                vec![],
-                            );
-                        }
-                    }
+                    data_flow_graph.add_path(
+                        &method_node.id,
+                        &new_sink.id,
+                        PathKind::Default,
+                        vec![],
+                        vec![],
+                    );
                 }
             }
         }

--- a/src/analyzer/stmt/switch_analyzer.rs
+++ b/src/analyzer/stmt/switch_analyzer.rs
@@ -86,13 +86,13 @@ pub(crate) fn analyze(
         None
     };
 
-    if stmt.2.is_none() {
-        if let Some(switch_var_type) = analysis_data.get_rc_expr_type(&stmt.0.1) {
-            if !switch_var_type.is_any()
-                && !switch_var_type.is_nothing()
-                && !switch_var_type.all_literals()
-            {
-                analysis_data.maybe_add_issue(
+    if stmt.2.is_none()
+        && let Some(switch_var_type) = analysis_data.get_rc_expr_type(&stmt.0.1)
+        && !switch_var_type.is_any()
+        && !switch_var_type.is_nothing()
+        && !switch_var_type.all_literals()
+    {
+        analysis_data.maybe_add_issue(
                     Issue::new(
                         IssueKind::NonEnumSwitchValue,
                         format!(
@@ -105,8 +105,6 @@ pub(crate) fn analyze(
                     statements_analyzer.get_config(),
                     statements_analyzer.get_file_path_actual(),
                 );
-            }
-        }
     }
 
     let original_context = context.clone();
@@ -188,8 +186,7 @@ pub(crate) fn analyze(
             let case_cond_type = TUnion::new(
                 case_cond_types
                     .iter()
-                    .map(|t| t.unwrap().types.clone())
-                    .flatten()
+                    .flat_map(|t| t.unwrap().types.clone())
                     .collect::<Vec<_>>(),
             );
             let assertion = Assertion::NotInArray(case_cond_type);

--- a/src/analyzer/stmt/switch_case_analyzer.rs
+++ b/src/analyzer/stmt/switch_case_analyzer.rs
@@ -184,7 +184,7 @@ pub(crate) fn analyze_case(
 
     let case_stmts = leftover_statements;
 
-    if (case_stmts.is_empty() || &case_stmts.last().unwrap().1 == &aast::Stmt_::Fallthrough)
+    if (case_stmts.is_empty() || case_stmts.last().unwrap().1 == aast::Stmt_::Fallthrough)
         && !is_last
     {
         // this is safe for non-defaults, and defaults are always last
@@ -303,16 +303,16 @@ pub(crate) fn analyze_case(
         }
     }
 
-    if !case_clauses_for_negation.is_empty() {
-        if let Some(case_equality_expr) = &case_equality_expr {
-            extend_switch_negated_clauses(
-                analysis_data,
-                switch_scope,
-                &assertion_context,
-                case_clauses_for_negation,
-                case_equality_expr,
-            );
-        }
+    if !case_clauses_for_negation.is_empty()
+        && let Some(case_equality_expr) = &case_equality_expr
+    {
+        extend_switch_negated_clauses(
+            analysis_data,
+            switch_scope,
+            &assertion_context,
+            case_clauses_for_negation,
+            case_equality_expr,
+        );
     }
 
     analysis_data.case_scopes.push(CaseScope::new());
@@ -544,7 +544,7 @@ fn expand_case_equality_from_leftovers(
         })),
     ));
 
-    return Some(aast::Expr(
+    Some(aast::Expr(
         (),
         case_or_default_equality_expr.pos().clone(),
         aast::Expr_::Binop(Box::new(Binop {
@@ -552,7 +552,7 @@ fn expand_case_equality_from_leftovers(
             lhs: leftover_case_equality_expr.clone(),
             rhs: case_or_default_equality_expr.clone(),
         })),
-    ));
+    ))
 }
 
 pub(crate) fn handle_non_returning_case(
@@ -566,24 +566,23 @@ pub(crate) fn handle_non_returning_case(
     original_context: &BlockContext,
     switch_scope: &mut SwitchScope,
 ) -> Result<(), AnalysisError> {
-    if is_default_case {
-        if let Some(switch_type) = case_context.locals.get(switch_var_id) {
-            if switch_type.is_nothing() {
-                analysis_data.maybe_add_issue(
-                    Issue::new(
-                        IssueKind::UselessDefaultCase,
-                        "All possible case statements have been met, default is impossible here"
-                            .to_string(),
-                        statements_analyzer.get_hpos(case_pos),
-                        &context.function_context.calling_functionlike_id,
-                    ),
-                    statements_analyzer.get_config(),
-                    statements_analyzer.get_file_path_actual(),
-                );
+    if is_default_case
+        && let Some(switch_type) = case_context.locals.get(switch_var_id)
+        && switch_type.is_nothing()
+    {
+        analysis_data.maybe_add_issue(
+            Issue::new(
+                IssueKind::UselessDefaultCase,
+                "All possible case statements have been met, default is impossible here"
+                    .to_string(),
+                statements_analyzer.get_hpos(case_pos),
+                &context.function_context.calling_functionlike_id,
+            ),
+            statements_analyzer.get_config(),
+            statements_analyzer.get_file_path_actual(),
+        );
 
-                return Ok(());
-            }
-        }
+        return Ok(());
     }
 
     let codebase = statements_analyzer.codebase;

--- a/src/analyzer/stmt/try_analyzer.rs
+++ b/src/analyzer/stmt/try_analyzer.rs
@@ -281,89 +281,85 @@ pub(crate) fn analyze(
     let finally_scope = try_context.finally_scope.clone();
     try_context.finally_scope = None;
 
-    if let Some(loop_scope) = loop_scope {
-        if !try_leaves_loop && !loop_scope.final_actions.contains(&ControlAction::None) {
-            loop_scope.final_actions.insert(ControlAction::None);
-        }
+    if let Some(loop_scope) = loop_scope
+        && !try_leaves_loop
+        && !loop_scope.final_actions.contains(&ControlAction::None)
+    {
+        loop_scope.final_actions.insert(ControlAction::None);
     }
 
     let mut finally_has_returned = false;
 
-    if !stmt.2.is_empty() {
-        if let Some(finally_scope) = finally_scope {
-            let finally_scope = finally_scope.borrow();
-            let mut finally_context = context.clone();
+    if !stmt.2.is_empty()
+        && let Some(finally_scope) = finally_scope
+    {
+        let finally_scope = finally_scope.borrow();
+        let mut finally_context = context.clone();
 
-            finally_context.assigned_var_ids = FxHashMap::default();
-            finally_context.possibly_assigned_var_ids = FxHashSet::default();
+        finally_context.assigned_var_ids = FxHashMap::default();
+        finally_context.possibly_assigned_var_ids = FxHashSet::default();
 
-            finally_context.locals = finally_scope.locals.clone();
+        finally_context.locals = finally_scope.locals.clone();
 
-            for (var_id, var_type) in &try_context.locals {
-                if let Some(finally_type) = finally_context.locals.get_mut(var_id) {
-                    *finally_type =
-                        Rc::new(combine_union_types(finally_type, var_type, codebase, false));
-                } else {
-                    finally_context
-                        .locals
-                        .insert(var_id.clone(), var_type.clone());
-                }
+        for (var_id, var_type) in &try_context.locals {
+            if let Some(finally_type) = finally_context.locals.get_mut(var_id) {
+                *finally_type =
+                    Rc::new(combine_union_types(finally_type, var_type, codebase, false));
+            } else {
+                finally_context
+                    .locals
+                    .insert(var_id.clone(), var_type.clone());
             }
+        }
 
-            statements_analyzer.analyze(
-                &stmt.2.0,
-                analysis_data,
-                &mut finally_context,
-                loop_scope,
-            )?;
+        statements_analyzer.analyze(&stmt.2.0, analysis_data, &mut finally_context, loop_scope)?;
 
-            finally_has_returned = finally_context.has_returned;
+        finally_has_returned = finally_context.has_returned;
 
-            let finally_actions = control_analyzer::get_control_actions(
-                codebase,
-                statements_analyzer.interner,
-                statements_analyzer.file_analyzer.resolved_names,
-                &stmt.2.0,
-                analysis_data,
-                vec![],
-                true,
-            );
+        let finally_actions = control_analyzer::get_control_actions(
+            codebase,
+            statements_analyzer.interner,
+            statements_analyzer.file_analyzer.resolved_names,
+            &stmt.2.0,
+            analysis_data,
+            vec![],
+            true,
+        );
 
-            if finally_actions.len() != 1
-                || !matches!(
-                    finally_actions.iter().next().unwrap(),
-                    ControlAction::End | ControlAction::Continue | ControlAction::Break
-                )
-            {
-                for (var_id, finally_type) in &finally_context.locals {
-                    if let Some(context_type) = context.locals.get_mut(var_id) {
-                        if context_type.possibly_undefined_from_try {
-                            let mut context_type_inner = (**context_type).clone();
-                            context_type_inner.possibly_undefined_from_try = false;
-                            *context_type = Rc::new(context_type_inner);
-                        }
-
-                        *context_type = Rc::new(combine_union_types(
-                            context_type,
-                            finally_type,
-                            codebase,
-                            false,
-                        ));
-                    } else {
-                        context.locals.insert(var_id.clone(), finally_type.clone());
+        if finally_actions.len() != 1
+            || !matches!(
+                finally_actions.iter().next().unwrap(),
+                ControlAction::End | ControlAction::Continue | ControlAction::Break
+            )
+        {
+            for (var_id, finally_type) in &finally_context.locals {
+                if let Some(context_type) = context.locals.get_mut(var_id) {
+                    if context_type.possibly_undefined_from_try {
+                        let mut context_type_inner = (**context_type).clone();
+                        context_type_inner.possibly_undefined_from_try = false;
+                        *context_type = Rc::new(context_type_inner);
                     }
+
+                    *context_type = Rc::new(combine_union_types(
+                        context_type,
+                        finally_type,
+                        codebase,
+                        false,
+                    ));
+                } else {
+                    context.locals.insert(var_id.clone(), finally_type.clone());
                 }
             }
         }
     }
 
     for var_id in definitely_newly_assigned_var_ids.keys() {
-        if let Some(context_type) = context.locals.get_mut(var_id) {
-            if context_type.possibly_undefined_from_try {
-                let mut context_type_inner = (**context_type).clone();
-                context_type_inner.possibly_undefined_from_try = false;
-                *context_type = Rc::new(context_type_inner);
-            }
+        if let Some(context_type) = context.locals.get_mut(var_id)
+            && context_type.possibly_undefined_from_try
+        {
+            let mut context_type_inner = (**context_type).clone();
+            context_type_inner.possibly_undefined_from_try = false;
+            *context_type = Rc::new(context_type_inner);
         }
     }
 

--- a/src/analyzer/stmt/while_analyzer.rs
+++ b/src/analyzer/stmt/while_analyzer.rs
@@ -108,12 +108,12 @@ pub(crate) fn analyze(
 }
 
 pub(crate) fn get_and_expressions(cond: &aast::Expr<(), ()>) -> Vec<&aast::Expr<(), ()>> {
-    if let aast::Expr_::Binop(boxed) = &cond.2 {
-        if let ast_defs::Bop::Ampamp = boxed.bop {
-            let mut anded = get_and_expressions(&boxed.lhs);
-            anded.extend(get_and_expressions(&boxed.rhs));
-            return anded;
-        }
+    if let aast::Expr_::Binop(boxed) = &cond.2
+        && let ast_defs::Bop::Ampamp = boxed.bop
+    {
+        let mut anded = get_and_expressions(&boxed.lhs);
+        anded.extend(get_and_expressions(&boxed.rhs));
+        return anded;
     }
 
     vec![cond]

--- a/src/analyzer/stmt_analyzer.rs
+++ b/src/analyzer/stmt_analyzer.rs
@@ -308,20 +308,20 @@ fn detect_unused_statement_expressions(
     if let Some(effect) = analysis_data.expr_effects.get(&(
         boxed.pos().start_offset() as u32,
         boxed.pos().end_offset() as u32,
-    )) {
-        if effect == &EFFECT_PURE && !matches!(boxed.2, aast::Expr_::New(..)) {
-            analysis_data.maybe_add_issue(
-                Issue::new(
-                    IssueKind::UnusedStatement,
-                    "This statement has no effect and can be removed".to_string(),
-                    statements_analyzer.get_hpos(&stmt.0),
-                    &context.function_context.calling_functionlike_id,
-                ),
-                statements_analyzer.get_config(),
-                statements_analyzer.get_file_path_actual(),
-            );
-            return;
-        }
+    )) && effect == &EFFECT_PURE
+        && !matches!(boxed.2, aast::Expr_::New(..))
+    {
+        analysis_data.maybe_add_issue(
+            Issue::new(
+                IssueKind::UnusedStatement,
+                "This statement has no effect and can be removed".to_string(),
+                statements_analyzer.get_hpos(&stmt.0),
+                &context.function_context.calling_functionlike_id,
+            ),
+            statements_analyzer.get_config(),
+            statements_analyzer.get_file_path_actual(),
+        );
+        return;
     }
 
     match &boxed.2 {
@@ -337,53 +337,52 @@ fn detect_unused_statement_expressions(
                 if let Some(functionlike_info) = codebase
                     .functionlike_infos
                     .get(&(function_id, StrId::EMPTY))
+                    && let Some(expr_type) = analysis_data.get_rc_expr_type(boxed.pos()).cloned()
                 {
-                    if let Some(expr_type) = analysis_data.get_rc_expr_type(boxed.pos()).cloned() {
-                        let function_name = statements_analyzer.interner.lookup(&function_id);
+                    let function_name = statements_analyzer.interner.lookup(&function_id);
 
-                        if !functionlike_info.user_defined
-                            && matches!(functionlike_info.effects, FnEffect::Arg(..))
-                            && expr_type.is_single()
+                    if !functionlike_info.user_defined
+                        && matches!(functionlike_info.effects, FnEffect::Arg(..))
+                        && expr_type.is_single()
+                    {
+                        let array_types = get_arrayish_params(expr_type.get_single(), codebase);
+
+                        if let Some((_, value_type)) = array_types
+                            && !value_type.is_null()
+                            && !value_type.is_void()
                         {
-                            let array_types = get_arrayish_params(expr_type.get_single(), codebase);
-
-                            if let Some((_, value_type)) = array_types {
-                                if !value_type.is_null() && !value_type.is_void() {
-                                    analysis_data.maybe_add_issue(
-                                        Issue::new(
-                                            IssueKind::UnusedBuiltinReturnValue,
-                                            format!(
-                                                "The value {} returned from {} should be consumed",
-                                                expr_type
-                                                    .get_id(Some(statements_analyzer.interner)),
-                                                function_name
-                                            ),
-                                            statements_analyzer.get_hpos(&stmt.0),
-                                            &context.function_context.calling_functionlike_id,
-                                        ),
-                                        statements_analyzer.get_config(),
-                                        statements_analyzer.get_file_path_actual(),
-                                    );
-                                }
-                            }
+                            analysis_data.maybe_add_issue(
+                                Issue::new(
+                                    IssueKind::UnusedBuiltinReturnValue,
+                                    format!(
+                                        "The value {} returned from {} should be consumed",
+                                        expr_type.get_id(Some(statements_analyzer.interner)),
+                                        function_name
+                                    ),
+                                    statements_analyzer.get_hpos(&stmt.0),
+                                    &context.function_context.calling_functionlike_id,
+                                ),
+                                statements_analyzer.get_config(),
+                                statements_analyzer.get_file_path_actual(),
+                            );
                         }
                     }
                 }
             }
 
-            if let Some(expr_type) = analysis_data.get_rc_expr_type(boxed.pos()).cloned() {
-                if expr_type.has_awaitable_types() {
-                    analysis_data.maybe_add_issue(
-                        Issue::new(
-                            IssueKind::UnusedAwaitable,
-                            "This awaitable is never awaited".to_string(),
-                            statements_analyzer.get_hpos(&stmt.0),
-                            &context.function_context.calling_functionlike_id,
-                        ),
-                        statements_analyzer.get_config(),
-                        statements_analyzer.get_file_path_actual(),
-                    );
-                }
+            if let Some(expr_type) = analysis_data.get_rc_expr_type(boxed.pos()).cloned()
+                && expr_type.has_awaitable_types()
+            {
+                analysis_data.maybe_add_issue(
+                    Issue::new(
+                        IssueKind::UnusedAwaitable,
+                        "This awaitable is never awaited".to_string(),
+                        statements_analyzer.get_hpos(&stmt.0),
+                        &context.function_context.calling_functionlike_id,
+                    ),
+                    statements_analyzer.get_config(),
+                    statements_analyzer.get_file_path_actual(),
+                );
             }
         }
         aast::Expr_::Collection(_)
@@ -429,7 +428,7 @@ fn has_unused_must_use(
                         if function_id == StrId::ASIO_JOIN {
                             for arg in boxed_call.args.iter() {
                                 let has_unused = has_unused_must_use(
-                                    &arg.to_expr_ref(),
+                                    arg.to_expr_ref(),
                                     statements_analyzer,
                                     analysis_data,
                                 );

--- a/src/cli/commands/cyclomatic_complexity.rs
+++ b/src/cli/commands/cyclomatic_complexity.rs
@@ -112,7 +112,7 @@ pub fn handle(
 
     if let Ok((analysis_result, successful_run_data)) = result {
         let mut results = analysis_result.cyclomatic_complexity;
-        results.sort_by(|a, b| b.cmp(&successful_run_data.interner, &a));
+        results.sort_by(|a, b| b.cmp(&successful_run_data.interner, a));
 
         let total_functions = successful_run_data.codebase.functionlike_infos.len();
 

--- a/src/cli/commands/lint.rs
+++ b/src/cli/commands/lint.rs
@@ -156,7 +156,7 @@ pub fn handle(
             let mut found = false;
             for linter in registry.all() {
                 if let Some(hhast_name) = linter.hhast_name() {
-                    let short_name = hhast_name.split('\\').last().unwrap_or(hhast_name);
+                    let short_name = hhast_name.split('\\').next_back().unwrap_or(hhast_name);
                     if linter_name == hhast_name
                         || linter_name == short_name
                         || linter_name == linter.name()
@@ -274,7 +274,7 @@ pub fn handle(
 
     for (i, path) in files_to_lint.into_iter().enumerate() {
         let group = i % group_size;
-        path_groups.entry(group).or_insert_with(Vec::new).push(path);
+        path_groups.entry(group).or_default().push(path);
     }
 
     let mut handles = vec![];
@@ -391,15 +391,15 @@ pub fn handle(
                                                     file_op.path.clone()
                                                 };
 
-                                                if let Some(parent_dir) = target_path.parent() {
-                                                    if let Err(e) = fs::create_dir_all(parent_dir) {
-                                                        lint_output.lock().unwrap().push(format!(
-                                                            "Error creating directory {}: {}",
-                                                            parent_dir.display(),
-                                                            e
-                                                        ));
-                                                        continue;
-                                                    }
+                                                if let Some(parent_dir) = target_path.parent()
+                                                    && let Err(e) = fs::create_dir_all(parent_dir)
+                                                {
+                                                    lint_output.lock().unwrap().push(format!(
+                                                        "Error creating directory {}: {}",
+                                                        parent_dir.display(),
+                                                        e
+                                                    ));
+                                                    continue;
                                                 }
 
                                                 match fs::write(&target_path, content) {
@@ -629,16 +629,12 @@ fn parse_codeowners_files(root_dir: &str) -> (Vec<glob::Pattern>, FxHashSet<Stri
                 } else {
                     exact_files.insert(format!("/{}", pattern));
                 }
-            } else {
-                if pattern.starts_with('/') {
-                    if let Ok(compiled) = glob::Pattern::new(&format!("{}/**", pattern)) {
-                        codeowner_patterns.push(compiled);
-                    }
-                } else {
-                    if let Ok(compiled) = glob::Pattern::new(&format!("**/{pattern}/**")) {
-                        codeowner_patterns.push(compiled);
-                    }
+            } else if pattern.starts_with('/') {
+                if let Ok(compiled) = glob::Pattern::new(&format!("{}/**", pattern)) {
+                    codeowner_patterns.push(compiled);
                 }
+            } else if let Ok(compiled) = glob::Pattern::new(&format!("**/{pattern}/**")) {
+                codeowner_patterns.push(compiled);
             }
         }
     }

--- a/src/cli/test_runners/core_test_runner.rs
+++ b/src/cli/test_runners/core_test_runner.rs
@@ -27,7 +27,7 @@ impl HooksProvider for CoreHooksProvider {
         all_linters.retain(|linter| {
             if let Some(hhast_name) = linter.hhast_name() {
                 // For HHAST-compatible linters, check if directory contains the linter name
-                dir.contains(hhast_name.split('\\').last().unwrap_or(""))
+                dir.contains(hhast_name.split('\\').next_back().unwrap_or(""))
             } else {
                 false
             }

--- a/src/cli/test_runners/test_runner.rs
+++ b/src/cli/test_runners/test_runner.rs
@@ -190,76 +190,75 @@ fn get_all_test_folders(test_or_test_dir: String) -> Result<Vec<String>, String>
 
             let metadata = fs::metadata(path).unwrap();
 
-            if metadata.is_dir() {
-                if let Some(path_str) = path.to_str() {
-                    let input_hack = path_str.to_owned() + "/input.hack";
-                    let output_txt = path_str.to_owned() + "/output.txt";
-                    let candidates_txt = path_str.to_owned() + "/candidates.txt";
+            if metadata.is_dir()
+                && let Some(path_str) = path.to_str()
+            {
+                let input_hack = path_str.to_owned() + "/input.hack";
+                let output_txt = path_str.to_owned() + "/output.txt";
+                let candidates_txt = path_str.to_owned() + "/candidates.txt";
 
-                    if path_str.contains("/diff/") {
-                        if Path::new(&(path_str.to_owned() + "/a")).is_dir() {
-                            // Found a diff test directory - check if output.txt exists
-                            if !Path::new(&output_txt).exists() {
-                                return Err(format!(
-                                    "Diff test directory is missing required output.txt file: {}",
-                                    path_str
-                                ));
-                            }
-                            test_folders.push(path_str.to_owned());
-                        }
-                    } else if path_str.contains("/hhast_tests/") {
-                        // Skip directories that start with "skipped-"
-                        if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
-                            if dir_name.starts_with("skipped-") {
-                                continue;
-                            }
-                        }
-
-                        // For HHAST tests, enumerate individual test files (not directories)
-                        if let Ok(entries) = fs::read_dir(path_str) {
-                            let mut in_files: Vec<String> = entries
-                                .filter_map(|e| e.ok())
-                                .filter_map(|e| {
-                                    let file_path = e.path();
-                                    let file_name = file_path.to_string_lossy().to_string();
-                                    if file_name.ends_with(".php.in")
-                                        || file_name.ends_with(".hack.in")
-                                    {
-                                        // Remove the ".in" extension to get the base test name
-                                        let base_name = file_name
-                                            .trim_end_matches(".php.in")
-                                            .trim_end_matches(".hack.in");
-                                        Some(base_name.to_string())
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect();
-
-                            in_files.sort();
-                            test_folders.extend(in_files);
-                        }
-                    } else if Path::new(&input_hack).exists() {
-                        // Migration candidates tests use candidates.txt instead of output.txt
-                        if path_str.contains("/migration-candidates/")
-                            && !Path::new(&candidates_txt).exists()
-                        {
+                if path_str.contains("/diff/") {
+                    if Path::new(&(path_str.to_owned() + "/a")).is_dir() {
+                        // Found a diff test directory - check if output.txt exists
+                        if !Path::new(&output_txt).exists() {
                             return Err(format!(
-                                "Migration candidates test directory is missing required candidates.txt file: {}",
-                                path_str
-                            ));
-                        } else if !Path::new(&output_txt).exists()
-                            && !path_str.contains("/goto-definition/")
-                            && !path_str.contains("/references/")
-                        {
-                            // Found a regular test directory - check if output.txt exists
-                            return Err(format!(
-                                "Test directory is missing required output.txt file: {}",
+                                "Diff test directory is missing required output.txt file: {}",
                                 path_str
                             ));
                         }
                         test_folders.push(path_str.to_owned());
                     }
+                } else if path_str.contains("/hhast_tests/") {
+                    // Skip directories that start with "skipped-"
+                    if let Some(dir_name) = path.file_name().and_then(|n| n.to_str())
+                        && dir_name.starts_with("skipped-")
+                    {
+                        continue;
+                    }
+
+                    // For HHAST tests, enumerate individual test files (not directories)
+                    if let Ok(entries) = fs::read_dir(path_str) {
+                        let mut in_files: Vec<String> = entries
+                            .filter_map(|e| e.ok())
+                            .filter_map(|e| {
+                                let file_path = e.path();
+                                let file_name = file_path.to_string_lossy().to_string();
+                                if file_name.ends_with(".php.in") || file_name.ends_with(".hack.in")
+                                {
+                                    // Remove the ".in" extension to get the base test name
+                                    let base_name = file_name
+                                        .trim_end_matches(".php.in")
+                                        .trim_end_matches(".hack.in");
+                                    Some(base_name.to_string())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+
+                        in_files.sort();
+                        test_folders.extend(in_files);
+                    }
+                } else if Path::new(&input_hack).exists() {
+                    // Migration candidates tests use candidates.txt instead of output.txt
+                    if path_str.contains("/migration-candidates/")
+                        && !Path::new(&candidates_txt).exists()
+                    {
+                        return Err(format!(
+                            "Migration candidates test directory is missing required candidates.txt file: {}",
+                            path_str
+                        ));
+                    } else if !Path::new(&output_txt).exists()
+                        && !path_str.contains("/goto-definition/")
+                        && !path_str.contains("/references/")
+                    {
+                        // Found a regular test directory - check if output.txt exists
+                        return Err(format!(
+                            "Test directory is missing required output.txt file: {}",
+                            path_str
+                        ));
+                    }
+                    test_folders.push(path_str.to_owned());
                 }
             }
         }

--- a/src/cli/test_runners/tests/cyclomatic_complexity.rs
+++ b/src/cli/test_runners/tests/cyclomatic_complexity.rs
@@ -54,7 +54,7 @@ impl IntegrationTest for CyclomaticComplexityTest {
                 let time_in_analysis = analysis_result.time_in_analysis;
 
                 let mut results = analysis_result.cyclomatic_complexity;
-                results.sort_by(|a, b| b.cmp(&run_data.interner, &a));
+                results.sort_by(|a, b| b.cmp(&run_data.interner, a));
 
                 let output: Vec<String> = results
                     .iter()

--- a/src/cli/test_runners/tests/linter.rs
+++ b/src/cli/test_runners/tests/linter.rs
@@ -50,7 +50,7 @@ impl IntegrationTest for LinterTest {
             ]
             .into_iter()
             .filter(|p| Path::new(p).exists())
-            .map(|p| std::path::PathBuf::from(p))
+            .map(std::path::PathBuf::from)
             .collect::<Vec<_>>()
         } else if Path::new(&format!("{}.php.in", ctx.dir)).exists() {
             vec![std::path::PathBuf::from(format!("{}.php.in", ctx.dir))]

--- a/src/cli/test_runners/utils.rs
+++ b/src/cli/test_runners/utils.rs
@@ -79,7 +79,7 @@ pub fn generate_definition_locations_json(
         } else {
             original_file_path_str
                 .split('/')
-                .last()
+                .next_back()
                 .unwrap_or(original_file_path_str)
                 .to_string()
         };

--- a/src/code_info/codebase_info/mod.rs
+++ b/src/code_info/codebase_info/mod.rs
@@ -244,7 +244,7 @@ impl CodebaseInfo {
                 }]))
             } else if let Some(constant_storage) = classlike_storage.constants.get(const_name) {
                 if matches!(classlike_storage.kind, SymbolKind::EnumClass) {
-                    return constant_storage.provided_type.clone();
+                    constant_storage.provided_type.clone()
                 } else if let Some(provided_type) = &constant_storage.provided_type {
                     if provided_type.types.iter().all(|v| v.is_boring_scalar()) && !is_this {
                         if let Some(inferred_type) = &constant_storage.inferred_type {
@@ -408,17 +408,17 @@ impl CodebaseInfo {
     pub fn get_symbol_pos(&self, classlike_name: &StrId, member_name: &StrId) -> Option<HPos> {
         let classlike_info = self.classlike_infos.get(classlike_name);
 
-        if *member_name == StrId::EMPTY {
-            if let Some(classlike_info) = classlike_info {
-                return Some(classlike_info.name_location);
-            }
+        if *member_name == StrId::EMPTY
+            && let Some(classlike_info) = classlike_info
+        {
+            return Some(classlike_info.name_location);
         }
 
         if let Some(classlike_info) = classlike_info {
-            if let Some(property_info) = classlike_info.properties.get(member_name) {
-                if let Some(property_pos) = property_info.pos {
-                    return Some(property_pos);
-                }
+            if let Some(property_info) = classlike_info.properties.get(member_name)
+                && let Some(property_pos) = property_info.pos
+            {
+                return Some(property_pos);
             }
 
             if let Some(constant_info) = classlike_info.constants.get(member_name) {
@@ -432,13 +432,13 @@ impl CodebaseInfo {
             .functionlike_infos
             .get(&(*classlike_name, *member_name));
 
-        if let Some(functionlike_info) = functionlike_info {
-            if let Some(name_pos) = functionlike_info.name_location {
-                return Some(name_pos);
-            }
+        if let Some(functionlike_info) = functionlike_info
+            && let Some(name_pos) = functionlike_info.name_location
+        {
+            return Some(name_pos);
         }
 
-        return None;
+        None
     }
 
     pub fn get_functionlike(
@@ -488,9 +488,7 @@ impl CodebaseInfo {
             if !defs.contains(&file_path) {
                 defs.push(file_path);
             }
-            if !self.classlike_infos.contains_key(&name) {
-                self.classlike_infos.insert(name, info);
-            }
+            self.classlike_infos.entry(name).or_insert(info);
         }
 
         // Track functionlike definitions and detect duplicates (only top-level functions)
@@ -504,9 +502,7 @@ impl CodebaseInfo {
                 if !defs.contains(&file_path) {
                     defs.push(file_path);
                 }
-                if !self.functionlike_infos.contains_key(&key) {
-                    self.functionlike_infos.insert(key, info);
-                }
+                self.functionlike_infos.entry(key).or_insert(info);
             } else {
                 self.functionlike_infos.insert(key, info);
             }
@@ -520,9 +516,7 @@ impl CodebaseInfo {
             if !defs.contains(&file_path) {
                 defs.push(file_path);
             }
-            if !self.type_definitions.contains_key(&name) {
-                self.type_definitions.insert(name, info);
-            }
+            self.type_definitions.entry(name).or_insert(info);
         }
 
         // Track constant definitions and detect duplicates
@@ -533,9 +527,7 @@ impl CodebaseInfo {
             if !defs.contains(&file_path) {
                 defs.push(file_path);
             }
-            if !self.constant_infos.contains_key(&name) {
-                self.constant_infos.insert(name, info);
-            }
+            self.constant_infos.entry(name).or_insert(info);
         }
 
         self.symbols.all.extend(other.symbols.all);
@@ -559,10 +551,7 @@ impl CodebaseInfo {
 
         let is_duplicate = self.classlike_infos.contains_key(&name);
 
-        let defs = self
-            .classlike_infos_defs
-            .entry(name)
-            .or_insert_with(Vec::new);
+        let defs = self.classlike_infos_defs.entry(name).or_default();
         // Only add if this file_path isn't already tracked
         if !defs.contains(&file_path) {
             defs.push(file_path);
@@ -587,10 +576,7 @@ impl CodebaseInfo {
         // Only track top-level functions (where second part is StrId::EMPTY)
         if key.1 == StrId::EMPTY {
             let file_path = info.def_location.file_path;
-            let defs = self
-                .functionlike_infos_defs
-                .entry(key)
-                .or_insert_with(Vec::new);
+            let defs = self.functionlike_infos_defs.entry(key).or_default();
             // Only add if this file_path isn't already tracked
             if !defs.contains(&file_path) {
                 defs.push(file_path);
@@ -608,42 +594,36 @@ impl CodebaseInfo {
     /// Insert a type definition, tracking the definition location for duplicate detection.
     pub fn insert_type_definition(&mut self, name: StrId, info: TypeDefinitionInfo) -> bool {
         let file_path = info.location.file_path;
-        let defs = self
-            .type_definitions_defs
-            .entry(name)
-            .or_insert_with(Vec::new);
+        let defs = self.type_definitions_defs.entry(name).or_default();
         // Only add if this file_path isn't already tracked
         if !defs.contains(&file_path) {
             defs.push(file_path);
         }
 
-        if self.type_definitions.contains_key(&name) {
+        if let std::collections::hash_map::Entry::Vacant(e) = self.type_definitions.entry(name) {
+            e.insert(info);
+            true
+        } else {
             // Duplicate - don't insert
             false
-        } else {
-            self.type_definitions.insert(name, info);
-            true
         }
     }
 
     /// Insert a constant info, tracking the definition location for duplicate detection.
     pub fn insert_constant_info(&mut self, name: StrId, info: ConstantInfo) -> bool {
         let file_path = info.pos.file_path;
-        let defs = self
-            .constant_infos_defs
-            .entry(name)
-            .or_insert_with(Vec::new);
+        let defs = self.constant_infos_defs.entry(name).or_default();
         // Only add if this file_path isn't already tracked
         if !defs.contains(&file_path) {
             defs.push(file_path);
         }
 
-        if self.constant_infos.contains_key(&name) {
+        if let std::collections::hash_map::Entry::Vacant(e) = self.constant_infos.entry(name) {
+            e.insert(info);
+            true
+        } else {
             // Duplicate - don't insert
             false
-        } else {
-            self.constant_infos.insert(name, info);
-            true
         }
     }
 }

--- a/src/code_info/data_flow/graph.rs
+++ b/src/code_info/data_flow/graph.rs
@@ -56,19 +56,19 @@ impl DataFlowGraph {
     pub fn add_node(&mut self, node: DataFlowNode) {
         match &node.kind {
             DataFlowNodeKind::Vertex { is_specialized, .. } => {
-                if let GraphKind::WholeProgram(_) = &self.kind {
-                    if *is_specialized {
-                        let (unspecialized_id, specialization_key) = node.id.unspecialize();
-                        self.specializations
-                            .entry(unspecialized_id.clone())
-                            .or_default()
-                            .insert(specialization_key);
+                if let GraphKind::WholeProgram(_) = &self.kind
+                    && *is_specialized
+                {
+                    let (unspecialized_id, specialization_key) = node.id.unspecialize();
+                    self.specializations
+                        .entry(unspecialized_id.clone())
+                        .or_default()
+                        .insert(specialization_key);
 
-                        self.specialized_calls
-                            .entry(specialization_key)
-                            .or_default()
-                            .insert(unspecialized_id.clone());
-                    }
+                    self.specialized_calls
+                        .entry(specialization_key)
+                        .or_default()
+                        .insert(unspecialized_id.clone());
                 }
 
                 self.vertices.insert(node.id.clone(), node);
@@ -215,11 +215,11 @@ impl DataFlowGraph {
 
                 visited_child_ids.insert(child_node_id.clone());
 
-                if var_ids_only {
-                    if let DataFlowNodeId::Var(..) | DataFlowNodeId::Param(..) = child_node_id {
-                        origin_nodes.push(child_node_id);
-                        continue;
-                    }
+                if var_ids_only
+                    && let DataFlowNodeId::Var(..) | DataFlowNodeId::Param(..) = child_node_id
+                {
+                    origin_nodes.push(child_node_id);
+                    continue;
                 }
 
                 let mut new_parent_nodes = FxHashSet::default();
@@ -227,12 +227,11 @@ impl DataFlowGraph {
 
                 if let Some(backward_edges) = self.backward_edges.get(&child_node_id) {
                     for from_id in backward_edges {
-                        if let Some(forward_flows) = self.forward_edges.get(from_id) {
-                            if let Some(path) = forward_flows.get(&child_node_id) {
-                                if ignore_paths.contains(&path.kind) {
-                                    break;
-                                }
-                            }
+                        if let Some(forward_flows) = self.forward_edges.get(from_id)
+                            && let Some(path) = forward_flows.get(&child_node_id)
+                            && ignore_paths.contains(&path.kind)
+                        {
+                            break;
                         }
 
                         if self.vertices.contains_key(from_id) || self.sources.contains_key(from_id)
@@ -354,7 +353,8 @@ impl DataFlowGraph {
         for parent_node in &stmt_var_type.parent_nodes {
             origin_node_ids.extend(self.get_origin_node_ids(&parent_node.id, &[], false));
         }
-        let has_param_source = origin_node_ids.iter().any(|id| {
+
+        origin_node_ids.iter().any(|id| {
             let node = &self.get_node(id).unwrap();
             match &node.kind {
                 DataFlowNodeKind::VariableUseSource { kind, .. } => {
@@ -365,7 +365,6 @@ impl DataFlowGraph {
                 }
                 _ => false,
             }
-        });
-        has_param_source
+        })
     }
 }

--- a/src/code_info/function_complexity.rs
+++ b/src/code_info/function_complexity.rs
@@ -21,7 +21,7 @@ impl FunctionComplexity {
         FunctionComplexity {
             file_path: functionlike_info.def_location.file_path.0,
             line: functionlike_info.def_location.start_line,
-            name: functionlike_id.clone(),
+            name: *functionlike_id,
             complexity,
         }
     }

--- a/src/code_info/function_context/mod.rs
+++ b/src/code_info/function_context/mod.rs
@@ -77,9 +77,7 @@ impl FunctionContext {
                 .and_then(|calling_class| codebase.classlike_infos.get(&calling_class))
                 // The calling class ID may not actually point to a valid class
                 // because we set it to a fake ID when analyzing global constants.
-                .map_or(false, |calling_class_info| {
-                    calling_class_info.is_production_code
-                }),
+                .is_some_and(|calling_class_info| calling_class_info.is_production_code),
         }
     }
 

--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -289,7 +289,7 @@ impl IssueKind {
     }
 
     pub fn has_autofix(&self) -> bool {
-        AUTOFIXABLE_ISSUES.contains(&self)
+        AUTOFIXABLE_ISSUES.contains(self)
     }
 }
 

--- a/src/code_info/method_info.rs
+++ b/src/code_info/method_info.rs
@@ -38,21 +38,17 @@ impl MethodInfo {
         function_context: &FunctionContext,
         codebase: &CodebaseInfo,
     ) -> bool {
-        if self.is_final {
-            if let Some(FunctionLikeIdentifier::Method(calling_class, calling_method_name)) =
+        if self.is_final
+            && let Some(FunctionLikeIdentifier::Method(calling_class, calling_method_name)) =
                 function_context.calling_functionlike_id
-            {
-                if let Some(classlike_info) = codebase.classlike_infos.get(&calling_class) {
-                    if !classlike_info
-                        .overridden_method_ids
-                        .contains_key(&calling_method_name)
-                    {
-                        return true;
-                    }
-                }
-            }
+            && let Some(classlike_info) = codebase.classlike_infos.get(&calling_class)
+            && !classlike_info
+                .overridden_method_ids
+                .contains_key(&calling_method_name)
+        {
+            return true;
         }
 
-        return false;
+        false
     }
 }

--- a/src/code_info/symbol_references.rs
+++ b/src/code_info/symbol_references.rs
@@ -119,10 +119,9 @@ impl SymbolReferences {
             if let Some(symbol_refs_in_signature) = self
                 .symbol_references_to_symbols_in_signature
                 .get(&(referencing_symbol, StrId::EMPTY))
+                && symbol_refs_in_signature.contains(&(symbol, StrId::EMPTY))
             {
-                if symbol_refs_in_signature.contains(&(symbol, StrId::EMPTY)) {
-                    return;
-                }
+                return;
             }
 
             self.symbol_references_to_symbols
@@ -180,10 +179,9 @@ impl SymbolReferences {
             if let Some(symbol_refs_in_signature) = self
                 .symbol_references_to_symbols_in_signature
                 .get(&referencing_class_member)
+                && symbol_refs_in_signature.contains(&(symbol, StrId::EMPTY))
             {
-                if symbol_refs_in_signature.contains(&(symbol, StrId::EMPTY)) {
-                    return;
-                }
+                return;
             }
 
             self.symbol_references_to_symbols

--- a/src/code_info/t_atomic.rs
+++ b/src/code_info/t_atomic.rs
@@ -398,7 +398,7 @@ impl TAtomic {
                 str += ">";
                 str
             }
-            TAtomic::TBool { .. } => "bool".to_string(),
+            TAtomic::TBool => "bool".to_string(),
             TAtomic::TClassname { as_type, .. } => {
                 let mut str = String::new();
                 str += "classname<";
@@ -435,8 +435,8 @@ impl TAtomic {
                     name.0.to_string()
                 }
             }
-            TAtomic::TFalse { .. } => "false".to_string(),
-            TAtomic::TFloat { .. } => "float".to_string(),
+            TAtomic::TFalse => "false".to_string(),
+            TAtomic::TFloat => "float".to_string(),
             TAtomic::TClosure(closure) => {
                 let mut str = String::new();
                 str += "(function(";
@@ -481,7 +481,7 @@ impl TAtomic {
                 str += "<>";
                 str
             }
-            TAtomic::TInt { .. } => "int".to_string(),
+            TAtomic::TInt => "int".to_string(),
             TAtomic::TObject => "object".to_string(),
             TAtomic::TKeyset { type_param, .. } => {
                 let mut str = String::new();
@@ -663,10 +663,10 @@ impl TAtomic {
                 }
             }
             TAtomic::TNothing => "nothing".to_string(),
-            TAtomic::TNull { .. } => "null".to_string(),
-            TAtomic::TNum { .. } => "num".to_string(),
+            TAtomic::TNull => "null".to_string(),
+            TAtomic::TNum => "num".to_string(),
             TAtomic::TScalar => "scalar".to_string(),
-            TAtomic::TString { .. } => "string".to_string(),
+            TAtomic::TString => "string".to_string(),
             TAtomic::TStringWithFlags(is_truthy, is_non_empty, is_nonspecific_literal) => {
                 let mut str = String::new();
 
@@ -748,7 +748,7 @@ impl TAtomic {
                 str += ">";
                 str
             }
-            TAtomic::TTrue { .. } => "true".to_string(),
+            TAtomic::TTrue => "true".to_string(),
             TAtomic::TVec(vec) => vec.get_id_with_refs(interner, refs, indent),
             TAtomic::TVoid => "void".to_string(),
             TAtomic::TReference { name, .. } => {
@@ -834,17 +834,17 @@ impl TAtomic {
                 str
             }
             TAtomic::TAwaitable { .. } => "Awaitable".to_string(),
-            TAtomic::TFalse { .. }
-            | TAtomic::TFloat { .. }
+            TAtomic::TFalse
+            | TAtomic::TFloat
             | TAtomic::TClosure(_)
             | TAtomic::TClosureAlias { .. }
-            | TAtomic::TInt { .. }
+            | TAtomic::TInt
             | TAtomic::TNothing
-            | TAtomic::TNull { .. }
-            | TAtomic::TNum { .. }
+            | TAtomic::TNull
+            | TAtomic::TNum
             | TAtomic::TMixed
             | TAtomic::TMixedFromLoopIsset
-            | TAtomic::TString { .. }
+            | TAtomic::TString
             | TAtomic::TEnum { .. }
             | TAtomic::TLiteralClassname { .. }
             | TAtomic::TLiteralClassPtr { .. }
@@ -854,13 +854,13 @@ impl TAtomic {
             | TAtomic::TClassTypeConstant { .. }
             | TAtomic::TLiteralString { .. }
             | TAtomic::TVoid
-            | TAtomic::TTrue { .. }
+            | TAtomic::TTrue
             | TAtomic::TObject
             | TAtomic::TScalar
             | TAtomic::TResource
             | TAtomic::TReference { .. }
             | TAtomic::TArraykey { .. }
-            | TAtomic::TBool { .. }
+            | TAtomic::TBool
             | TAtomic::TEnumClassLabel { .. }
             | TAtomic::TMixedWithFlags(..)
             | TAtomic::TTypeVariable { .. } => self.get_id_with_refs(None, &mut vec![], None),
@@ -972,7 +972,7 @@ impl TAtomic {
                     None
                 }
             }
-            TAtomic::TFalse { .. } => Some("false".to_string()),
+            TAtomic::TFalse => Some("false".to_string()),
             TAtomic::TLiteralClassname { name } => {
                 let mut str = String::new();
                 str += interner.lookup(name);
@@ -1014,8 +1014,8 @@ impl TAtomic {
                 Some(str)
             }
 
-            TAtomic::TNull { .. } => Some("null".to_string()),
-            TAtomic::TTrue { .. } => Some("true".to_string()),
+            TAtomic::TNull => Some("null".to_string()),
+            TAtomic::TTrue => Some("true".to_string()),
             TAtomic::TVec(TVec {
                 type_param,
                 known_items: Some(known_items),
@@ -1060,7 +1060,7 @@ impl TAtomic {
 
     pub fn is_object_type(&self) -> bool {
         match self {
-            TAtomic::TObject { .. } => true,
+            TAtomic::TObject => true,
             TAtomic::TClosure(_) => true,
             TAtomic::TAwaitable { .. } => true,
             TAtomic::TNamedObject(TNamedObject { .. }) => true,
@@ -1128,17 +1128,17 @@ impl TAtomic {
                 | TAtomic::TLiteralInt { .. }
                 | TAtomic::TLiteralString { .. }
                 | TAtomic::TArraykey { .. }
-                | TAtomic::TBool { .. }
+                | TAtomic::TBool
                 | TAtomic::TClassPtr { .. }
                 | TAtomic::TClassname { .. }
                 | TAtomic::TTypename { .. }
-                | TAtomic::TFalse { .. }
-                | TAtomic::TFloat { .. }
-                | TAtomic::TInt { .. }
-                | TAtomic::TNum { .. }
-                | TAtomic::TString { .. }
+                | TAtomic::TFalse
+                | TAtomic::TFloat
+                | TAtomic::TInt
+                | TAtomic::TNum
+                | TAtomic::TString
                 | TAtomic::TStringWithFlags(..)
-                | TAtomic::TTrue { .. }
+                | TAtomic::TTrue
                 | TAtomic::TEnum { .. }
                 | TAtomic::TEnumLiteralCase { .. }
         )
@@ -1149,14 +1149,14 @@ impl TAtomic {
         matches!(
             self,
             TAtomic::TArraykey { .. }
-                | TAtomic::TBool { .. }
+                | TAtomic::TBool
                 | TAtomic::TClassname { .. }
                 | TAtomic::TTypename { .. }
-                | TAtomic::TFalse { .. }
-                | TAtomic::TFloat { .. }
-                | TAtomic::TInt { .. }
-                | TAtomic::TNum { .. }
-                | TAtomic::TString { .. }
+                | TAtomic::TFalse
+                | TAtomic::TFloat
+                | TAtomic::TInt
+                | TAtomic::TNum
+                | TAtomic::TString
         )
     }
 
@@ -1179,7 +1179,7 @@ impl TAtomic {
     pub fn is_string(&self) -> bool {
         matches!(
             self,
-            TAtomic::TString { .. }
+            TAtomic::TString
                 | TAtomic::TLiteralClassname { .. }
                 | TAtomic::TLiteralString { .. }
                 | TAtomic::TLiteralClassPtr { .. }
@@ -1218,15 +1218,12 @@ impl TAtomic {
 
     #[inline]
     pub fn is_int(&self) -> bool {
-        matches!(self, TAtomic::TLiteralInt { .. } | TAtomic::TInt { .. })
+        matches!(self, TAtomic::TLiteralInt { .. } | TAtomic::TInt)
     }
 
     #[inline]
     pub fn is_bool(&self) -> bool {
-        matches!(
-            self,
-            TAtomic::TFalse { .. } | TAtomic::TTrue { .. } | TAtomic::TBool { .. }
-        )
+        matches!(self, TAtomic::TFalse | TAtomic::TTrue | TAtomic::TBool)
     }
 
     pub fn is_literal(&self) -> bool {
@@ -1237,10 +1234,10 @@ impl TAtomic {
                 | TAtomic::TLiteralInt { .. }
                 | TAtomic::TLiteralString { .. }
                 | TAtomic::TEnumLiteralCase { .. }
-                | TAtomic::TFalse { .. }
-                | TAtomic::TTrue { .. }
-                | TAtomic::TBool { .. }
-                | TAtomic::TNull { .. }
+                | TAtomic::TFalse
+                | TAtomic::TTrue
+                | TAtomic::TBool
+                | TAtomic::TNull
         )
     }
 
@@ -1313,10 +1310,10 @@ impl TAtomic {
 
     pub fn is_truthy(&self) -> bool {
         match &self {
-            &TAtomic::TTrue { .. }
+            &TAtomic::TTrue
             | &TAtomic::TMixedWithFlags(_, true, _, _)
             | &TAtomic::TStringWithFlags(true, _, _)
-            | &TAtomic::TObject { .. }
+            | &TAtomic::TObject
             | &TAtomic::TClosure(_)
             | &TAtomic::TLiteralClassname { .. }
             | &TAtomic::TLiteralClassPtr { .. }
@@ -1389,9 +1386,7 @@ impl TAtomic {
 
     pub fn is_falsy(&self) -> bool {
         match &self {
-            &TAtomic::TFalse { .. }
-            | &TAtomic::TNull { .. }
-            | &TAtomic::TMixedWithFlags(_, _, true, _) => true,
+            &TAtomic::TFalse | &TAtomic::TNull | &TAtomic::TMixedWithFlags(_, _, true, _) => true,
             &TAtomic::TLiteralInt { value, .. } => {
                 if *value == 0 {
                     return true;
@@ -1581,25 +1576,22 @@ impl TAtomic {
                 ..
             }) => {
                 if let TAtomic::TPlaceholder = params.0.get_single() {
-                    params.0 = Box::new(TUnion::new(vec![TAtomic::TArraykey { from_any: true }]));
+                    *params.0 = TUnion::new(vec![TAtomic::TArraykey { from_any: true }]);
                 }
                 if let TAtomic::TPlaceholder = params.1.get_single() {
-                    params.1 = Box::new(TUnion::new(vec![TAtomic::TMixedWithFlags(
-                        true, false, false, false,
-                    )]));
+                    *params.1 =
+                        TUnion::new(vec![TAtomic::TMixedWithFlags(true, false, false, false)]);
                 }
             }
             TAtomic::TVec(TVec { type_param, .. }) => {
                 if let TAtomic::TPlaceholder = type_param.get_single() {
-                    *type_param = Box::new(TUnion::new(vec![TAtomic::TMixedWithFlags(
-                        true, false, false, false,
-                    )]));
+                    **type_param =
+                        TUnion::new(vec![TAtomic::TMixedWithFlags(true, false, false, false)]);
                 }
             }
             TAtomic::TKeyset { type_param, .. } => {
                 if let TAtomic::TPlaceholder = type_param.get_single() {
-                    *type_param =
-                        Box::new(TUnion::new(vec![TAtomic::TArraykey { from_any: true }]));
+                    **type_param = TUnion::new(vec![TAtomic::TArraykey { from_any: true }]);
                 }
             }
             TAtomic::TNamedObject(TNamedObject {
@@ -1611,26 +1603,24 @@ impl TAtomic {
                     || name == &StrId::ANY_ARRAY
                     || name == &StrId::KEYED_TRAVERSABLE
                 {
-                    if let Some(key_param) = type_params.get_mut(0) {
-                        if let TAtomic::TPlaceholder = key_param.get_single() {
-                            *key_param = TUnion::new(vec![TAtomic::TArraykey { from_any: true }]);
-                        }
+                    if let Some(key_param) = type_params.get_mut(0)
+                        && let TAtomic::TPlaceholder = key_param.get_single()
+                    {
+                        *key_param = TUnion::new(vec![TAtomic::TArraykey { from_any: true }]);
                     }
 
-                    if let Some(value_param) = type_params.get_mut(1) {
-                        if let TAtomic::TPlaceholder = value_param.get_single() {
-                            *value_param = TUnion::new(vec![TAtomic::TMixedWithFlags(
-                                true, false, false, false,
-                            )]);
-                        }
+                    if let Some(value_param) = type_params.get_mut(1)
+                        && let TAtomic::TPlaceholder = value_param.get_single()
+                    {
+                        *value_param =
+                            TUnion::new(vec![TAtomic::TMixedWithFlags(true, false, false, false)]);
                     }
                 } else if name == &StrId::CONTAINER || name == &StrId::TRAVERSABLE {
-                    if let Some(value_param) = type_params.get_mut(0) {
-                        if let TAtomic::TPlaceholder = value_param.get_single() {
-                            *value_param = TUnion::new(vec![TAtomic::TMixedWithFlags(
-                                true, false, false, false,
-                            )]);
-                        }
+                    if let Some(value_param) = type_params.get_mut(0)
+                        && let TAtomic::TPlaceholder = value_param.get_single()
+                    {
+                        *value_param =
+                            TUnion::new(vec![TAtomic::TMixedWithFlags(true, false, false, false)]);
                     }
                 } else {
                     for type_param in type_params {
@@ -1706,16 +1696,16 @@ impl TAtomic {
                 shape_name,
                 ..
             }) => {
-                if let Some((shape_name, None)) = shape_name {
-                    if banned_type_aliases.contains(shape_name) {
-                        return false;
-                    }
+                if let Some((shape_name, None)) = shape_name
+                    && banned_type_aliases.contains(shape_name)
+                {
+                    return false;
                 }
 
-                if let Some(params) = params {
-                    if !params.1.is_json_compatible(banned_type_aliases) {
-                        return false;
-                    }
+                if let Some(params) = params
+                    && !params.1.is_json_compatible(banned_type_aliases)
+                {
+                    return false;
                 }
 
                 if let Some(known_items) = known_items {

--- a/src/code_info/t_union.rs
+++ b/src/code_info/t_union.rs
@@ -81,7 +81,7 @@ impl TUnion {
 
     pub fn is_int(&self) -> bool {
         for atomic in &self.types {
-            let no_int = !matches!(atomic, TAtomic::TInt { .. } | TAtomic::TLiteralInt { .. });
+            let no_int = !matches!(atomic, TAtomic::TInt | TAtomic::TLiteralInt { .. });
 
             if no_int {
                 return false;
@@ -94,7 +94,7 @@ impl TUnion {
     pub fn has_int(&self) -> bool {
         for atomic in &self.types {
             match atomic {
-                TAtomic::TInt { .. } | TAtomic::TLiteralInt { .. } => {
+                TAtomic::TInt | TAtomic::TLiteralInt { .. } => {
                     return true;
                 }
                 _ => {}
@@ -106,7 +106,7 @@ impl TUnion {
 
     pub fn has_float(&self) -> bool {
         for atomic in &self.types {
-            if let TAtomic::TFloat { .. } = atomic {
+            if let TAtomic::TFloat = atomic {
                 return true;
             };
         }
@@ -127,7 +127,7 @@ impl TUnion {
     pub fn has_string(&self) -> bool {
         for atomic in &self.types {
             match atomic {
-                TAtomic::TString { .. }
+                TAtomic::TString
                 | TAtomic::TLiteralString { .. }
                 | TAtomic::TStringWithFlags { .. } => {
                     return true;
@@ -232,10 +232,10 @@ impl TUnion {
                 return true;
             }
 
-            if let TAtomic::TNamedObject(TNamedObject { is_this, .. }) = atomic {
-                if *is_this {
-                    return true;
-                }
+            if let TAtomic::TNamedObject(TNamedObject { is_this, .. }) = atomic
+                && *is_this
+            {
+                return true;
             }
 
             if let TAtomic::TObjectIntersection { types } = atomic {
@@ -316,15 +316,14 @@ impl TUnion {
         let mut template_types = Vec::new();
 
         for child_node in all_child_nodes {
-            if let TypeNode::Atomic(inner) = child_node {
-                if let TAtomic::TGenericParam(TGenericParam { .. })
+            if let TypeNode::Atomic(inner) = child_node
+                && let TAtomic::TGenericParam(TGenericParam { .. })
                 | TAtomic::TGenericClassPtr { .. }
                 | TAtomic::TGenericClassname { .. }
                 | TAtomic::TGenericTypename { .. }
                 | TAtomic::TClassTypeConstant { .. } = inner
-                {
-                    template_types.push(inner);
-                }
+            {
+                template_types.push(inner);
             }
         }
 
@@ -333,7 +332,7 @@ impl TUnion {
 
     pub fn is_objecty(&self) -> bool {
         for atomic in &self.types {
-            if let &TAtomic::TObject { .. }
+            if let &TAtomic::TObject
             | TAtomic::TNamedObject(TNamedObject { .. })
             | TAtomic::TAwaitable { .. }
             | TAtomic::TClosure(_) = atomic
@@ -349,10 +348,10 @@ impl TUnion {
 
     pub fn is_generator(&self) -> bool {
         for atomic in &self.types {
-            if let &TAtomic::TNamedObject(TNamedObject { name, .. }) = &atomic {
-                if *name == StrId::GENERATOR {
-                    continue;
-                }
+            if let &TAtomic::TNamedObject(TNamedObject { name, .. }) = &atomic
+                && *name == StrId::GENERATOR
+            {
+                continue;
             }
 
             return false;
@@ -386,18 +385,15 @@ impl TUnion {
     }
 
     pub fn has_bool(&self) -> bool {
-        self.types.iter().any(|atomic| {
-            matches!(
-                atomic,
-                TAtomic::TBool { .. } | TAtomic::TFalse { .. } | TAtomic::TTrue { .. }
-            )
-        })
+        self.types
+            .iter()
+            .any(|atomic| matches!(atomic, TAtomic::TBool | TAtomic::TFalse | TAtomic::TTrue))
     }
 
     pub fn has_scalar(&self) -> bool {
         self.types
             .iter()
-            .any(|atomic| matches!(atomic, TAtomic::TScalar { .. }))
+            .any(|atomic| matches!(atomic, TAtomic::TScalar))
     }
 
     pub fn is_always_truthy(&self) -> bool {
@@ -436,10 +432,10 @@ impl TUnion {
             }
             TAtomic::TEnum { name, .. } => {
                 for self_atomic_type in &self.types {
-                    if let TAtomic::TEnumLiteralCase { enum_name, .. } = self_atomic_type {
-                        if enum_name == name {
-                            continue;
-                        }
+                    if let TAtomic::TEnumLiteralCase { enum_name, .. } = self_atomic_type
+                        && enum_name == name
+                    {
+                        continue;
                     }
 
                     return false;
@@ -465,21 +461,19 @@ impl TUnion {
                     | TAtomic::TTrue
             ) {
                 true
-            } else {
-                if let TAtomic::TVec(TVec {
-                    known_items: Some(known_items),
-                    type_param,
-                    ..
-                }) = atomic
-                {
-                    if type_param.is_nothing() {
-                        known_items.iter().all(|(_, t)| t.1.all_literals())
-                    } else {
-                        false
-                    }
+            } else if let TAtomic::TVec(TVec {
+                known_items: Some(known_items),
+                type_param,
+                ..
+            }) = atomic
+            {
+                if type_param.is_nothing() {
+                    known_items.iter().all(|(_, t)| t.1.all_literals())
                 } else {
                     false
                 }
+            } else {
+                false
             }
         })
     }
@@ -572,9 +566,7 @@ impl TUnion {
 
     #[inline]
     pub fn has_object(&self) -> bool {
-        self.types
-            .iter()
-            .any(|t| matches!(t, TAtomic::TObject { .. }))
+        self.types.iter().any(|t| matches!(t, TAtomic::TObject))
     }
 
     #[inline]
@@ -663,8 +655,8 @@ impl TUnion {
                 atomic,
                 TAtomic::TLiteralInt { .. }
                     | TAtomic::TLiteralString { .. }
-                    | TAtomic::TTrue { .. }
-                    | TAtomic::TFalse { .. }
+                    | TAtomic::TTrue
+                    | TAtomic::TFalse
                     | TAtomic::TLiteralClassname { .. }
                     | TAtomic::TLiteralClassPtr { .. }
             )
@@ -818,7 +810,7 @@ pub fn populate_union_type(
                 symbol_references,
                 force,
             );
-            *as_type = Box::new(new_as_type);
+            **as_type = new_as_type;
         } else {
             populate_atomic_type(
                 atomic,

--- a/src/code_info/ttype/comparison/atomic_type_comparator.rs
+++ b/src/code_info/ttype/comparison/atomic_type_comparator.rs
@@ -45,28 +45,24 @@ pub fn is_contained_by(
 
     if let TAtomic::TGenericParam(TGenericParam { .. }) | TAtomic::TObjectIntersection { .. } =
         container_type_part
-    {
-        if let TAtomic::TGenericParam(TGenericParam { .. }) | TAtomic::TObjectIntersection { .. } =
+        && let TAtomic::TGenericParam(TGenericParam { .. }) | TAtomic::TObjectIntersection { .. } =
             input_type_part
-        {
-            return object_type_comparator::is_shallowly_contained_by(
-                codebase,
-                file_path,
-                input_type_part,
-                container_type_part,
-                inside_assertion,
-                atomic_comparison_result,
-            );
-        }
+    {
+        return object_type_comparator::is_shallowly_contained_by(
+            codebase,
+            file_path,
+            input_type_part,
+            container_type_part,
+            inside_assertion,
+            atomic_comparison_result,
+        );
     }
 
     if container_type_part.is_mixed() || container_type_part.is_templated_as_mixed(&mut false) {
         if matches!(container_type_part, TAtomic::TMixedWithFlags(_, _, _, true))
             && matches!(
                 input_type_part,
-                TAtomic::TNull { .. }
-                    | TAtomic::TMixed
-                    | TAtomic::TMixedWithFlags(_, false, _, false)
+                TAtomic::TNull | TAtomic::TMixed | TAtomic::TMixedWithFlags(_, false, _, false)
             )
         {
             return false;
@@ -136,10 +132,10 @@ pub fn is_contained_by(
     }
 
     if let TAtomic::TNull = input_type_part {
-        if let TAtomic::TGenericParam(TGenericParam { as_type, .. }) = container_type_part {
-            if as_type.is_nullable() || as_type.is_mixed() {
-                return true;
-            }
+        if let TAtomic::TGenericParam(TGenericParam { as_type, .. }) = container_type_part
+            && (as_type.is_nullable() || as_type.is_mixed())
+        {
+            return true;
         }
 
         return false;
@@ -167,33 +163,31 @@ pub fn is_contained_by(
         type_params: Some(type_params),
         ..
     }) = container_type_part
-    {
-        if let TAtomic::TVec(TVec { .. }) | TAtomic::TDict(TDict { .. }) | TAtomic::TKeyset { .. } =
+        && let TAtomic::TVec(TVec { .. }) | TAtomic::TDict(TDict { .. }) | TAtomic::TKeyset { .. } =
             input_type_part
-        {
-            let arrayish_params = get_arrayish_params(input_type_part, codebase);
+    {
+        let arrayish_params = get_arrayish_params(input_type_part, codebase);
 
-            if let Some(arrayish_params) = arrayish_params {
-                return union_type_comparator::is_contained_by(
-                    codebase,
-                    file_path,
-                    &arrayish_params.0,
-                    &type_params[0],
-                    false,
-                    false,
-                    inside_assertion,
-                    atomic_comparison_result,
-                ) && union_type_comparator::is_contained_by(
-                    codebase,
-                    file_path,
-                    &arrayish_params.1,
-                    &type_params[1],
-                    false,
-                    false,
-                    inside_assertion,
-                    atomic_comparison_result,
-                );
-            }
+        if let Some(arrayish_params) = arrayish_params {
+            return union_type_comparator::is_contained_by(
+                codebase,
+                file_path,
+                &arrayish_params.0,
+                &type_params[0],
+                false,
+                false,
+                inside_assertion,
+                atomic_comparison_result,
+            ) && union_type_comparator::is_contained_by(
+                codebase,
+                file_path,
+                &arrayish_params.1,
+                &type_params[1],
+                false,
+                false,
+                inside_assertion,
+                atomic_comparison_result,
+            );
         }
     }
 
@@ -294,66 +288,64 @@ pub fn is_contained_by(
         }
     }
 
-    if let TAtomic::TDict(TDict { .. }) = container_type_part {
-        if let TAtomic::TDict(TDict { .. }) = input_type_part {
-            return dict_type_comparator::is_contained_by(
-                codebase,
-                file_path,
-                input_type_part,
-                container_type_part,
-                inside_assertion,
-                atomic_comparison_result,
-            );
-        }
+    if let TAtomic::TDict(TDict { .. }) = container_type_part
+        && let TAtomic::TDict(TDict { .. }) = input_type_part
+    {
+        return dict_type_comparator::is_contained_by(
+            codebase,
+            file_path,
+            input_type_part,
+            container_type_part,
+            inside_assertion,
+            atomic_comparison_result,
+        );
     }
 
-    if let TAtomic::TVec(TVec { .. }) = container_type_part {
-        if let TAtomic::TVec(TVec { .. }) = input_type_part {
-            return vec_type_comparator::is_contained_by(
-                codebase,
-                file_path,
-                input_type_part,
-                container_type_part,
-                inside_assertion,
-                atomic_comparison_result,
-            );
-        }
+    if let TAtomic::TVec(TVec { .. }) = container_type_part
+        && let TAtomic::TVec(TVec { .. }) = input_type_part
+    {
+        return vec_type_comparator::is_contained_by(
+            codebase,
+            file_path,
+            input_type_part,
+            container_type_part,
+            inside_assertion,
+            atomic_comparison_result,
+        );
     }
 
     if let TAtomic::TKeyset {
         type_param: container_type_param,
         ..
     } = container_type_part
-    {
-        if let TAtomic::TKeyset {
+        && let TAtomic::TKeyset {
             type_param: input_type_param,
             ..
         } = input_type_part
-        {
-            return union_type_comparator::is_contained_by(
-                codebase,
-                file_path,
-                input_type_param,
-                container_type_param,
-                false,
-                input_type_param.ignore_falsable_issues,
-                inside_assertion,
-                atomic_comparison_result,
-            );
-        }
+    {
+        return union_type_comparator::is_contained_by(
+            codebase,
+            file_path,
+            input_type_param,
+            container_type_param,
+            false,
+            input_type_param.ignore_falsable_issues,
+            inside_assertion,
+            atomic_comparison_result,
+        );
     }
 
-    if let TAtomic::TObject { .. } = container_type_part {
-        if let TAtomic::TNamedObject(TNamedObject { .. }) = input_type_part {
-            return true;
-        }
+    if let TAtomic::TObject = container_type_part
+        && let TAtomic::TNamedObject(TNamedObject { .. }) = input_type_part
+    {
+        return true;
     }
 
-    if let TAtomic::TObject { .. } = input_type_part {
-        if let TAtomic::TNamedObject(TNamedObject { .. }) = container_type_part {
-            atomic_comparison_result.type_coerced = Some(true);
-            return false;
-        }
+    if let TAtomic::TObject = input_type_part
+        && let TAtomic::TNamedObject(TNamedObject { .. }) = container_type_part
+    {
+        atomic_comparison_result.type_coerced = Some(true);
+        return false;
     }
 
     if let (
@@ -421,10 +413,10 @@ pub fn is_contained_by(
         return false;
     }
 
-    if let TAtomic::TObject { .. } = input_type_part {
-        if let TAtomic::TObject { .. } = container_type_part {
-            return true;
-        }
+    if let TAtomic::TObject = input_type_part
+        && let TAtomic::TObject = container_type_part
+    {
+        return true;
     }
 
     if let TAtomic::TGenericParam(TGenericParam {
@@ -475,8 +467,8 @@ pub fn is_contained_by(
     }) = input_type_part
     {
         for input_extends_type_part in input_extends.types.iter() {
-            if matches!(input_extends_type_part, TAtomic::TNull { .. })
-                && matches!(container_type_part, TAtomic::TNull { .. })
+            if matches!(input_extends_type_part, TAtomic::TNull)
+                && matches!(container_type_part, TAtomic::TNull)
             {
                 continue;
             }
@@ -502,16 +494,13 @@ pub fn is_contained_by(
         name: StrId::STATIC,
         ..
     }) = input_type_part
-    {
-        if let TAtomic::TNamedObject(TNamedObject {
+        && let TAtomic::TNamedObject(TNamedObject {
             name: container_name,
             ..
         }) = container_type_part
-        {
-            if container_name == &StrId::SELF {
-                return true;
-            }
-        }
+        && container_name == &StrId::SELF
+    {
+        return true;
     }
 
     // handle KeyedContainer and Container accepting arrays
@@ -520,98 +509,94 @@ pub fn is_contained_by(
         type_params: Some(container_type_params),
         ..
     }) = container_type_part
+        && let StrId::CONTAINER | StrId::KEYED_CONTAINER | StrId::ANY_ARRAY = *container_name
     {
-        if let StrId::CONTAINER | StrId::KEYED_CONTAINER | StrId::ANY_ARRAY = *container_name {
-            let type_params = get_arrayish_params(input_type_part, codebase);
+        let type_params = get_arrayish_params(input_type_part, codebase);
 
-            if let Some(input_type_params) = type_params {
-                let mut all_types_contain = true;
+        if let Some(input_type_params) = type_params {
+            let mut all_types_contain = true;
 
-                let mut array_comparison_result = TypeComparisonResult::new();
-                if *container_name == StrId::CONTAINER {
-                    if let Some(container_value_param) = container_type_params.first() {
-                        if !union_type_comparator::is_contained_by(
-                            codebase,
-                            file_path,
-                            &input_type_params.1,
-                            container_value_param,
-                            false,
-                            input_type_params.1.ignore_falsable_issues,
-                            inside_assertion,
-                            &mut array_comparison_result,
-                        ) && !array_comparison_result
-                            .type_coerced_to_literal
-                            .unwrap_or(false)
-                        {
-                            if array_comparison_result
-                                .type_coerced_from_nested_mixed
-                                .unwrap_or(false)
-                            {
-                                atomic_comparison_result.type_coerced_from_nested_mixed =
-                                    Some(true);
-                            }
-
-                            all_types_contain = false;
-                        }
-                    }
-                } else {
-                    if let Some(container_key_param) = container_type_params.first() {
-                        if !union_type_comparator::is_contained_by(
-                            codebase,
-                            file_path,
-                            &input_type_params.0,
-                            container_key_param,
-                            false,
-                            input_type_params.0.ignore_falsable_issues,
-                            inside_assertion,
-                            &mut array_comparison_result,
-                        ) && !array_comparison_result
-                            .type_coerced_to_literal
-                            .unwrap_or(false)
-                        {
-                            if array_comparison_result
-                                .type_coerced_from_nested_mixed
-                                .unwrap_or(false)
-                            {
-                                atomic_comparison_result.type_coerced_from_nested_mixed =
-                                    Some(true);
-                            }
-
-                            all_types_contain = false;
-                        }
+            let mut array_comparison_result = TypeComparisonResult::new();
+            if *container_name == StrId::CONTAINER {
+                if let Some(container_value_param) = container_type_params.first()
+                    && !union_type_comparator::is_contained_by(
+                        codebase,
+                        file_path,
+                        &input_type_params.1,
+                        container_value_param,
+                        false,
+                        input_type_params.1.ignore_falsable_issues,
+                        inside_assertion,
+                        &mut array_comparison_result,
+                    )
+                    && !array_comparison_result
+                        .type_coerced_to_literal
+                        .unwrap_or(false)
+                {
+                    if array_comparison_result
+                        .type_coerced_from_nested_mixed
+                        .unwrap_or(false)
+                    {
+                        atomic_comparison_result.type_coerced_from_nested_mixed = Some(true);
                     }
 
-                    let mut array_comparison_result = TypeComparisonResult::new();
-
-                    if let Some(container_value_param) = container_type_params.get(1) {
-                        if !union_type_comparator::is_contained_by(
-                            codebase,
-                            file_path,
-                            &input_type_params.1,
-                            container_value_param,
-                            false,
-                            input_type_params.1.ignore_falsable_issues,
-                            inside_assertion,
-                            &mut array_comparison_result,
-                        ) && !array_comparison_result
-                            .type_coerced_to_literal
-                            .unwrap_or(false)
-                        {
-                            if array_comparison_result
-                                .type_coerced_from_nested_mixed
-                                .unwrap_or(false)
-                            {
-                                atomic_comparison_result.type_coerced_from_nested_mixed =
-                                    Some(true);
-                            }
-
-                            all_types_contain = false;
-                        }
+                    all_types_contain = false;
+                }
+            } else {
+                if let Some(container_key_param) = container_type_params.first()
+                    && !union_type_comparator::is_contained_by(
+                        codebase,
+                        file_path,
+                        &input_type_params.0,
+                        container_key_param,
+                        false,
+                        input_type_params.0.ignore_falsable_issues,
+                        inside_assertion,
+                        &mut array_comparison_result,
+                    )
+                    && !array_comparison_result
+                        .type_coerced_to_literal
+                        .unwrap_or(false)
+                {
+                    if array_comparison_result
+                        .type_coerced_from_nested_mixed
+                        .unwrap_or(false)
+                    {
+                        atomic_comparison_result.type_coerced_from_nested_mixed = Some(true);
                     }
+
+                    all_types_contain = false;
                 }
 
-                return all_types_contain;
+                let mut array_comparison_result = TypeComparisonResult::new();
+
+                if let Some(container_value_param) = container_type_params.get(1)
+                    && !union_type_comparator::is_contained_by(
+                        codebase,
+                        file_path,
+                        &input_type_params.1,
+                        container_value_param,
+                        false,
+                        input_type_params.1.ignore_falsable_issues,
+                        inside_assertion,
+                        &mut array_comparison_result,
+                    )
+                    && !array_comparison_result
+                        .type_coerced_to_literal
+                        .unwrap_or(false)
+                {
+                    if array_comparison_result
+                        .type_coerced_from_nested_mixed
+                        .unwrap_or(false)
+                    {
+                        atomic_comparison_result.type_coerced_from_nested_mixed = Some(true);
+                    }
+
+                    all_types_contain = false;
+                }
             }
+
+            return all_types_contain;
         }
     }
 
@@ -621,84 +606,76 @@ pub fn is_contained_by(
         type_params: Some(input_type_params),
         ..
     }) = input_type_part
-    {
-        if matches!(
+        && matches!(
             *input_name,
             StrId::CONTAINER | StrId::KEYED_CONTAINER | StrId::ANY_ARRAY
-        ) {
-            if let TAtomic::TKeyset { .. }
-            | TAtomic::TVec(TVec { .. })
-            | TAtomic::TDict(TDict { .. }) = container_type_part
-            {
-                atomic_comparison_result.type_coerced = Some(true);
+        )
+        && let TAtomic::TKeyset { .. } | TAtomic::TVec(TVec { .. }) | TAtomic::TDict(TDict { .. }) =
+            container_type_part
+    {
+        atomic_comparison_result.type_coerced = Some(true);
 
-                let container_arrayish_params =
-                    get_arrayish_params(container_type_part, codebase).unwrap();
+        let container_arrayish_params = get_arrayish_params(container_type_part, codebase).unwrap();
 
-                if *input_name == StrId::CONTAINER {
-                    if let Some(input_value_param) = input_type_params.first() {
-                        union_type_comparator::is_contained_by(
-                            codebase,
-                            file_path,
-                            input_value_param,
-                            &container_arrayish_params.1,
-                            false,
-                            input_value_param.ignore_falsable_issues,
-                            inside_assertion,
-                            atomic_comparison_result,
-                        );
-                    }
-                } else {
-                    if let Some(input_key_param) = input_type_params.first() {
-                        union_type_comparator::is_contained_by(
-                            codebase,
-                            file_path,
-                            input_key_param,
-                            &container_arrayish_params.0,
-                            false,
-                            input_key_param.ignore_falsable_issues,
-                            inside_assertion,
-                            atomic_comparison_result,
-                        );
-                    }
+        if *input_name == StrId::CONTAINER {
+            if let Some(input_value_param) = input_type_params.first() {
+                union_type_comparator::is_contained_by(
+                    codebase,
+                    file_path,
+                    input_value_param,
+                    &container_arrayish_params.1,
+                    false,
+                    input_value_param.ignore_falsable_issues,
+                    inside_assertion,
+                    atomic_comparison_result,
+                );
+            }
+        } else {
+            if let Some(input_key_param) = input_type_params.first() {
+                union_type_comparator::is_contained_by(
+                    codebase,
+                    file_path,
+                    input_key_param,
+                    &container_arrayish_params.0,
+                    false,
+                    input_key_param.ignore_falsable_issues,
+                    inside_assertion,
+                    atomic_comparison_result,
+                );
+            }
 
-                    let mut array_comparison_result = TypeComparisonResult::new();
+            let mut array_comparison_result = TypeComparisonResult::new();
 
-                    if let Some(input_value_param) = input_type_params.get(1) {
-                        union_type_comparator::is_contained_by(
-                            codebase,
-                            file_path,
-                            input_value_param,
-                            &container_arrayish_params.1,
-                            false,
-                            input_value_param.ignore_falsable_issues,
-                            inside_assertion,
-                            &mut array_comparison_result,
-                        );
-                    }
-                }
-
-                return false;
+            if let Some(input_value_param) = input_type_params.get(1) {
+                union_type_comparator::is_contained_by(
+                    codebase,
+                    file_path,
+                    input_value_param,
+                    &container_arrayish_params.1,
+                    false,
+                    input_value_param.ignore_falsable_issues,
+                    inside_assertion,
+                    &mut array_comparison_result,
+                );
             }
         }
+
+        return false;
     }
 
     if let TAtomic::TNamedObject(TNamedObject {
         name: container_name,
         ..
     }) = container_type_part
+        && container_name == &StrId::XHP_CHILD
+        && let TAtomic::TString
+        | TAtomic::TLiteralString { .. }
+        | TAtomic::TInt
+        | TAtomic::TLiteralInt { .. }
+        | TAtomic::TFloat
+        | TAtomic::TNum = input_type_part
     {
-        if container_name == &StrId::XHP_CHILD {
-            if let TAtomic::TString
-            | TAtomic::TLiteralString { .. }
-            | TAtomic::TInt
-            | TAtomic::TLiteralInt { .. }
-            | TAtomic::TFloat
-            | TAtomic::TNum = input_type_part
-            {
-                return true;
-            }
-        }
+        return true;
     }
 
     if let TAtomic::TTypeAlias {
@@ -712,37 +689,36 @@ pub fn is_contained_by(
             type_params: input_type_params,
             ..
         } = input_type_part
+            && input_name == container_name
         {
-            if input_name == container_name {
-                match (input_type_params, container_type_params) {
-                    (None, None) => return true,
-                    (None, Some(_)) => return false,
-                    (Some(_), None) => return false,
-                    (Some(input_type_params), Some(container_type_params)) => {
-                        let mut all_types_contain = true;
-                        for (i, input_param) in input_type_params.iter().enumerate() {
-                            if let Some(container_param) = container_type_params.get(i) {
-                                compare_generic_params(
-                                    codebase,
-                                    file_path,
-                                    input_type_part,
-                                    input_name,
-                                    input_param,
-                                    container_name,
-                                    container_param,
-                                    None,
-                                    i,
-                                    inside_assertion,
-                                    &mut all_types_contain,
-                                    atomic_comparison_result,
-                                );
-                            } else {
-                                all_types_contain = false;
-                            }
+            match (input_type_params, container_type_params) {
+                (None, None) => return true,
+                (None, Some(_)) => return false,
+                (Some(_), None) => return false,
+                (Some(input_type_params), Some(container_type_params)) => {
+                    let mut all_types_contain = true;
+                    for (i, input_param) in input_type_params.iter().enumerate() {
+                        if let Some(container_param) = container_type_params.get(i) {
+                            compare_generic_params(
+                                codebase,
+                                file_path,
+                                input_type_part,
+                                input_name,
+                                input_param,
+                                container_name,
+                                container_param,
+                                None,
+                                i,
+                                inside_assertion,
+                                &mut all_types_contain,
+                                atomic_comparison_result,
+                            );
+                        } else {
+                            all_types_contain = false;
                         }
-
-                        return all_types_contain;
                     }
+
+                    return all_types_contain;
                 }
             }
         }
@@ -750,42 +726,37 @@ pub fn is_contained_by(
         if matches!(
             *container_name,
             StrId::FORMAT_STRING | StrId::TYPED_FORMAT_STRING
-        ) {
-            if let TAtomic::TString { .. }
-            | TAtomic::TLiteralString { .. }
-            | TAtomic::TStringWithFlags { .. } = input_type_part
-            {
-                // todo maybe more specific checks for the type of format string
-                return true;
-            }
+        ) && let TAtomic::TString
+        | TAtomic::TLiteralString { .. }
+        | TAtomic::TStringWithFlags { .. } = input_type_part
+        {
+            // todo maybe more specific checks for the type of format string
+            return true;
         }
 
-        if *container_name == StrId::ENUM_CLASS_LABEL {
-            if let TAtomic::TEnumClassLabel {
+        if *container_name == StrId::ENUM_CLASS_LABEL
+            && let TAtomic::TEnumClassLabel {
                 class_name: input_class_name,
                 member_name: input_member_name,
             } = input_type_part
-            {
-                if let Some(container_type_params) = container_type_params {
-                    if let (Some(container_enum_param), Some(_)) =
-                        (container_type_params.first(), container_type_params.get(1))
-                    {
-                        let container_enum_param = container_enum_param.get_single();
+        {
+            if let Some(container_type_params) = container_type_params {
+                if let (Some(container_enum_param), Some(_)) =
+                    (container_type_params.first(), container_type_params.get(1))
+                {
+                    let container_enum_param = container_enum_param.get_single();
 
-                        if let TAtomic::TNamedObject(TNamedObject {
-                            name: container_enum_name,
-                            ..
-                        }) = container_enum_param
+                    if let TAtomic::TNamedObject(TNamedObject {
+                        name: container_enum_name,
+                        ..
+                    }) = container_enum_param
+                    {
+                        if let Some(input_class_name) = input_class_name {
+                            return input_class_name == container_enum_name;
+                        } else if let Some(classlike_info) =
+                            codebase.classlike_infos.get(container_enum_name)
                         {
-                            if let Some(input_class_name) = input_class_name {
-                                return input_class_name == container_enum_name;
-                            } else if let Some(classlike_info) =
-                                codebase.classlike_infos.get(container_enum_name)
-                            {
-                                return classlike_info.constants.contains_key(input_member_name);
-                            }
-                        } else {
-                            return false;
+                            return classlike_info.constants.contains_key(input_member_name);
                         }
                     } else {
                         return false;
@@ -793,6 +764,8 @@ pub fn is_contained_by(
                 } else {
                     return false;
                 }
+            } else {
+                return false;
             }
         }
     }
@@ -806,10 +779,9 @@ pub fn is_contained_by(
         if matches!(
             *input_name,
             StrId::FORMAT_STRING | StrId::TYPED_FORMAT_STRING
-        ) {
-            if let TAtomic::TString { .. } = container_type_part {
-                return true;
-            }
+        ) && let TAtomic::TString = container_type_part
+        {
+            return true;
         }
 
         if let Some(as_type) = as_type {
@@ -881,15 +853,14 @@ pub(crate) fn can_be_identical<'a>(
         as_type: None,
         underlying_type: Some(underlying_type),
     } = type1_part
+        && !matches!(type2_part, TAtomic::TEnum { .. })
     {
-        if !matches!(type2_part, TAtomic::TEnum { .. }) {
-            let class_const_type = codebase.get_classconst_literal_value(enum_name, member_name);
+        let class_const_type = codebase.get_classconst_literal_value(enum_name, member_name);
 
-            if let Some(class_const_type) = class_const_type {
-                type1_part = class_const_type;
-            } else {
-                type1_part = underlying_type;
-            }
+        if let Some(class_const_type) = class_const_type {
+            type1_part = class_const_type;
+        } else {
+            type1_part = underlying_type;
         }
     }
 
@@ -899,15 +870,14 @@ pub(crate) fn can_be_identical<'a>(
         as_type: None,
         underlying_type: Some(underlying_type),
     } = type2_part
+        && !matches!(type1_part, TAtomic::TEnum { .. })
     {
-        if !matches!(type1_part, TAtomic::TEnum { .. }) {
-            let class_const_type = codebase.get_classconst_literal_value(enum_name, member_name);
+        let class_const_type = codebase.get_classconst_literal_value(enum_name, member_name);
 
-            if let Some(class_const_type) = class_const_type {
-                type2_part = class_const_type;
-            } else {
-                type2_part = underlying_type;
-            }
+        if let Some(class_const_type) = class_const_type {
+            type2_part = class_const_type;
+        } else {
+            type2_part = underlying_type;
         }
     }
 
@@ -916,8 +886,7 @@ pub(crate) fn can_be_identical<'a>(
         underlying_type: Some(underlying_type),
         ..
     } = type1_part
-    {
-        if !matches!(
+        && !matches!(
             type2_part,
             TAtomic::TEnum { .. }
                 | TAtomic::TEnumLiteralCase { .. }
@@ -925,9 +894,9 @@ pub(crate) fn can_be_identical<'a>(
                 | TAtomic::TLiteralInt { .. }
                 | TAtomic::TLiteralClassname { .. }
                 | TAtomic::TLiteralClassPtr { .. }
-        ) {
-            type1_part = underlying_type;
-        }
+        )
+    {
+        type1_part = underlying_type;
     }
 
     if let TAtomic::TEnum {
@@ -935,8 +904,7 @@ pub(crate) fn can_be_identical<'a>(
         underlying_type: Some(underlying_type),
         ..
     } = type2_part
-    {
-        if !matches!(
+        && !matches!(
             type1_part,
             TAtomic::TEnum { .. }
                 | TAtomic::TEnumLiteralCase { .. }
@@ -944,9 +912,9 @@ pub(crate) fn can_be_identical<'a>(
                 | TAtomic::TLiteralInt { .. }
                 | TAtomic::TLiteralClassname { .. }
                 | TAtomic::TLiteralClassPtr { .. }
-        ) {
-            type2_part = underlying_type;
-        }
+        )
+    {
+        type2_part = underlying_type;
     }
 
     if let (
@@ -1002,10 +970,10 @@ pub(crate) fn can_be_identical<'a>(
             ..
         },
     ) = (type1_part, type2_part)
+        && enum_1_name == enum_2_name
+        && enum_1_member_name == enum_2_member_name
     {
-        if enum_1_name == enum_2_name && enum_1_member_name == enum_2_member_name {
-            return true;
-        }
+        return true;
     }
 
     if let (
@@ -1133,12 +1101,10 @@ pub fn expand_constant_value(v: &ConstantInfo, codebase: &CodebaseInfo) -> TAtom
         member_name,
         ..
     }) = &v.inferred_type
+        && let Some(classlike_info) = codebase.classlike_infos.get(enum_name)
+        && let Some(constant_info) = classlike_info.constants.get(member_name)
     {
-        if let Some(classlike_info) = codebase.classlike_infos.get(enum_name) {
-            if let Some(constant_info) = classlike_info.constants.get(member_name) {
-                return expand_constant_value(constant_info, codebase);
-            }
-        }
+        return expand_constant_value(constant_info, codebase);
     }
 
     v.inferred_type.clone().unwrap_or(

--- a/src/code_info/ttype/comparison/closure_type_comparator.rs
+++ b/src/code_info/ttype/comparison/closure_type_comparator.rs
@@ -11,96 +11,97 @@ pub(crate) fn is_contained_by(
     container_type_part: &TAtomic,
     atomic_comparison_result: &mut TypeComparisonResult,
 ) -> bool {
-    if let TAtomic::TClosure(input_closure) = input_type_part {
-        if let TAtomic::TClosure(container_closure) = container_type_part {
-            if let Some(container_effects) = container_closure.effects {
-                if container_effects == 0 && input_closure.effects.unwrap_or(0) > 0 {
-                    atomic_comparison_result.type_coerced = Some(true);
+    if let TAtomic::TClosure(input_closure) = input_type_part
+        && let TAtomic::TClosure(container_closure) = container_type_part
+    {
+        if let Some(container_effects) = container_closure.effects
+            && container_effects == 0
+            && input_closure.effects.unwrap_or(0) > 0
+        {
+            atomic_comparison_result.type_coerced = Some(true);
 
-                    return false;
-                }
+            return false;
+        }
+
+        for (i, input_param) in input_closure.params.iter().enumerate() {
+            let mut container_param = None;
+
+            if let Some(inner) = container_closure.params.get(i) {
+                container_param = Some(inner);
+            } else if let Some(last_param) = container_closure.params.last()
+                && last_param.is_variadic
+            {
+                container_param = Some(last_param);
             }
 
-            for (i, input_param) in input_closure.params.iter().enumerate() {
-                let mut container_param = None;
+            if let Some(container_param) = container_param {
+                if let Some(container_param_type) = &container_param.signature_type {
+                    let mut param_comparison_result = TypeComparisonResult::new();
 
-                if let Some(inner) = container_closure.params.get(i) {
-                    container_param = Some(inner);
-                } else if let Some(last_param) = container_closure.params.last() {
-                    if last_param.is_variadic {
-                        container_param = Some(last_param);
-                    }
-                }
-
-                if let Some(container_param) = container_param {
-                    if let Some(container_param_type) = &container_param.signature_type {
-                        let mut param_comparison_result = TypeComparisonResult::new();
-
-                        if !container_param_type.is_mixed()
-                            && !union_type_comparator::is_contained_by(
-                                codebase,
-                                file_path,
-                                container_param_type,
-                                &input_param
-                                    .signature_type
-                                    .clone()
-                                    .unwrap_or(Box::new(get_mixed_any())),
-                                false,
-                                false,
-                                false,
-                                &mut param_comparison_result,
-                            )
-                        {
-                            return false;
-                        }
-
-                        atomic_comparison_result
-                            .type_variable_lower_bounds
-                            .extend(param_comparison_result.type_variable_upper_bounds);
-
-                        atomic_comparison_result
-                            .type_variable_upper_bounds
-                            .extend(param_comparison_result.type_variable_lower_bounds);
-                    }
-                } else {
-                    if input_param.is_optional {
-                        break;
-                    }
-
-                    return false;
-                }
-            }
-
-            if let Some(container_return_type) = &container_closure.return_type {
-                if let Some(input_return_type) = &input_closure.return_type {
-                    if input_return_type.is_void() && container_return_type.is_nullable() {
-                        return true;
-                    }
-
-                    if !container_return_type.is_void()
+                    if !container_param_type.is_mixed()
                         && !union_type_comparator::is_contained_by(
                             codebase,
                             file_path,
-                            input_return_type,
-                            container_return_type,
+                            container_param_type,
+                            &input_param
+                                .signature_type
+                                .clone()
+                                .unwrap_or(Box::new(get_mixed_any())),
                             false,
-                            input_return_type.ignore_falsable_issues,
                             false,
-                            atomic_comparison_result,
+                            false,
+                            &mut param_comparison_result,
                         )
                     {
                         return false;
                     }
-                } else {
-                    atomic_comparison_result.type_coerced = Some(true);
-                    atomic_comparison_result.type_coerced_from_nested_mixed = Some(true);
 
+                    atomic_comparison_result
+                        .type_variable_lower_bounds
+                        .extend(param_comparison_result.type_variable_upper_bounds);
+
+                    atomic_comparison_result
+                        .type_variable_upper_bounds
+                        .extend(param_comparison_result.type_variable_lower_bounds);
+                }
+            } else {
+                if input_param.is_optional {
+                    break;
+                }
+
+                return false;
+            }
+        }
+
+        if let Some(container_return_type) = &container_closure.return_type {
+            if let Some(input_return_type) = &input_closure.return_type {
+                if input_return_type.is_void() && container_return_type.is_nullable() {
+                    return true;
+                }
+
+                if !container_return_type.is_void()
+                    && !union_type_comparator::is_contained_by(
+                        codebase,
+                        file_path,
+                        input_return_type,
+                        container_return_type,
+                        false,
+                        input_return_type.ignore_falsable_issues,
+                        false,
+                        atomic_comparison_result,
+                    )
+                {
                     return false;
                 }
-            }
+            } else {
+                atomic_comparison_result.type_coerced = Some(true);
+                atomic_comparison_result.type_coerced_from_nested_mixed = Some(true);
 
-            return true;
+                return false;
+            }
         }
+
+        return true;
     }
 
     false

--- a/src/code_info/ttype/comparison/generic_type_comparator.rs
+++ b/src/code_info/ttype/comparison/generic_type_comparator.rs
@@ -188,12 +188,10 @@ pub(crate) fn compare_generic_params(
             type_params: Some(ref mut type_params),
             ..
         })) = atomic_comparison_result.replacement_atomic_type
+            && let Some(input_param_offset) = input_param_offset
+            && let Some(existing_param) = type_params.get_mut(input_param_offset)
         {
-            if let Some(input_param_offset) = input_param_offset {
-                if let Some(existing_param) = type_params.get_mut(input_param_offset) {
-                    *existing_param = container_param.clone();
-                }
-            }
+            *existing_param = container_param.clone();
         }
 
         return;
@@ -226,8 +224,8 @@ pub(crate) fn compare_generic_params(
         inside_assertion,
         &mut param_comparison_result,
     ) {
-        if let Some(Variance::Contravariant) = container_type_param_variance {
-            if union_type_comparator::is_contained_by(
+        if let Some(Variance::Contravariant) = container_type_param_variance
+            && union_type_comparator::is_contained_by(
                 codebase,
                 file_path,
                 container_param,
@@ -236,9 +234,9 @@ pub(crate) fn compare_generic_params(
                 container_param.ignore_falsable_issues,
                 inside_assertion,
                 &mut param_comparison_result,
-            ) {
-                return;
-            }
+            )
+        {
+            return;
         }
 
         if input_name == &StrId::KEYED_CONTAINER && container_param_offset == 0 {

--- a/src/code_info/ttype/comparison/object_type_comparator.rs
+++ b/src/code_info/ttype/comparison/object_type_comparator.rs
@@ -75,19 +75,15 @@ fn is_intersection_shallowly_contained_by(
                     GenericParent::ClassLike(input_defining_class),
                     GenericParent::ClassLike(container_defining_class),
                 ) => {
-                    if input_defining_class != container_defining_class {
-                        if let Some(input_class_storage) =
+                    if input_defining_class != container_defining_class
+                        && let Some(input_class_storage) =
                             codebase.classlike_infos.get(input_defining_class)
-                        {
-                            if let Some(defining_entity_params) = &input_class_storage
-                                .template_extended_params
-                                .get(container_defining_class)
-                            {
-                                if defining_entity_params.get(container_param_name).is_some() {
-                                    return true;
-                                }
-                            }
-                        }
+                        && let Some(defining_entity_params) = &input_class_storage
+                            .template_extended_params
+                            .get(container_defining_class)
+                        && defining_entity_params.get(container_param_name).is_some()
+                    {
+                        return true;
                     }
                 }
                 (GenericParent::ClassLike(_), _) | (_, GenericParent::ClassLike(_)) => {

--- a/src/code_info/ttype/comparison/scalar_type_comparator.rs
+++ b/src/code_info/ttype/comparison/scalar_type_comparator.rs
@@ -139,13 +139,11 @@ pub fn is_contained_by(
         name: container_name,
         ..
     } = container_type_part
-    {
-        if let TAtomic::TLiteralClassname {
+        && let TAtomic::TLiteralClassname {
             name: input_name, ..
         } = input_type_part
-        {
-            return input_name == container_name;
-        }
+    {
+        return input_name == container_name;
     }
 
     if let TAtomic::TLiteralString {
@@ -175,13 +173,11 @@ pub fn is_contained_by(
         value: container_value,
         ..
     } = container_type_part
-    {
-        if let TAtomic::TLiteralInt {
+        && let TAtomic::TLiteralInt {
             value: input_value, ..
         } = input_type_part
-        {
-            return input_value == container_value;
-        }
+    {
+        return input_value == container_value;
     }
 
     if let TAtomic::TEnum {
@@ -267,10 +263,10 @@ pub fn is_contained_by(
             ..
         },
     ) = (input_type_part, container_type_part)
+        && enum_1_name == enum_2_name
+        && enum_1_member_name == enum_2_member_name
     {
-        if enum_1_name == enum_2_name && enum_1_member_name == enum_2_member_name {
-            return true;
-        }
+        return true;
     }
 
     // handles newtypes (hopefully)
@@ -356,15 +352,15 @@ pub fn is_contained_by(
         return true;
     }
 
-    if let TAtomic::TArraykey { from_any } = input_type_part {
-        if container_type_part.is_int() || container_type_part.is_string() {
-            atomic_comparison_result.type_coerced = Some(true);
-            if *from_any {
-                atomic_comparison_result.type_coerced_from_nested_mixed = Some(true);
-                atomic_comparison_result.type_coerced_from_nested_any = Some(true);
-            }
-            return false;
+    if let TAtomic::TArraykey { from_any } = input_type_part
+        && (container_type_part.is_int() || container_type_part.is_string())
+    {
+        atomic_comparison_result.type_coerced = Some(true);
+        if *from_any {
+            atomic_comparison_result.type_coerced_from_nested_mixed = Some(true);
+            atomic_comparison_result.type_coerced_from_nested_any = Some(true);
         }
+        return false;
     }
 
     if matches!(container_type_part, TAtomic::TScalar) && input_type_part.is_some_scalar() {
@@ -575,10 +571,9 @@ pub fn is_contained_by(
                     if let TAtomic::TTypeAlias {
                         name: alias_name, ..
                     } = &**container_name
+                        && alias_name == input_name
                     {
-                        if alias_name == input_name {
-                            return true;
-                        }
+                        return true;
                     }
 
                     typedef_info.actual_type.clone().get_single_owned()
@@ -663,10 +658,10 @@ pub fn is_contained_by(
         }
     }
 
-    if let TAtomic::TGenericTypename { .. } = input_type_part {
-        if let TAtomic::TString = container_type_part {
-            return true;
-        }
+    if let TAtomic::TGenericTypename { .. } = input_type_part
+        && let TAtomic::TString = container_type_part
+    {
+        return true;
     }
 
     // classname<Foo> into Bar::class
@@ -685,33 +680,31 @@ pub fn is_contained_by(
         as_type: input_name,
         ..
     } = input_type_part
-    {
-        if let TAtomic::TLiteralClassname {
+        && let TAtomic::TLiteralClassname {
             name: container_name,
             ..
         }
         | TAtomic::TLiteralClassPtr {
             name: container_name,
         } = container_type_part
-        {
-            if atomic_type_comparator::is_contained_by(
-                codebase,
-                file_path,
-                &TAtomic::TNamedObject(TNamedObject {
-                    name: *container_name,
-                    type_params: None,
-                    is_this: false,
-                    remapped_params: false,
-                }),
-                input_name,
-                inside_assertion,
-                atomic_comparison_result,
-            ) {
-                atomic_comparison_result.type_coerced = Some(true);
-            }
-
-            return false;
+    {
+        if atomic_type_comparator::is_contained_by(
+            codebase,
+            file_path,
+            &TAtomic::TNamedObject(TNamedObject {
+                name: *container_name,
+                type_params: None,
+                is_this: false,
+                remapped_params: false,
+            }),
+            input_name,
+            inside_assertion,
+            atomic_comparison_result,
+        ) {
+            atomic_comparison_result.type_coerced = Some(true);
         }
+
+        return false;
     }
 
     false

--- a/src/code_info/ttype/comparison/union_type_comparator.rs
+++ b/src/code_info/ttype/comparison/union_type_comparator.rs
@@ -58,26 +58,24 @@ pub fn is_contained_by(
 
     while let Some(input_type_part) = input_atomic_types.pop() {
         match input_type_part {
-            TAtomic::TNull { .. } => {
+            TAtomic::TNull => {
                 if comparison_config.ignore_null {
                     continue;
                 }
             }
-            TAtomic::TFalse { .. } => {
+            TAtomic::TFalse => {
                 if comparison_config.ignore_false {
                     continue;
                 }
             }
             TAtomic::TTypeVariable { name } => {
-                if container_type.is_single() {
-                    if let TAtomic::TTypeVariable {
+                if container_type.is_single()
+                    && let TAtomic::TTypeVariable {
                         name: container_name,
                     } = container_type.get_single()
-                    {
-                        if container_name == name {
-                            continue;
-                        }
-                    }
+                    && container_name == name
+                {
+                    continue;
                 }
                 union_comparison_result.type_variable_upper_bounds.push((
                     name.clone(),
@@ -105,30 +103,29 @@ pub fn is_contained_by(
             comparison_config,
             union_comparison_result,
             &container_atomic_types,
-        ) {
-            if !atomic_union_check_result.type_match_found {
-                if atomic_union_check_result.some_type_coerced {
-                    union_comparison_result.type_coerced = Some(true);
-                }
-
-                if atomic_union_check_result.some_type_coerced_from_nested_mixed {
-                    union_comparison_result.type_coerced_from_nested_mixed = Some(true);
-
-                    if input_type.from_template_default
-                        || atomic_union_check_result
-                            .all_type_coerced_from_as_mixed
-                            .unwrap_or(false)
-                    {
-                        union_comparison_result.type_coerced_from_as_mixed = Some(true);
-                    }
-                }
-
-                if atomic_union_check_result.some_type_coerced_from_nested_any {
-                    union_comparison_result.type_coerced_from_nested_any = Some(true);
-                }
-
-                return false;
+        ) && !atomic_union_check_result.type_match_found
+        {
+            if atomic_union_check_result.some_type_coerced {
+                union_comparison_result.type_coerced = Some(true);
             }
+
+            if atomic_union_check_result.some_type_coerced_from_nested_mixed {
+                union_comparison_result.type_coerced_from_nested_mixed = Some(true);
+
+                if input_type.from_template_default
+                    || atomic_union_check_result
+                        .all_type_coerced_from_as_mixed
+                        .unwrap_or(false)
+                {
+                    union_comparison_result.type_coerced_from_as_mixed = Some(true);
+                }
+            }
+
+            if atomic_union_check_result.some_type_coerced_from_nested_any {
+                union_comparison_result.type_coerced_from_nested_any = Some(true);
+            }
+
+            return false;
         }
     }
 
@@ -153,10 +150,10 @@ fn check_atomic_contained_by_union(
         }
 
         for container_atomic_type in container_atomic_types {
-            if let TAtomic::TGenericParam(TGenericParam { as_type, .. }) = container_atomic_type {
-                if as_type.is_arraykey() {
-                    return None;
-                }
+            if let TAtomic::TGenericParam(TGenericParam { as_type, .. }) = container_atomic_type
+                && as_type.is_arraykey()
+            {
+                return None;
             }
         }
     }
@@ -219,8 +216,8 @@ fn check_atomic_contained_by_atomic(
     container_type_part: &&TAtomic,
 ) -> Option<bool> {
     if comparison_config.ignore_false
-        && matches!(container_type_part, TAtomic::TFalse { .. })
-        && !matches!(input_type_part, TAtomic::TFalse { .. })
+        && matches!(container_type_part, TAtomic::TFalse)
+        && !matches!(input_type_part, TAtomic::TFalse)
     {
         return None;
     }
@@ -376,11 +373,11 @@ pub(crate) fn can_be_contained_by(
     }
 
     for container_type_part in &container_type.types {
-        if matches!(container_type_part, TAtomic::TNull { .. }) && ignore_null {
+        if matches!(container_type_part, TAtomic::TNull) && ignore_null {
             continue;
         }
 
-        if matches!(container_type_part, TAtomic::TFalse { .. }) && ignore_false {
+        if matches!(container_type_part, TAtomic::TFalse) && ignore_false {
             continue;
         }
 

--- a/src/code_info/ttype/mod.rs
+++ b/src/code_info/ttype/mod.rs
@@ -126,18 +126,17 @@ pub fn get_named_object(
     name: StrId,
     type_resolution_context: Option<&TypeResolutionContext>,
 ) -> TUnion {
-    if let Some(type_resolution_context) = type_resolution_context {
-        if let Some(t) = type_resolution_context
+    if let Some(type_resolution_context) = type_resolution_context
+        && let Some(t) = type_resolution_context
             .template_type_map
             .iter()
             .find(|v| v.0 == name)
-        {
-            return wrap_atomic(TAtomic::TGenericClassname {
-                param_name: name,
-                defining_entity: t.1[0].0,
-                as_type: Box::new((*(t.1[0].1.get_single())).clone()),
-            });
-        }
+    {
+        return wrap_atomic(TAtomic::TGenericClassname {
+            param_name: name,
+            defining_entity: t.1[0].0,
+            as_type: Box::new((*(t.1[0].1.get_single())).clone()),
+        });
     }
     wrap_atomic(TAtomic::TNamedObject(TNamedObject {
         name,
@@ -412,7 +411,7 @@ fn intersect_atomic_with_atomic_simple(
         }
         (TAtomic::TNull, TAtomic::TMixedWithFlags(_, _, _, true)) => return None,
         (
-            TAtomic::TObject { .. }
+            TAtomic::TObject
             | TAtomic::TClosure(_)
             | TAtomic::TAwaitable { .. }
             | TAtomic::TNamedObject(TNamedObject { .. }),
@@ -440,7 +439,7 @@ fn intersect_atomic_with_atomic_simple(
         (type_1_atomic, TAtomic::TNum) => {
             if type_1_atomic.is_mixed() {
                 return Some(TAtomic::TNum);
-            } else if type_1_atomic.is_int() || matches!(type_1_atomic, TAtomic::TFloat { .. }) {
+            } else if type_1_atomic.is_int() || matches!(type_1_atomic, TAtomic::TFloat) {
                 return Some(type_1_atomic.clone());
             } else if matches!(type_1_atomic, TAtomic::TArraykey { .. }) {
                 return Some(TAtomic::TInt);
@@ -456,7 +455,7 @@ fn intersect_atomic_with_atomic_simple(
             | TAtomic::TClassPtr { .. }
             | TAtomic::TTypename { .. }
             | TAtomic::TStringWithFlags(..)
-            | TAtomic::TString { .. },
+            | TAtomic::TString,
             TAtomic::TString,
         ) => {
             return Some(type_1_atomic.clone());
@@ -764,31 +763,25 @@ fn intersect_vecs_simple(
                 }
             }
 
-            if let Some(type_param) = type_param {
-                Some(TAtomic::TVec(TVec {
+            type_param.map(|type_param| {
+                TAtomic::TVec(TVec {
                     known_items: Some(type_2_known_items),
                     type_param: Box::new(type_param),
                     non_empty: true,
                     known_count: None,
                     variadic_type: None,
-                }))
-            } else {
-                None
-            }
+                })
+            })
         }
-        _ => {
-            if let Some(type_param) = type_param {
-                Some(TAtomic::TVec(TVec {
-                    known_items: None,
-                    type_param: Box::new(type_param),
-                    non_empty: false,
-                    known_count: None,
-                    variadic_type: None,
-                }))
-            } else {
-                None
-            }
-        }
+        _ => type_param.map(|type_param| {
+            TAtomic::TVec(TVec {
+                known_items: None,
+                type_param: Box::new(type_param),
+                non_empty: false,
+                known_count: None,
+                variadic_type: None,
+            })
+        }),
     }
 }
 
@@ -940,7 +933,7 @@ pub fn get_union_syntax_type(
     let is_nullable = union.is_nullable() && !union.is_mixed();
 
     for atomic in &union.types {
-        if let TAtomic::TNull { .. } = atomic {
+        if let TAtomic::TNull = atomic {
             continue;
         }
 
@@ -951,12 +944,10 @@ pub fn get_union_syntax_type(
                 type_params: None,
                 ..
             }) = atomic
+                && let Some(storage) = codebase.classlike_infos.get(name)
+                && let Some(parent_class) = &storage.direct_parent_class
             {
-                if let Some(storage) = codebase.classlike_infos.get(name) {
-                    if let Some(parent_class) = &storage.direct_parent_class {
-                        t_object_parents.insert(*name, *parent_class);
-                    }
-                }
+                t_object_parents.insert(*name, *parent_class);
             }
             s
         });
@@ -1006,7 +997,7 @@ pub fn get_atomic_syntax_type(
 ) -> String {
     match atomic {
         TAtomic::TArraykey { .. } => "arraykey".to_string(),
-        TAtomic::TBool { .. } => "bool".to_string(),
+        TAtomic::TBool => "bool".to_string(),
         TAtomic::TClassname { as_type, .. } => {
             let as_string = get_atomic_syntax_type(as_type, codebase, interner, is_valid);
             let mut str = String::new();
@@ -1057,37 +1048,37 @@ pub fn get_atomic_syntax_type(
                 };
             }
 
-            if let Some(known_items) = known_items {
-                if if let Some(params) = params {
+            if let Some(known_items) = known_items
+                && if let Some(params) = params {
                     params.0.is_arraykey() && params.1.is_mixed()
                 } else {
                     true
-                } {
-                    let mut str = String::new();
-                    str += "shape(";
-                    let mut known_item_strings = vec![];
-
-                    for (property, (pu, property_type)) in known_items {
-                        known_item_strings.push({
-                            let property_type_string =
-                                get_union_syntax_type(property_type, codebase, interner, is_valid);
-                            format!(
-                                "{}'{}' => {}",
-                                if *pu { "?".to_string() } else { "".to_string() },
-                                property.to_string(Some(interner)),
-                                property_type_string
-                            )
-                        })
-                    }
-                    str += known_item_strings.join(", ").as_str();
-
-                    if !params.is_none() {
-                        str += ", ...";
-                    }
-
-                    str += ")";
-                    return str;
                 }
+            {
+                let mut str = String::new();
+                str += "shape(";
+                let mut known_item_strings = vec![];
+
+                for (property, (pu, property_type)) in known_items {
+                    known_item_strings.push({
+                        let property_type_string =
+                            get_union_syntax_type(property_type, codebase, interner, is_valid);
+                        format!(
+                            "{}'{}' => {}",
+                            if *pu { "?".to_string() } else { "".to_string() },
+                            property.to_string(Some(interner)),
+                            property_type_string
+                        )
+                    })
+                }
+                str += known_item_strings.join(", ").as_str();
+
+                if !params.is_none() {
+                    str += ", ...";
+                }
+
+                str += ")";
+                return str;
             }
 
             if let Some(params) = params {
@@ -1099,8 +1090,8 @@ pub fn get_atomic_syntax_type(
             }
         }
         TAtomic::TEnum { name, .. } => interner.lookup(name).to_string(),
-        TAtomic::TFalse { .. } => "bool".to_string(),
-        TAtomic::TFloat { .. } => "float".to_string(),
+        TAtomic::TFalse => "bool".to_string(),
+        TAtomic::TFloat => "float".to_string(),
         TAtomic::TClosure(_) => {
             *is_valid = false;
             // todo
@@ -1111,7 +1102,7 @@ pub fn get_atomic_syntax_type(
             // todo
             "_".to_string()
         }
-        TAtomic::TInt { .. } => "int".to_string(),
+        TAtomic::TInt => "int".to_string(),
         TAtomic::TObject => {
             *is_valid = false;
             "_".to_string()
@@ -1159,16 +1150,16 @@ pub fn get_atomic_syntax_type(
             }
         }
         TAtomic::TNothing => "nothing".to_string(),
-        TAtomic::TNull { .. } => {
+        TAtomic::TNull => {
             *is_valid = false;
             "_".to_string()
         }
-        TAtomic::TNum { .. } => "num".to_string(),
+        TAtomic::TNum => "num".to_string(),
         TAtomic::TScalar => {
             *is_valid = false;
             "_".to_string()
         }
-        TAtomic::TString { .. } => "string".to_string(),
+        TAtomic::TString => "string".to_string(),
         TAtomic::TGenericParam(TGenericParam { param_name, .. }) => {
             interner.lookup(param_name).to_string()
         }
@@ -1199,29 +1190,29 @@ pub fn get_atomic_syntax_type(
             interner.lookup(param_name),
             defining_entity.to_string(Some(interner))
         ),
-        TAtomic::TTrue { .. } => "bool".to_string(),
+        TAtomic::TTrue => "bool".to_string(),
         TAtomic::TVec(TVec {
             type_param,
             known_items,
             ..
         }) => {
-            if type_param.is_nothing() {
-                if let Some(known_items) = known_items {
-                    let mut known_item_strings = vec![];
-                    let mut all_good = true;
-                    for (i, (offset, (pu, t))) in known_items.iter().enumerate() {
-                        if i == *offset && !pu {
-                            known_item_strings
-                                .push(get_union_syntax_type(t, codebase, interner, is_valid))
-                        } else {
-                            all_good = false;
-                            break;
-                        }
+            if type_param.is_nothing()
+                && let Some(known_items) = known_items
+            {
+                let mut known_item_strings = vec![];
+                let mut all_good = true;
+                for (i, (offset, (pu, t))) in known_items.iter().enumerate() {
+                    if i == *offset && !pu {
+                        known_item_strings
+                            .push(get_union_syntax_type(t, codebase, interner, is_valid))
+                    } else {
+                        all_good = false;
+                        break;
                     }
+                }
 
-                    if all_good {
-                        return format!("({})", known_item_strings.join(", "));
-                    }
+                if all_good {
+                    return format!("({})", known_item_strings.join(", "));
                 }
             }
 

--- a/src/code_info/ttype/template/inferred_type_replacer.rs
+++ b/src/code_info/ttype/template/inferred_type_replacer.rs
@@ -248,30 +248,26 @@ fn replace_template_param(
                     }
                 };
 
-                if let Some(classlike_info) = codebase.classlike_infos.get(classlike_name) {
-                    if let Some(param_map) =
+                if let Some(classlike_info) = codebase.classlike_infos.get(classlike_name)
+                    && let Some(param_map) =
                         classlike_info.template_extended_params.get(classlike_name)
+                    && let Some(param_inner) = param_map.get(key)
+                {
+                    let template_name =
+                        if let TAtomic::TGenericParam(TGenericParam { param_name, .. }) =
+                            param_inner.get_single()
+                        {
+                            param_name
+                        } else {
+                            panic!()
+                        };
+                    if let Some(bounds_map) = inferred_lower_bounds.get(template_name)
+                        && let Some(bounds) = bounds_map.get(map_defining_entity)
                     {
-                        if let Some(param_inner) = param_map.get(key) {
-                            let template_name = if let TAtomic::TGenericParam(TGenericParam {
-                                param_name,
-                                ..
-                            }) = param_inner.get_single()
-                            {
-                                param_name
-                            } else {
-                                panic!()
-                            };
-                            if let Some(bounds_map) = inferred_lower_bounds.get(template_name) {
-                                if let Some(bounds) = bounds_map.get(map_defining_entity) {
-                                    template_type = Some(
-                                        standin_type_replacer::get_most_specific_type_from_bounds(
-                                            bounds, codebase,
-                                        ),
-                                    );
-                                }
-                            }
-                        }
+                        template_type =
+                            Some(standin_type_replacer::get_most_specific_type_from_bounds(
+                                bounds, codebase,
+                            ));
                     }
                 }
             }
@@ -292,7 +288,7 @@ fn replace_atomic(
             ref mut known_items,
             ..
         }) => {
-            *type_param = Box::new(replace(type_param, template_result, codebase));
+            **type_param = replace(type_param, template_result, codebase);
 
             if let Some(known_items) = known_items {
                 for (_, t) in known_items.values_mut() {
@@ -306,8 +302,8 @@ fn replace_atomic(
             ..
         }) => {
             if let Some(params) = params {
-                params.0 = Box::new(replace(&params.0, template_result, codebase));
-                params.1 = Box::new(replace(&params.1, template_result, codebase));
+                *params.0 = replace(&params.0, template_result, codebase);
+                *params.1 = replace(&params.1, template_result, codebase);
             }
 
             if let Some(known_items) = known_items {
@@ -319,7 +315,7 @@ fn replace_atomic(
         TAtomic::TKeyset {
             ref mut type_param, ..
         } => {
-            *type_param = Box::new(replace(type_param, template_result, codebase));
+            **type_param = replace(type_param, template_result, codebase);
         }
         TAtomic::TNamedObject(TNamedObject {
             type_params: Some(ref mut type_params),
@@ -330,12 +326,12 @@ fn replace_atomic(
             }
         }
         TAtomic::TAwaitable { ref mut value, .. } => {
-            *value = Box::new(replace(value, template_result, codebase));
+            **value = replace(value, template_result, codebase);
         }
         TAtomic::TClosure(ref mut closure) => {
             for param in closure.params.iter_mut() {
                 if let Some(ref mut t) = param.signature_type {
-                    *t = Box::new(replace(t, template_result, codebase));
+                    **t = replace(t, template_result, codebase);
                 }
             }
 

--- a/src/code_info/ttype/template/standin_type_replacer.rs
+++ b/src/code_info/ttype/template/standin_type_replacer.rs
@@ -64,39 +64,38 @@ pub fn replace(
 
     let mut input_type = input_type.cloned();
 
-    if let Some(ref mut input_type) = input_type {
-        if original_atomic_types.len() > 1
-            && original_atomic_types
-                .iter()
-                .any(|t| matches!(t, TAtomic::TNull))
-            && input_type.is_mixed()
-        {
-            original_atomic_types.retain(|t| !matches!(t, TAtomic::TNull));
+    if let Some(ref mut input_type) = input_type
+        && original_atomic_types.len() > 1
+        && original_atomic_types
+            .iter()
+            .any(|t| matches!(t, TAtomic::TNull))
+        && input_type.is_mixed()
+    {
+        original_atomic_types.retain(|t| !matches!(t, TAtomic::TNull));
 
-            input_type.types = vec![match input_type.types[0] {
-                TAtomic::TMixedWithFlags(any_mixed, truthy_mixed, falsy_mixed, _) => {
-                    TAtomic::TMixedWithFlags(any_mixed, truthy_mixed, falsy_mixed, true)
-                }
-                TAtomic::TMixed | TAtomic::TMixedFromLoopIsset => {
-                    TAtomic::TMixedWithFlags(false, false, false, true)
-                }
-                _ => TAtomic::TMixedWithFlags(true, false, false, true),
-            }];
-        }
+        input_type.types = vec![match input_type.types[0] {
+            TAtomic::TMixedWithFlags(any_mixed, truthy_mixed, falsy_mixed, _) => {
+                TAtomic::TMixedWithFlags(any_mixed, truthy_mixed, falsy_mixed, true)
+            }
+            TAtomic::TMixed | TAtomic::TMixedFromLoopIsset => {
+                TAtomic::TMixedWithFlags(false, false, false, true)
+            }
+            _ => TAtomic::TMixedWithFlags(true, false, false, true),
+        }];
     }
 
-    if let Some(ref mut input_type_inner) = input_type {
-        if !input_type_inner.is_single() {
-            // here we want to subtract atomic types from the input type
-            // when they're also in the union type, so those shared atomic
-            // types will never be inferred as part of the generic type
-            for original_atomic_type in &original_atomic_types {
-                input_type_inner.remove_type(original_atomic_type);
-            }
+    if let Some(ref mut input_type_inner) = input_type
+        && !input_type_inner.is_single()
+    {
+        // here we want to subtract atomic types from the input type
+        // when they're also in the union type, so those shared atomic
+        // types will never be inferred as part of the generic type
+        for original_atomic_type in &original_atomic_types {
+            input_type_inner.remove_type(original_atomic_type);
+        }
 
-            if input_type_inner.types.is_empty() {
-                return union_type.clone();
-            }
+        if input_type_inner.types.is_empty() {
+            return union_type.clone();
         }
     }
 
@@ -134,7 +133,7 @@ pub fn replace(
         new_union_type.had_template = true;
     }
 
-    return new_union_type;
+    new_union_type
 }
 
 fn handle_atomic_standin(
@@ -163,27 +162,26 @@ fn handle_atomic_standin(
         defining_entity,
         ..
     }) = atomic_type
-    {
-        if let Some(template_type) = template_types_contains(
+        && let Some(template_type) = template_types_contains(
             &template_result.template_types.clone(),
             param_name,
             defining_entity,
-        ) {
-            return handle_template_param_standin(
-                atomic_type,
-                &normalized_key,
-                template_type,
-                template_result,
-                codebase,
-                interner,
-                file_path,
-                input_type,
-                input_arg_offset,
-                input_arg_pos,
-                opts,
-                had_template,
-            );
-        }
+        )
+    {
+        return handle_template_param_standin(
+            atomic_type,
+            &normalized_key,
+            template_type,
+            template_result,
+            codebase,
+            interner,
+            file_path,
+            input_type,
+            input_arg_offset,
+            input_arg_pos,
+            opts,
+            had_template,
+        );
     }
 
     if let TAtomic::TGenericClassname {
@@ -196,27 +194,25 @@ fn handle_atomic_standin(
         defining_entity,
         ..
     } = atomic_type
-    {
-        if template_types_contains(
+        && template_types_contains(
             &template_result.template_types.clone(),
             param_name,
             defining_entity,
         )
         .is_some()
-        {
-            return handle_template_param_class_standin(
-                atomic_type,
-                template_result,
-                codebase,
-                interner,
-                file_path,
-                input_type,
-                input_arg_offset,
-                input_arg_pos,
-                opts,
-                was_single,
-            );
-        }
+    {
+        return handle_template_param_class_standin(
+            atomic_type,
+            template_result,
+            codebase,
+            interner,
+            file_path,
+            input_type,
+            input_arg_offset,
+            input_arg_pos,
+            opts,
+            was_single,
+        );
     }
 
     if let TAtomic::TGenericTypename {
@@ -224,27 +220,25 @@ fn handle_atomic_standin(
         defining_entity,
         ..
     } = atomic_type
-    {
-        if template_types_contains(
+        && template_types_contains(
             &template_result.template_types.clone(),
             param_name,
             defining_entity,
         )
         .is_some()
-        {
-            return handle_template_param_type_standin(
-                atomic_type,
-                template_result,
-                codebase,
-                interner,
-                file_path,
-                input_type,
-                input_arg_offset,
-                input_arg_pos,
-                opts,
-                was_single,
-            );
-        }
+    {
+        return handle_template_param_type_standin(
+            atomic_type,
+            template_result,
+            codebase,
+            interner,
+            file_path,
+            input_type,
+            input_arg_offset,
+            input_arg_pos,
+            opts,
+            was_single,
+        );
     }
 
     let mut matching_input_types = Vec::new();
@@ -367,7 +361,7 @@ fn replace_atomic<'a>(
                     None
                 };
 
-                params.0 = Box::new(self::replace(
+                *params.0 = self::replace(
                     &params.0,
                     template_result,
                     codebase,
@@ -384,9 +378,9 @@ fn replace_atomic<'a>(
                         iteration_depth: opts.iteration_depth + 1,
                         ..opts
                     },
-                ));
+                );
 
-                params.1 = Box::new(self::replace(
+                *params.1 = self::replace(
                     &params.1,
                     template_result,
                     codebase,
@@ -403,7 +397,7 @@ fn replace_atomic<'a>(
                         iteration_depth: opts.iteration_depth + 1,
                         ..opts
                     },
-                ));
+                );
             }
 
             return atomic_type;
@@ -451,7 +445,7 @@ fn replace_atomic<'a>(
                     None
                 };
 
-                *type_param = Box::new(self::replace(
+                **type_param = self::replace(
                     type_param,
                     template_result,
                     codebase,
@@ -468,7 +462,7 @@ fn replace_atomic<'a>(
                         iteration_depth: opts.iteration_depth + 1,
                         ..opts
                     },
-                ));
+                );
             }
 
             return atomic_type;
@@ -476,7 +470,7 @@ fn replace_atomic<'a>(
         TAtomic::TKeyset {
             ref mut type_param, ..
         } => {
-            *type_param = Box::new(self::replace(
+            **type_param = self::replace(
                 type_param,
                 template_result,
                 codebase,
@@ -497,12 +491,12 @@ fn replace_atomic<'a>(
                     iteration_depth: opts.iteration_depth + 1,
                     ..opts
                 },
-            ));
+            );
 
             return atomic_type;
         }
         TAtomic::TAwaitable { ref mut value, .. } => {
-            *value = Box::new(self::replace(
+            **value = self::replace(
                 value,
                 template_result,
                 codebase,
@@ -522,7 +516,7 @@ fn replace_atomic<'a>(
                     iteration_depth: opts.iteration_depth + 1,
                     ..opts
                 },
-            ));
+            );
 
             return atomic_type;
         }
@@ -681,7 +675,7 @@ fn replace_atomic<'a>(
                 };
 
                 if let Some(ref mut param_type) = param.signature_type {
-                    *param_type = Box::new(self::replace(
+                    **param_type = self::replace(
                         param_type,
                         template_result,
                         codebase,
@@ -698,7 +692,7 @@ fn replace_atomic<'a>(
                             add_lower_bound: !opts.add_lower_bound,
                             ..opts
                         },
-                    ));
+                    );
                 }
             }
 
@@ -726,7 +720,7 @@ fn replace_atomic<'a>(
             return atomic_type;
         }
         TAtomic::TClassname { ref mut as_type } => {
-            *as_type = Box::new(replace_atomic(
+            **as_type = replace_atomic(
                 as_type,
                 template_result,
                 codebase,
@@ -743,12 +737,12 @@ fn replace_atomic<'a>(
                 input_arg_offset,
                 input_arg_pos,
                 opts,
-            ));
+            );
 
             return atomic_type;
         }
         TAtomic::TClassPtr { ref mut as_type } => {
-            *as_type = Box::new(replace_atomic(
+            **as_type = replace_atomic(
                 as_type,
                 template_result,
                 codebase,
@@ -765,12 +759,12 @@ fn replace_atomic<'a>(
                 input_arg_offset,
                 input_arg_pos,
                 opts,
-            ));
+            );
 
             return atomic_type;
         }
         TAtomic::TTypename { ref mut as_type } => {
-            *as_type = Box::new(replace_atomic(
+            **as_type = replace_atomic(
                 as_type,
                 template_result,
                 codebase,
@@ -787,7 +781,7 @@ fn replace_atomic<'a>(
                 input_arg_offset,
                 input_arg_pos,
                 opts,
-            ));
+            );
 
             return atomic_type;
         }
@@ -823,10 +817,10 @@ fn handle_template_param_standin<'a>(
         panic!()
     };
 
-    if let Some(calling_class) = opts.calling_class {
-        if defining_entity == &GenericParent::ClassLike(calling_class) {
-            return vec![atomic_type.clone()];
-        }
+    if let Some(calling_class) = opts.calling_class
+        && defining_entity == &GenericParent::ClassLike(calling_class)
+    {
+        return vec![atomic_type.clone()];
     }
 
     if &template_type.get_id(None) == normalized_key {
@@ -894,26 +888,24 @@ fn handle_template_param_standin<'a>(
                 as_type: replacement_as_type,
                 ..
             }) = replacement_atomic_type
-            {
-                if (opts.calling_class.is_none()
+                && (opts.calling_class.is_none()
                     || replacement_defining_entity
                         != &GenericParent::ClassLike(opts.calling_class.unwrap()))
-                    && match opts.calling_function {
-                        Some(FunctionLikeIdentifier::Function(calling_function)) => {
-                            replacement_defining_entity
-                                != &GenericParent::FunctionLike(calling_function)
-                        }
-                        Some(FunctionLikeIdentifier::Method(_, _)) => true,
-                        Some(_) => {
-                            panic!()
-                        }
-                        None => true,
+                && match opts.calling_function {
+                    Some(FunctionLikeIdentifier::Function(calling_function)) => {
+                        replacement_defining_entity
+                            != &GenericParent::FunctionLike(calling_function)
                     }
-                {
-                    for nested_type_atomic in &replacement_as_type.types {
-                        replacements_found = true;
-                        atomic_types.push(nested_type_atomic.clone());
+                    Some(FunctionLikeIdentifier::Method(_, _)) => true,
+                    Some(_) => {
+                        panic!()
                     }
+                    None => true,
+                }
+            {
+                for nested_type_atomic in &replacement_as_type.types {
+                    replacements_found = true;
+                    atomic_types.push(nested_type_atomic.clone());
                 }
             }
 
@@ -965,82 +957,81 @@ fn handle_template_param_standin<'a>(
         },
     );
 
-    if let Some(input_type) = input_type {
-        if !template_result.readonly
-            && (as_type.is_mixed()
-                || union_type_comparator::can_be_contained_by(
-                    codebase,
-                    file_path,
-                    input_type,
-                    &as_type,
-                    false,
-                    false,
-                    &mut matching_input_keys,
-                ))
-        {
-            let mut input_type = (*input_type).clone();
+    if let Some(input_type) = input_type
+        && !template_result.readonly
+        && (as_type.is_mixed()
+            || union_type_comparator::can_be_contained_by(
+                codebase,
+                file_path,
+                input_type,
+                &as_type,
+                false,
+                false,
+                &mut matching_input_keys,
+            ))
+    {
+        let mut input_type = (*input_type).clone();
 
-            if !matching_input_keys.is_empty() {
-                for atomic in &input_type.clone().types {
-                    if !matching_input_keys.contains(&atomic.get_key()) {
-                        input_type.remove_type(atomic);
-                    }
+        if !matching_input_keys.is_empty() {
+            for atomic in &input_type.clone().types {
+                if !matching_input_keys.contains(&atomic.get_key()) {
+                    input_type.remove_type(atomic);
                 }
             }
+        }
 
-            if !opts.add_lower_bound {
-                return input_type.types.clone();
-            }
+        if !opts.add_lower_bound {
+            return input_type.types.clone();
+        }
 
-            if let Some(existing_lower_bounds) =
-                if let Some(mapped_bounds) = template_result.lower_bounds.get(&param_name_key) {
-                    mapped_bounds.get(defining_entity)
-                } else {
-                    None
-                }
-            {
-                let mut has_matching_lower_bound = false;
-
-                for existing_lower_bound in existing_lower_bounds {
-                    let existing_depth = &existing_lower_bound.appearance_depth;
-                    let existing_arg_offset = if existing_lower_bound.arg_offset.is_none() {
-                        &input_arg_offset
-                    } else {
-                        &existing_lower_bound.arg_offset
-                    };
-
-                    if existing_depth == &opts.appearance_depth
-                        && &input_arg_offset == existing_arg_offset
-                        && existing_lower_bound.bound_type == input_type
-                        && existing_lower_bound.equality_bound_classlike.is_none()
-                    {
-                        has_matching_lower_bound = true;
-                        break;
-                    }
-                }
-
-                if !has_matching_lower_bound {
-                    insert_bound_type(
-                        template_result,
-                        param_name_key,
-                        defining_entity,
-                        input_type,
-                        opts,
-                        input_arg_offset,
-                        input_arg_pos,
-                    );
-                }
+        if let Some(existing_lower_bounds) =
+            if let Some(mapped_bounds) = template_result.lower_bounds.get(&param_name_key) {
+                mapped_bounds.get(defining_entity)
             } else {
+                None
+            }
+        {
+            let mut has_matching_lower_bound = false;
+
+            for existing_lower_bound in existing_lower_bounds {
+                let existing_depth = &existing_lower_bound.appearance_depth;
+                let existing_arg_offset = if existing_lower_bound.arg_offset.is_none() {
+                    &input_arg_offset
+                } else {
+                    &existing_lower_bound.arg_offset
+                };
+
+                if existing_depth == &opts.appearance_depth
+                    && &input_arg_offset == existing_arg_offset
+                    && existing_lower_bound.bound_type == input_type
+                    && existing_lower_bound.equality_bound_classlike.is_none()
+                {
+                    has_matching_lower_bound = true;
+                    break;
+                }
+            }
+
+            if !has_matching_lower_bound {
                 insert_bound_type(
                     template_result,
                     param_name_key,
                     defining_entity,
-                    input_type.clone(),
+                    input_type,
                     opts,
                     input_arg_offset,
                     input_arg_pos,
                 );
             }
+        } else {
+            insert_bound_type(
+                template_result,
+                param_name_key,
+                defining_entity,
+                input_type.clone(),
+                opts,
+                input_arg_offset,
+                input_arg_pos,
+            );
         }
     }
 
@@ -1064,9 +1055,9 @@ fn insert_bound_type(
     template_result
         .lower_bounds
         .entry(param_name_key)
-        .or_insert_with(FxHashMap::default)
+        .or_default()
         .entry(*defining_entity)
-        .or_insert_with(Vec::new)
+        .or_default()
         .push(TemplateBound {
             bound_type: input_type.generalize_literals(),
             appearance_depth: opts.appearance_depth,
@@ -1103,10 +1094,10 @@ fn handle_template_param_class_standin<'a>(
     {
         let is_class_ptr = matches!(atomic_type, TAtomic::TGenericClassPtr { .. });
         let mut atomic_type_as = *as_type.clone();
-        if let Some(calling_class) = opts.calling_class {
-            if defining_entity == &GenericParent::ClassLike(calling_class) {
-                return vec![atomic_type.clone()];
-            }
+        if let Some(calling_class) = opts.calling_class
+            && defining_entity == &GenericParent::ClassLike(calling_class)
+        {
+            return vec![atomic_type.clone()];
         }
 
         let mut atomic_types = vec![];
@@ -1313,10 +1304,10 @@ fn handle_template_param_type_standin<'a>(
     } = atomic_type
     {
         let mut atomic_type_as = *as_type.clone();
-        if let Some(calling_class) = opts.calling_class {
-            if defining_entity == &GenericParent::ClassLike(calling_class) {
-                return vec![atomic_type.clone()];
-            }
+        if let Some(calling_class) = opts.calling_class
+            && defining_entity == &GenericParent::ClassLike(calling_class)
+        {
+            return vec![atomic_type.clone()];
         }
 
         let mut atomic_types = vec![];
@@ -1578,28 +1569,27 @@ fn find_matching_atomic_types_for_template(
                 {
                     let classlike_info = codebase.classlike_infos.get(atomic_class_name);
 
-                    if let Some(classlike_info) = classlike_info {
-                        if let Some(extended_params) =
+                    if let Some(classlike_info) = classlike_info
+                        && let Some(extended_params) =
                             classlike_info.template_extended_params.get(base_as_value)
-                        {
-                            *depth += 1;
+                    {
+                        *depth += 1;
 
-                            matching_atomic_types.push(TAtomic::TClassname {
-                                as_type: Box::new(TAtomic::TNamedObject(TNamedObject {
-                                    name: *base_as_value,
-                                    type_params: Some(
-                                        extended_params
-                                            .clone()
-                                            .into_iter()
-                                            .map(|(_, v)| (*v).clone())
-                                            .collect::<Vec<_>>(),
-                                    ),
-                                    is_this: false,
-                                    remapped_params: false,
-                                })),
-                            });
-                            continue;
-                        }
+                        matching_atomic_types.push(TAtomic::TClassname {
+                            as_type: Box::new(TAtomic::TNamedObject(TNamedObject {
+                                name: *base_as_value,
+                                type_params: Some(
+                                    extended_params
+                                        .clone()
+                                        .into_iter()
+                                        .map(|(_, v)| (*v).clone())
+                                        .collect::<Vec<_>>(),
+                                ),
+                                is_this: false,
+                                remapped_params: false,
+                            })),
+                        });
+                        continue;
                     }
                 }
             }
@@ -1698,11 +1688,10 @@ fn find_matching_atomic_types_for_template(
                 if let TAtomic::TTypeAlias {
                     name: base_name, ..
                 } = base_type
+                    && input_name == base_name
                 {
-                    if input_name == base_name {
-                        matching_atomic_types.push(atomic_input_type.clone());
-                        continue;
-                    }
+                    matching_atomic_types.push(atomic_input_type.clone());
+                    continue;
                 }
 
                 matching_atomic_types.extend(find_matching_atomic_types_for_template(
@@ -1738,29 +1727,23 @@ fn find_matching_atomic_types_for_template(
                 if let TAtomic::TNamedObject(TNamedObject {
                     name: enum_name, ..
                 }) = &enum_type
+                    && let Some(classlike_info) = codebase.classlike_infos.get(enum_name)
+                    && let Some(constant_info) = classlike_info.constants.get(member_name)
                 {
-                    if let Some(classlike_info) = codebase.classlike_infos.get(enum_name) {
-                        if let Some(constant_info) = classlike_info.constants.get(member_name) {
-                            let provided_type =
-                                constant_info.provided_type.as_ref().unwrap().get_single();
+                    let provided_type = constant_info.provided_type.as_ref().unwrap().get_single();
 
-                            if let TAtomic::TTypeAlias {
-                                type_params: Some(type_params),
-                                ..
-                            } = provided_type
-                            {
-                                *depth += 1;
-                                matching_atomic_types.push(TAtomic::TTypeAlias {
-                                    name: StrId::ENUM_CLASS_LABEL,
-                                    type_params: Some(vec![
-                                        wrap_atomic(enum_type),
-                                        type_params[1].clone(),
-                                    ]),
-                                    as_type: None,
-                                    newtype: true,
-                                });
-                            }
-                        }
+                    if let TAtomic::TTypeAlias {
+                        type_params: Some(type_params),
+                        ..
+                    } = provided_type
+                    {
+                        *depth += 1;
+                        matching_atomic_types.push(TAtomic::TTypeAlias {
+                            name: StrId::ENUM_CLASS_LABEL,
+                            type_params: Some(vec![wrap_atomic(enum_type), type_params[1].clone()]),
+                            as_type: None,
+                            newtype: true,
+                        });
                     }
                 }
             }
@@ -1891,25 +1874,22 @@ pub fn get_mapped_generic_type_params(
                     defining_entity,
                     ..
                 })) = ets.first()
-                {
-                    if let Some((old_params_offset, (_, defining_classes))) = input_class_storage
+                    && let Some((old_params_offset, (_, defining_classes))) = input_class_storage
                         .template_types
                         .iter()
                         .enumerate()
                         .find(|(_, (n, _))| n == param_name)
-                    {
-                        if defining_classes.iter().any(|(e, _)| defining_entity == e) {
-                            let candidate_param_type_inner = input_type_params
-                                .get(old_params_offset)
-                                .unwrap_or(&(None, get_mixed_any()))
-                                .clone()
-                                .1;
+                    && defining_classes.iter().any(|(e, _)| defining_entity == e)
+                {
+                    let candidate_param_type_inner = input_type_params
+                        .get(old_params_offset)
+                        .unwrap_or(&(None, get_mixed_any()))
+                        .clone()
+                        .1;
 
-                            mapped_input_offset = Some(old_params_offset);
+                    mapped_input_offset = Some(old_params_offset);
 
-                            candidate_param_type = Some(candidate_param_type_inner);
-                        }
-                    }
+                    candidate_param_type = Some(candidate_param_type_inner);
                 }
 
                 let mut candidate_param_type =
@@ -2005,37 +1985,37 @@ pub(crate) fn get_root_template_type(
         return None;
     }
 
-    if let Some(mapped) = lower_bounds.get(param_name) {
-        if let Some(bounds) = mapped.get(defining_entity) {
-            let mapped_type = get_most_specific_type_from_bounds(bounds, codebase);
+    if let Some(mapped) = lower_bounds.get(param_name)
+        && let Some(bounds) = mapped.get(defining_entity)
+    {
+        let mapped_type = get_most_specific_type_from_bounds(bounds, codebase);
 
-            if !mapped_type.is_single() {
-                return Some(mapped_type);
-            }
-
-            let first_template = &mapped_type.get_single();
-
-            if let TAtomic::TGenericParam(TGenericParam {
-                param_name,
-                defining_entity,
-                ..
-            }) = first_template
-            {
-                visited_entities.insert(*defining_entity);
-                return Some(
-                    get_root_template_type(
-                        lower_bounds,
-                        param_name,
-                        defining_entity,
-                        visited_entities,
-                        codebase,
-                    )
-                    .unwrap_or(mapped_type),
-                );
-            }
-
-            return Some(mapped_type.clone());
+        if !mapped_type.is_single() {
+            return Some(mapped_type);
         }
+
+        let first_template = &mapped_type.get_single();
+
+        if let TAtomic::TGenericParam(TGenericParam {
+            param_name,
+            defining_entity,
+            ..
+        }) = first_template
+        {
+            visited_entities.insert(*defining_entity);
+            return Some(
+                get_root_template_type(
+                    lower_bounds,
+                    param_name,
+                    defining_entity,
+                    visited_entities,
+                    codebase,
+                )
+                .unwrap_or(mapped_type),
+            );
+        }
+
+        return Some(mapped_type.clone());
     }
 
     None

--- a/src/code_info/ttype/type_combination.rs
+++ b/src/code_info/ttype/type_combination.rs
@@ -96,22 +96,23 @@ impl TypeCombination {
 
     #[inline]
     pub(crate) fn is_simple(&self) -> bool {
-        if self.value_types.len() == 1 && !self.has_dict {
-            if let (None, None, None, None) = (
+        if self.value_types.len() == 1
+            && !self.has_dict
+            && let (None, None, None, None) = (
                 &self.dict_type_params,
                 &self.vec_type_param,
                 &self.keyset_type_param,
                 &self.awaitable_param,
-            ) {
-                return self.dict_entries.is_empty()
-                    && self.vec_entries.is_empty()
-                    && self.object_type_params.is_empty()
-                    && self.enum_types.is_empty()
-                    && self.enum_value_types.is_empty()
-                    && self.literal_strings.is_empty()
-                    && self.literal_ints.is_empty()
-                    && self.class_string_types.is_empty();
-            }
+            )
+        {
+            return self.dict_entries.is_empty()
+                && self.vec_entries.is_empty()
+                && self.object_type_params.is_empty()
+                && self.enum_types.is_empty()
+                && self.enum_value_types.is_empty()
+                && self.literal_strings.is_empty()
+                && self.literal_ints.is_empty()
+                && self.class_string_types.is_empty();
         }
 
         false

--- a/src/code_info/ttype/type_combiner.rs
+++ b/src/code_info/ttype/type_combiner.rs
@@ -206,11 +206,11 @@ pub fn combine(
             continue;
         }
 
-        if let TAtomic::TNothing = atomic {
-            if combination_value_type_count > 1 || !new_types.is_empty() {
-                has_nothing = true;
-                continue;
-            }
+        if let TAtomic::TNothing = atomic
+            && (combination_value_type_count > 1 || !new_types.is_empty())
+        {
+            has_nothing = true;
+            continue;
         }
 
         new_types.push(atomic);
@@ -376,14 +376,14 @@ fn scrape_type_properties(
     }
 
     // bool|false = bool
-    if let TAtomic::TFalse { .. } | TAtomic::TTrue { .. } = atomic {
-        if combination.value_types.contains_key("bool") {
-            return;
-        }
+    if let TAtomic::TFalse | TAtomic::TTrue = atomic
+        && combination.value_types.contains_key("bool")
+    {
+        return;
     }
 
     // false|bool = bool
-    if let TAtomic::TBool { .. } = atomic {
+    if let TAtomic::TBool = atomic {
         combination.value_types.remove("false");
         combination.value_types.remove("true");
     }
@@ -553,10 +553,10 @@ fn scrape_type_properties(
 
         if let Some(shape_name) = &shape_name {
             if let Some(ref mut existing_name) = combination.dict_alias_name {
-                if let Some(existing_name_inner) = existing_name {
-                    if existing_name_inner != shape_name {
-                        *existing_name = None;
-                    }
+                if let Some(existing_name_inner) = existing_name
+                    && existing_name_inner != shape_name
+                {
+                    *existing_name = None;
                 }
             } else {
                 combination.dict_alias_name = Some(Some(*shape_name));
@@ -867,16 +867,14 @@ fn scrape_type_properties(
             } else {
                 existing_enum_values.insert(member_name, (as_type, underlying_type));
             }
-        } else {
-            if let Some(enum_storage) = codebase.classlike_infos.get(&enum_name) {
-                combination.enum_value_types.insert(
-                    enum_name,
-                    (
-                        enum_storage.constants.len(),
-                        FxHashMap::from_iter([(member_name, (as_type, underlying_type))]),
-                    ),
-                );
-            }
+        } else if let Some(enum_storage) = codebase.classlike_infos.get(&enum_name) {
+            combination.enum_value_types.insert(
+                enum_name,
+                (
+                    enum_storage.constants.len(),
+                    FxHashMap::from_iter([(member_name, (as_type, underlying_type))]),
+                ),
+            );
         }
 
         if let Some((as_type, underlying_type)) = matched_len_constraint {
@@ -1036,7 +1034,7 @@ fn scrape_type_properties(
         return;
     }
 
-    if let TAtomic::TScalar { .. } = atomic {
+    if let TAtomic::TScalar = atomic {
         combination.literal_strings = FxHashSet::default();
         combination.literal_ints = FxHashSet::default();
         combination.value_types.retain(|k, _| {
@@ -1069,7 +1067,7 @@ fn scrape_type_properties(
         return;
     }
 
-    if let TAtomic::TNum { .. } = atomic {
+    if let TAtomic::TNum = atomic {
         if combination.value_types.contains_key("scalar") {
             return;
         }
@@ -1083,28 +1081,25 @@ fn scrape_type_properties(
         return;
     }
 
-    if let TAtomic::TString { .. }
+    if let TAtomic::TString
     | TAtomic::TLiteralString { .. }
     | TAtomic::TStringWithFlags(..)
     | TAtomic::TInt
     | TAtomic::TLiteralInt { .. } = atomic
+        && (combination.value_types.contains_key("arraykey")
+            || combination.value_types.contains_key("scalar"))
     {
-        if combination.value_types.contains_key("arraykey")
-            || combination.value_types.contains_key("scalar")
-        {
-            return;
-        }
+        return;
     }
 
-    if let TAtomic::TFloat | TAtomic::TInt | TAtomic::TLiteralInt { .. } = atomic {
-        if combination.value_types.contains_key("num")
-            || combination.value_types.contains_key("scalar")
-        {
-            return;
-        }
+    if let TAtomic::TFloat | TAtomic::TInt | TAtomic::TLiteralInt { .. } = atomic
+        && (combination.value_types.contains_key("num")
+            || combination.value_types.contains_key("scalar"))
+    {
+        return;
     }
 
-    if let TAtomic::TString { .. } = atomic {
+    if let TAtomic::TString = atomic {
         combination.literal_strings = FxHashSet::default();
         combination.value_types.insert(atomic.get_key(), atomic);
         return;
@@ -1171,7 +1166,7 @@ fn scrape_type_properties(
             match existing_string_type {
                 TAtomic::TString => return,
                 TAtomic::TStringWithFlags(is_truthy, is_nonempty, is_nonspecific_literal) => {
-                    if value == "" {
+                    if value.is_empty() {
                         *is_truthy = false;
                         *is_nonempty = false;
                     } else if value == "0" {
@@ -1194,8 +1189,8 @@ fn scrape_type_properties(
                     combination
                         .literal_strings
                         .iter()
-                        .all(|s| s != "" && s != "0"),
-                    combination.literal_strings.iter().all(|s| s != ""),
+                        .all(|s| !s.is_empty() && s != "0"),
+                    combination.literal_strings.iter().all(|s| !s.is_empty()),
                     true,
                 ),
             );

--- a/src/code_info/ttype/type_expander.rs
+++ b/src/code_info/ttype/type_expander.rs
@@ -207,8 +207,6 @@ fn expand_atomic(
                 );
             }
         }
-
-        return;
     } else if let TAtomic::TKeyset { type_param, .. } = return_type_part {
         expand_union(
             codebase,
@@ -219,8 +217,6 @@ fn expand_atomic(
             data_flow_graph,
             cost,
         );
-
-        return;
     } else if let TAtomic::TAwaitable { value } = return_type_part {
         expand_union(
             codebase,
@@ -231,8 +227,6 @@ fn expand_atomic(
             data_flow_graph,
             cost,
         );
-
-        return;
     } else if let TAtomic::TNamedObject(TNamedObject {
         name,
         type_params,
@@ -254,21 +248,18 @@ fn expand_atomic(
             if options.function_is_final {
                 *is_this = false;
             }
-        } else if *is_this {
-            if let StaticClassType::Object(obj) = options.static_class_type {
-                if let TAtomic::TNamedObject(TNamedObject {
-                    name: new_this_name,
-                    ..
-                }) = obj
-                {
-                    if codebase.class_extends_or_implements(new_this_name, name) {
-                        *skip_key = true;
-                        new_return_type_parts.push(obj.clone());
-                        return;
-                    }
-                }
-            };
-        }
+        } else if *is_this
+            && let StaticClassType::Object(obj) = options.static_class_type
+            && let TAtomic::TNamedObject(TNamedObject {
+                name: new_this_name,
+                ..
+            }) = obj
+            && codebase.class_extends_or_implements(new_this_name, name)
+        {
+            *skip_key = true;
+            new_return_type_parts.push(obj.clone());
+            return;
+        };
 
         if let Some(type_params) = type_params {
             for param_type in type_params {
@@ -283,8 +274,6 @@ fn expand_atomic(
                 );
             }
         }
-
-        return;
     } else if let TAtomic::TClosure(closure) = return_type_part {
         if let Some(ref mut return_type) = closure.return_type {
             expand_union(
@@ -319,10 +308,8 @@ fn expand_atomic(
     {
         if let Some(where_constraints) = options.where_constraints {
             for (_, constraint_type) in where_constraints.iter().filter(|(k, _)| k == param_name) {
-                *as_type = Box::new(
-                    intersect_union_types_simple(as_type, constraint_type, codebase)
-                        .unwrap_or(get_nothing()),
-                );
+                **as_type = intersect_union_types_simple(as_type, constraint_type, codebase)
+                    .unwrap_or(get_nothing());
             }
         }
         expand_union(
@@ -334,8 +321,6 @@ fn expand_atomic(
             data_flow_graph,
             cost,
         );
-
-        return;
     } else if let TAtomic::TClassname { as_type, .. }
     | TAtomic::TTypename { as_type, .. }
     | TAtomic::TClassPtr { as_type } = return_type_part
@@ -355,10 +340,8 @@ fn expand_atomic(
         );
 
         if !atomic_return_type_parts.is_empty() {
-            *as_type = Box::new(atomic_return_type_parts.remove(0));
+            **as_type = atomic_return_type_parts.remove(0);
         }
-
-        return;
     } else if let &mut TAtomic::TEnumLiteralCase {
         ref enum_name,
         ref mut as_type,
@@ -401,8 +384,6 @@ fn expand_atomic(
                 *underlying_type = Some(Arc::new(underlying_type_union.get_single_owned()));
             }
         }
-
-        return;
     } else if let &mut TAtomic::TMemberReference {
         ref classlike_name,
         ref member_name,
@@ -453,8 +434,6 @@ fn expand_atomic(
                 new_return_type_parts.push(TAtomic::TMixed);
             }
         }
-
-        return;
     } else if let TAtomic::TTypeAlias {
         name: type_name,
         type_params,
@@ -523,61 +502,60 @@ fn expand_atomic(
                 .types
                 .into_iter()
                 .map(|mut v| {
-                    if type_params.is_none() {
-                        if let TAtomic::TDict(TDict {
+                    if type_params.is_none()
+                        && let TAtomic::TDict(TDict {
                             is_shape: true,
                             ref mut shape_name,
                             ..
                         }) = v
+                    {
+                        if let (Some(shape_field_taints), Some(interner)) =
+                            (&type_definition.shape_field_taints, interner)
                         {
-                            if let (Some(shape_field_taints), Some(interner)) =
-                                (&type_definition.shape_field_taints, interner)
-                            {
-                                let shape_node =
-                                    DataFlowNode::get_for_type(type_name, type_definition.location);
+                            let shape_node =
+                                DataFlowNode::get_for_type(type_name, type_definition.location);
 
-                                for (field_name, taints) in shape_field_taints {
-                                    let field_name_str = field_name.to_string(Some(interner));
+                            for (field_name, taints) in shape_field_taints {
+                                let field_name_str = field_name.to_string(Some(interner));
 
-                                    let field_node = DataFlowNode {
-                                        id: DataFlowNodeId::ShapeFieldAccess(
-                                            *type_name,
-                                            field_name_str,
-                                        ),
-                                        kind: DataFlowNodeKind::TaintSource {
-                                            pos: Some(taints.0),
-                                            types: taints.1.clone(),
+                                let field_node = DataFlowNode {
+                                    id: DataFlowNodeId::ShapeFieldAccess(
+                                        *type_name,
+                                        field_name_str,
+                                    ),
+                                    kind: DataFlowNodeKind::TaintSource {
+                                        pos: Some(taints.0),
+                                        types: taints.1.clone(),
+                                    },
+                                };
+
+                                data_flow_graph.add_path(
+                                    &field_node.id,
+                                    &shape_node.id,
+                                    PathKind::ArrayAssignment(
+                                        ArrayDataKind::ArrayValue,
+                                        match field_name {
+                                            DictKey::Int(i) => i.to_string(),
+                                            DictKey::String(k) => k.clone(),
+                                            DictKey::Enum(_, _) => todo!(),
                                         },
-                                    };
+                                    ),
+                                    vec![],
+                                    vec![],
+                                );
 
-                                    data_flow_graph.add_path(
-                                        &field_node.id,
-                                        &shape_node.id,
-                                        PathKind::ArrayAssignment(
-                                            ArrayDataKind::ArrayValue,
-                                            match field_name {
-                                                DictKey::Int(i) => i.to_string(),
-                                                DictKey::String(k) => k.clone(),
-                                                DictKey::Enum(_, _) => todo!(),
-                                            },
-                                        ),
-                                        vec![],
-                                        vec![],
-                                    );
-
-                                    data_flow_graph.add_node(field_node);
-                                }
-
-                                extra_data_flow_nodes.push(shape_node.clone());
-
-                                data_flow_graph.add_node(shape_node);
+                                data_flow_graph.add_node(field_node);
                             }
 
-                            if !options.force_alias_expansion {
-                                *shape_name = Some((*type_name, None));
-                            }
-                        };
-                    }
+                            extra_data_flow_nodes.push(shape_node.clone());
+
+                            data_flow_graph.add_node(shape_node);
+                        }
+
+                        if !options.force_alias_expansion {
+                            *shape_name = Some((*type_name, None));
+                        }
+                    };
                     v
                 })
                 .collect::<Vec<_>>();
@@ -638,8 +616,6 @@ fn expand_atomic(
                 );
             }
         }
-
-        return;
     } else if let TAtomic::TClassTypeConstant {
         class_type,
         member_name,
@@ -661,7 +637,7 @@ fn expand_atomic(
         );
 
         if !atomic_return_type_parts.is_empty() {
-            *class_type = Box::new(atomic_return_type_parts.remove(0));
+            **class_type = atomic_return_type_parts.remove(0);
         }
 
         // Collect class names to check - either a single class or all classes in an intersection
@@ -734,19 +710,19 @@ fn expand_atomic(
         let mut found_any = false;
 
         for check_class in &classes_to_check {
-            if let Some(classlike_storage) = codebase.classlike_infos.get(*check_class) {
-                if let Some(type_const) = classlike_storage.type_constants.get(member_name) {
-                    found_any = true;
-                    match type_const {
-                        ClassConstantType::Concrete(type_) => {
-                            resolved_types.push(type_.clone());
-                        }
-                        ClassConstantType::Abstract(Some(type_)) => {
-                            resolved_types.push(type_.clone());
-                        }
-                        ClassConstantType::Abstract(None) => {
-                            // Abstract with no constraint - don't add anything specific
-                        }
+            if let Some(classlike_storage) = codebase.classlike_infos.get(*check_class)
+                && let Some(type_const) = classlike_storage.type_constants.get(member_name)
+            {
+                found_any = true;
+                match type_const {
+                    ClassConstantType::Concrete(type_) => {
+                        resolved_types.push(type_.clone());
+                    }
+                    ClassConstantType::Abstract(Some(type_)) => {
+                        resolved_types.push(type_.clone());
+                    }
+                    ClassConstantType::Abstract(None) => {
+                        // Abstract with no constraint - don't add anything specific
                     }
                 }
             }
@@ -822,12 +798,10 @@ fn expand_atomic(
                         ref mut shape_name,
                         ..
                     }) = v
+                        && !options.force_alias_expansion
+                        && let Some(class_name) = first_class_name
                     {
-                        if !options.force_alias_expansion {
-                            if let Some(class_name) = first_class_name {
-                                *shape_name = Some((*class_name, Some(*member_name)));
-                            }
-                        }
+                        *shape_name = Some((*class_name, Some(*member_name)));
                     };
                     v
                 }));
@@ -843,7 +817,7 @@ fn expand_atomic(
                     cost,
                 );
 
-                *as_type = Box::new(resolved_type);
+                **as_type = resolved_type;
             }
         }
     } else if let TAtomic::TClosureAlias { id, .. } = &return_type_part {
@@ -852,7 +826,6 @@ fn expand_atomic(
         {
             *skip_key = true;
             new_return_type_parts.push(value);
-            return;
         }
     } else if let TAtomic::TObjectIntersection { types } = return_type_part {
         // Expand each type within the intersection
@@ -876,7 +849,6 @@ fn expand_atomic(
                 *intersection_type = inner_new_parts.remove(0);
             }
         }
-        return;
     }
 }
 

--- a/src/code_info_builder/classlike_scanner.rs
+++ b/src/code_info_builder/classlike_scanner.rs
@@ -172,42 +172,42 @@ pub(crate) fn scan(
 
             codebase.symbols.add_class_name(class_name);
 
-            if let Some(parent_class) = classlike_node.extends.first() {
-                if let oxidized::ast::Hint_::Happly(name, params) = &*parent_class.1 {
-                    signature_end = name.0.end_offset() as u32;
+            if let Some(parent_class) = classlike_node.extends.first()
+                && let oxidized::ast::Hint_::Happly(name, params) = &*parent_class.1
+            {
+                signature_end = name.0.end_offset() as u32;
 
-                    let parent_name = *resolved_names.get(&(name.0.start_offset() as u32)).unwrap();
+                let parent_name = *resolved_names.get(&(name.0.start_offset() as u32)).unwrap();
 
-                    if !params.is_empty() {
-                        signature_end = params.last().unwrap().0.end_offset() as u32;
-                    }
-
-                    storage.direct_parent_class = Some(parent_name);
-                    storage.all_parent_classes.push(parent_name);
-
-                    storage.template_extended_offsets.insert(
-                        parent_name,
-                        params
-                            .iter()
-                            .map(|param| {
-                                Arc::new(
-                                    get_type_from_hint(
-                                        &param.1,
-                                        Some(*class_name),
-                                        &TypeResolutionContext {
-                                            template_type_map: storage.template_types.clone(),
-                                            template_supers: vec![],
-                                        },
-                                        resolved_names,
-                                        file_source.file_path,
-                                        param.0.start_offset() as u32,
-                                    )
-                                    .unwrap(),
-                                )
-                            })
-                            .collect(),
-                    );
+                if !params.is_empty() {
+                    signature_end = params.last().unwrap().0.end_offset() as u32;
                 }
+
+                storage.direct_parent_class = Some(parent_name);
+                storage.all_parent_classes.push(parent_name);
+
+                storage.template_extended_offsets.insert(
+                    parent_name,
+                    params
+                        .iter()
+                        .map(|param| {
+                            Arc::new(
+                                get_type_from_hint(
+                                    &param.1,
+                                    Some(*class_name),
+                                    &TypeResolutionContext {
+                                        template_type_map: storage.template_types.clone(),
+                                        template_supers: vec![],
+                                    },
+                                    resolved_names,
+                                    file_source.file_path,
+                                    param.0.start_offset() as u32,
+                                )
+                                .unwrap(),
+                            )
+                        })
+                        .collect(),
+                );
             }
 
             for extended_interface in &classlike_node.implements {
@@ -621,12 +621,11 @@ pub(crate) fn scan(
                 let attribute_param_type =
                     simple_type_inferer::infer(attribute_param_expr, resolved_names, false);
 
-                if let Some(attribute_param_type) = attribute_param_type {
-                    if let TAtomic::TLiteralClassname { name: value }
+                if let Some(attribute_param_type) = attribute_param_type
+                    && let TAtomic::TLiteralClassname { name: value }
                     | TAtomic::TLiteralClassPtr { name: value } = attribute_param_type
-                    {
-                        child_classlikes.insert(value);
-                    }
+                {
+                    child_classlikes.insert(value);
                 }
             }
 
@@ -1017,7 +1016,7 @@ fn visit_class_const_declaration(
         unresolved_value: None,
         is_abstract: matches!(const_node.kind, ClassConstKind::CCAbstract(..)),
         allow_non_exclusive_enum_values: false,
-        suppressed_issues: suppressed_issues,
+        suppressed_issues,
         defining_class: *class_name,
     };
 
@@ -1167,14 +1166,13 @@ fn visit_property_declaration(
 
     if !classlike_storage.template_readonly.is_empty()
         && matches!(property_node.visibility, ast_defs::Visibility::Public)
+        && let Some(property_type) = &property_type
     {
-        if let Some(property_type) = &property_type {
-            let template_types = property_type.get_template_types();
+        let template_types = property_type.get_template_types();
 
-            for template_type in template_types {
-                if let TAtomic::TGenericParam(TGenericParam { param_name, .. }) = template_type {
-                    classlike_storage.template_readonly.remove(param_name);
-                }
+        for template_type in template_types {
+            if let TAtomic::TGenericParam(TGenericParam { param_name, .. }) = template_type {
+                classlike_storage.template_readonly.remove(param_name);
             }
         }
     }

--- a/src/code_info_builder/functionlike_scanner.rs
+++ b/src/code_info_builder/functionlike_scanner.rs
@@ -277,14 +277,13 @@ pub(crate) fn get_functionlike(
         )
         .unwrap();
 
-        if let TAtomic::TGenericParam(TGenericParam { param_name, .. }) = where_first {
-            if let ast_defs::ConstraintKind::ConstraintEq | ast_defs::ConstraintKind::ConstraintAs =
+        if let TAtomic::TGenericParam(TGenericParam { param_name, .. }) = where_first
+            && let ast_defs::ConstraintKind::ConstraintEq | ast_defs::ConstraintKind::ConstraintAs =
                 where_hint.1
-            {
-                functionlike_info
-                    .where_constraints
-                    .push((param_name, where_second));
-            }
+        {
+            functionlike_info
+                .where_constraints
+                .push((param_name, where_second));
         }
     }
 
@@ -382,11 +381,11 @@ pub(crate) fn get_functionlike(
                 functionlike_info.effects = FnEffect::Some(EFFECT_IMPURE_DB);
             }
             StrId::HAKANA_BANNED_FUNCTION => {
-                if let Some(attribute_param_expr) = user_attribute.params.first() {
-                    if let aast::Expr_::String(str) = &attribute_param_expr.2 {
-                        functionlike_info.banned_function_message =
-                            Some(interner.intern(str.to_string()));
-                    }
+                if let Some(attribute_param_expr) = user_attribute.params.first()
+                    && let aast::Expr_::String(str) = &attribute_param_expr.2
+                {
+                    functionlike_info.banned_function_message =
+                        Some(interner.intern(str.to_string()));
                 }
             }
             StrId::HAKANA_SECURITY_ANALYSIS_IGNORE_PATH_IF_TRUE => {
@@ -462,18 +461,17 @@ pub(crate) fn get_functionlike(
     {
         let stmt = &stmts[0];
 
-        if let aast::Stmt_::Return(expr) = &stmt.1 {
-            if let Some(expr) = expr.as_ref() {
-                if let Some(function_id) = get_async_version(
-                    expr,
-                    resolved_names,
-                    &functionlike_info.params,
-                    interner,
-                    this_name,
-                ) {
-                    functionlike_info.async_version = Some(function_id);
-                }
-            }
+        if let aast::Stmt_::Return(expr) = &stmt.1
+            && let Some(expr) = expr.as_ref()
+            && let Some(function_id) = get_async_version(
+                expr,
+                resolved_names,
+                &functionlike_info.params,
+                interner,
+                this_name,
+            )
+        {
+            functionlike_info.async_version = Some(function_id);
         }
     }
 
@@ -520,47 +518,40 @@ fn get_async_version(
 ) -> Option<FunctionLikeIdentifier> {
     match &expr.2 {
         aast::Expr_::Call(call) => {
-            if let aast::Expr_::Id(boxed_id) = &call.func.2 {
-                if let Some(fn_id) = resolved_names.get(&(boxed_id.0.start_offset() as u32)) {
-                    if fn_id == &StrId::ASIO_JOIN && call.args.len() == 1 {
-                        let first_join_expr = &call.args[0].to_expr_ref().2;
+            if let aast::Expr_::Id(boxed_id) = &call.func.2
+                && let Some(fn_id) = resolved_names.get(&(boxed_id.0.start_offset() as u32))
+                && fn_id == &StrId::ASIO_JOIN
+                && call.args.len() == 1
+            {
+                let first_join_expr = &call.args[0].to_expr_ref().2;
 
-                        if let aast::Expr_::Call(call) = &first_join_expr {
-                            if !is_async_call_is_same_as_sync(&call.args, params, interner) {
-                                return None;
-                            }
-
-                            return get_name_from_expr(
-                                resolved_names,
-                                interner,
-                                &call.func.2,
-                                current_class,
-                            );
-                        }
+                if let aast::Expr_::Call(call) = &first_join_expr {
+                    if !is_async_call_is_same_as_sync(&call.args, params, interner) {
+                        return None;
                     }
+
+                    return get_name_from_expr(
+                        resolved_names,
+                        interner,
+                        &call.func.2,
+                        current_class,
+                    );
                 }
             }
         }
         aast::Expr_::Pipe(boxed) => {
-            if let aast::Expr_::Call(call) = &boxed.2.2 {
-                if let aast::Expr_::Id(boxed_id) = &call.func.2 {
-                    if let Some(fn_id) = resolved_names.get(&(boxed_id.0.start_offset() as u32)) {
-                        if fn_id == &StrId::ASIO_JOIN && call.args.len() == 1 {
-                            if let aast::Expr_::Call(call) = &boxed.1.2 {
-                                if !is_async_call_is_same_as_sync(&call.args, params, interner) {
-                                    return None;
-                                }
-
-                                return get_name_from_expr(
-                                    resolved_names,
-                                    interner,
-                                    &call.func.2,
-                                    current_class,
-                                );
-                            }
-                        }
-                    }
+            if let aast::Expr_::Call(call) = &boxed.2.2
+                && let aast::Expr_::Id(boxed_id) = &call.func.2
+                && let Some(fn_id) = resolved_names.get(&(boxed_id.0.start_offset() as u32))
+                && fn_id == &StrId::ASIO_JOIN
+                && call.args.len() == 1
+                && let aast::Expr_::Call(call) = &boxed.1.2
+            {
+                if !is_async_call_is_same_as_sync(&call.args, params, interner) {
+                    return None;
                 }
+
+                return get_name_from_expr(resolved_names, interner, &call.func.2, current_class);
             }
         }
         _ => {}
@@ -586,14 +577,13 @@ fn get_name_from_expr(
 
             match &class_id.2 {
                 aast::ClassId_::CIexpr(lhs_expr) => {
-                    if let aast::Expr_::Id(id) = &lhs_expr.2 {
-                        if let Some(class_name) = resolved_names.get(&(id.0.start_offset() as u32))
-                        {
-                            return Some(FunctionLikeIdentifier::Method(
-                                *class_name,
-                                interner.intern(rhs_expr.1.clone()),
-                            ));
-                        }
+                    if let aast::Expr_::Id(id) = &lhs_expr.2
+                        && let Some(class_name) = resolved_names.get(&(id.0.start_offset() as u32))
+                    {
+                        return Some(FunctionLikeIdentifier::Method(
+                            *class_name,
+                            interner.intern(rhs_expr.1.clone()),
+                        ));
                     }
                 }
                 aast::ClassId_::CIreified(id) => {
@@ -625,17 +615,15 @@ fn get_name_from_expr(
             let (obj_expr, member_expr, _nullflavor, _prop_or_method) = &**boxed;
 
             // Check if this is $this->method_name()
-            if let aast::Expr_::Lvar(var_id) = &obj_expr.2 {
-                if var_id.1.1 == "$this" {
-                    if let aast::Expr_::Id(method_id) = &member_expr.2 {
-                        if let Some(class_name) = current_class {
-                            return Some(FunctionLikeIdentifier::Method(
-                                class_name,
-                                interner.intern(method_id.1.clone()),
-                            ));
-                        }
-                    }
-                }
+            if let aast::Expr_::Lvar(var_id) = &obj_expr.2
+                && var_id.1.1 == "$this"
+                && let aast::Expr_::Id(method_id) = &member_expr.2
+                && let Some(class_name) = current_class
+            {
+                return Some(FunctionLikeIdentifier::Method(
+                    class_name,
+                    interner.intern(method_id.1.clone()),
+                ));
             }
         }
         _ => (),

--- a/src/code_info_builder/lib.rs
+++ b/src/code_info_builder/lib.rs
@@ -209,7 +209,7 @@ impl<'ast> Visitor<'ast> for Scanner<'_> {
                 let transformed_type = transform_shape_type_constant(
                     full_type,
                     &shape_type_constant.map,
-                    &self.codebase,
+                    self.codebase,
                 );
 
                 if let Some(type_storage) = self
@@ -460,32 +460,31 @@ impl<'ast> Visitor<'ast> for Scanner<'_> {
             let attribute_param_type =
                 simple_type_inferer::infer(attribute_param_expr, self.resolved_names, false);
 
-            if let Some(atomic_param_attribute) = attribute_param_type {
-                if let TAtomic::TDict(TDict {
+            if let Some(atomic_param_attribute) = attribute_param_type
+                && let TAtomic::TDict(TDict {
                     known_items: Some(attribute_known_items),
                     ..
                 }) = atomic_param_attribute
-                {
-                    for (name, (_, item_type)) in attribute_known_items {
-                        let mut source_types = vec![];
+            {
+                for (name, (_, item_type)) in attribute_known_items {
+                    let mut source_types = vec![];
 
-                        if let Some(str) = item_type.get_single_literal_string_value() {
-                            if let Some(source_type) = string_to_source_types(str) {
-                                source_types.push(source_type);
-                            }
-                        }
-
-                        shape_sources.insert(
-                            name.clone(),
-                            (
-                                HPos::new(
-                                    shape_source_attribute.name.pos(),
-                                    self.file_source.file_path,
-                                ),
-                                source_types,
-                            ),
-                        );
+                    if let Some(str) = item_type.get_single_literal_string_value()
+                        && let Some(source_type) = string_to_source_types(str)
+                    {
+                        source_types.push(source_type);
                     }
+
+                    shape_sources.insert(
+                        name.clone(),
+                        (
+                            HPos::new(
+                                shape_source_attribute.name.pos(),
+                                self.file_source.file_path,
+                            ),
+                            source_types,
+                        ),
+                    );
                 }
             }
 
@@ -521,18 +520,17 @@ impl<'ast> Visitor<'ast> for Scanner<'_> {
                 let attribute_param_type =
                     simple_type_inferer::infer(attribute_param_expr, self.resolved_names, false);
 
-                if let Some(atomic_param_attribute) = attribute_param_type {
-                    if let TAtomic::TDict(TDict {
+                if let Some(atomic_param_attribute) = attribute_param_type
+                    && let TAtomic::TDict(TDict {
                         known_items: Some(attribute_known_items),
                         ..
                     }) = atomic_param_attribute
-                    {
-                        for (name, (_, item_type)) in attribute_known_items {
-                            if let (DictKey::String(key_str), Some(value)) =
-                                (name, item_type.get_single_literal_string_value())
-                            {
-                                type_map.insert(key_str, value);
-                            }
+                {
+                    for (name, (_, item_type)) in attribute_known_items {
+                        if let (DictKey::String(key_str), Some(value)) =
+                            (name, item_type.get_single_literal_string_value())
+                        {
+                            type_map.insert(key_str, value);
                         }
                     }
                 }
@@ -759,12 +757,11 @@ impl<'ast> Visitor<'ast> for Scanner<'_> {
                 }
             }
             aast::Expr_::Call(boxed) => {
-                if let aast::Expr_::Id(boxed_id) = &boxed.func.2 {
-                    if let Some(&StrId::ASIO_JOIN) =
+                if let aast::Expr_::Id(boxed_id) = &boxed.func.2
+                    && let Some(&StrId::ASIO_JOIN) =
                         self.resolved_names.get(&(boxed_id.0.start_offset() as u32))
-                    {
-                        c.has_asio_join = true;
-                    }
+                {
+                    c.has_asio_join = true;
                 }
             }
             _ => (),
@@ -907,10 +904,10 @@ impl<'a> Scanner<'a> {
 
         functionlike_storage.type_resolution_context = Some(type_resolution_context);
 
-        if !self.user_defined {
-            if let Some(name) = name {
-                fix_function_return_type(name, &mut functionlike_storage);
-            }
+        if !self.user_defined
+            && let Some(name) = name
+        {
+            fix_function_return_type(name, &mut functionlike_storage);
         }
 
         functionlike_storage
@@ -1000,7 +997,7 @@ fn transform_shape_type_constant(
             for (key, (_, value_type)) in items {
                 // For each value in the dict, we need to resolve it
                 let transformed_value_type = if value_type.types.len() == 1 {
-                    let atomic = value_type.types.iter().next().unwrap();
+                    let atomic = value_type.types.first().unwrap();
 
                     // If it's a TMemberReference (enum constant), resolve it
                     if let TAtomic::TMemberReference {

--- a/src/code_info_builder/pcre_parser.rs
+++ b/src/code_info_builder/pcre_parser.rs
@@ -108,14 +108,15 @@ pub fn parse_capture_groups(pattern: &str) -> Vec<CaptureGroup> {
 
                     if next == 'P' {
                         // Python-style named group (?P<name>...)
-                        if i + 3 < len && chars[i + 3] == '<' {
-                            if let Some(name) = extract_name(&chars, i + 4, '>') {
-                                groups.push(CaptureGroup {
-                                    index: group_index,
-                                    name: Some(name),
-                                });
-                                group_index += 1;
-                            }
+                        if i + 3 < len
+                            && chars[i + 3] == '<'
+                            && let Some(name) = extract_name(&chars, i + 4, '>')
+                        {
+                            groups.push(CaptureGroup {
+                                index: group_index,
+                                name: Some(name),
+                            });
+                            group_index += 1;
                         }
                         i += 1;
                         continue;

--- a/src/code_info_builder/simple_type_inferer.rs
+++ b/src/code_info_builder/simple_type_inferer.rs
@@ -191,12 +191,12 @@ pub fn infer(
             }
         }
         aast::Expr_::Id(name) => {
-            if let Some(name_string) = resolved_names.get(&(name.0.start_offset() as u32)) {
-                if *name_string == StrId::LIB_MATH_INT32_MAX {
-                    return Some(TAtomic::TLiteralInt {
-                        value: i32::MAX as i64,
-                    });
-                }
+            if let Some(name_string) = resolved_names.get(&(name.0.start_offset() as u32))
+                && *name_string == StrId::LIB_MATH_INT32_MAX
+            {
+                return Some(TAtomic::TLiteralInt {
+                    value: i32::MAX as i64,
+                });
             }
 
             None

--- a/src/code_info_builder/typehint_resolver.rs
+++ b/src/code_info_builder/typehint_resolver.rs
@@ -171,15 +171,13 @@ fn get_classname_type_from_hint(
                     as_type: Box::new(as_type.get_single_owned()),
                 }
             }
+        } else if is_class_ptr {
+            TAtomic::TClassPtr {
+                as_type: Box::new(as_type),
+            }
         } else {
-            if is_class_ptr {
-                TAtomic::TClassPtr {
-                    as_type: Box::new(as_type),
-                }
-            } else {
-                TAtomic::TClassname {
-                    as_type: Box::new(as_type),
-                }
+            TAtomic::TClassname {
+                as_type: Box::new(as_type),
             }
         }
     } else {
@@ -534,14 +532,13 @@ pub fn get_type_from_hint(
                 .strip_prefix('\\')
                 .unwrap_or(applied_type.as_str());
 
-            if let Some(resolved_name) = resolved_names.get(&(id.0.start_offset() as u32)) {
-                if let Some((_, type_name)) = type_context
+            if let Some(resolved_name) = resolved_names.get(&(id.0.start_offset() as u32))
+                && let Some((_, type_name)) = type_context
                     .template_supers
                     .iter()
                     .find(|(id, _)| id == resolved_name)
-                {
-                    return Some(type_name.clone());
-                }
+            {
+                return Some(type_name.clone());
             }
 
             match applied_type_str {

--- a/src/executable_code_finder/lib.rs
+++ b/src/executable_code_finder/lib.rs
@@ -176,28 +176,23 @@ impl<'ast> Visitor<'ast> for Scanner {
                         match &ns_def {
                             Def::Fun(boxed) => {
                                 self.visit_block(c, &boxed.fun.body.fb_ast)?;
-                                ()
                             }
                             Def::Class(boxed) => {
                                 for method in &boxed.methods {
                                     self.visit_block(c, &method.body.fb_ast)?;
                                 }
-                                ()
                             }
                             _ => (),
                         }
                     }
-                    ()
                 }
                 Def::Fun(boxed) => {
                     self.visit_block(c, &boxed.fun.body.fb_ast)?;
-                    ()
                 }
                 Def::Class(boxed) => {
                     for method in &boxed.methods {
                         self.visit_block(c, &method.body.fb_ast)?;
                     }
-                    ()
                 }
                 _ => (),
             }
@@ -241,7 +236,7 @@ impl<'ast> Visitor<'ast> for Scanner {
                 boxed.2.recurse(c, self)
             }
             Stmt_::Block(boxed) => boxed.recurse(c, self),
-            Stmt_::Expr(boxed) => self.visit_expr(c, &boxed),
+            Stmt_::Expr(boxed) => self.visit_expr(c, boxed),
             Stmt_::Try(boxed) => self.visit_block(c, &boxed.0),
             Stmt_::Concurrent(boxed) => {
                 push_start(&p.0, c); // The line where concurrent block is declared is coverable
@@ -255,7 +250,7 @@ impl<'ast> Visitor<'ast> for Scanner {
                 }
                 match **boxed {
                     None => Ok(()),
-                    Some(ref expr) => self.visit_expr(c, &expr),
+                    Some(ref expr) => self.visit_expr(c, expr),
                 }
             }
             _ => {
@@ -390,7 +385,7 @@ fn push_end(p: &Pos, res: &mut BTreeSet<u64>) {
 fn is_single_line(p: &Pos) -> bool {
     let start = p.to_raw_span().start.line();
     let end = p.to_raw_span().end.line();
-    return start == end;
+    start == end
 }
 
 // Given an ordered set of ints representing individual executable lines,
@@ -402,7 +397,7 @@ fn to_ranges(lines: BTreeSet<u64>) -> Vec<String> {
     let mut i = 0;
     while let Some(start) = sorted.get(i) {
         i += 1;
-        out.push(make_range(&sorted, &start, &mut i));
+        out.push(make_range(&sorted, start, &mut i));
     }
     out
 }

--- a/src/language_server/lib.rs
+++ b/src/language_server/lib.rs
@@ -156,10 +156,11 @@ impl LanguageServer for Backend {
                     }
                     _ => {}
                 }
-            } else if Path::new(&file_path).extension().is_none() && !file_path.contains("/.git/") {
-                if let FileChangeType::DELETED = change_type {
-                    new_file_statuses.insert(file_path, FileStatus::DeletedDir);
-                }
+            } else if Path::new(&file_path).extension().is_none()
+                && !file_path.contains("/.git/")
+                && let FileChangeType::DELETED = change_type
+            {
+                new_file_statuses.insert(file_path, FileStatus::DeletedDir);
             }
         }
 
@@ -220,38 +221,35 @@ impl LanguageServer for Backend {
                     let file_path_obj = hakana_code_info::code_location::FilePath(file_path_id);
 
                     // Check member definition locations (methods, properties, constants)
-                    if let Some(analysis_result) = analysis_result_guard.as_ref() {
-                        if let Some(definition_locations) =
+                    if let Some(analysis_result) = analysis_result_guard.as_ref()
+                        && let Some(definition_locations) =
                             analysis_result.definition_locations.get(&file_path_obj)
+                    {
+                        // Find all matching ranges and pick the most specific (narrowest) one
+                        let mut best_match = None;
+                        let mut best_range_size = u32::MAX;
+
+                        for ((start_offset, end_offset), (classlike_name, member_name)) in
+                            definition_locations
                         {
-                            // Find all matching ranges and pick the most specific (narrowest) one
-                            let mut best_match = None;
-                            let mut best_range_size = u32::MAX;
+                            if (offset as u32) >= *start_offset && (offset as u32) <= *end_offset {
+                                let range_size = end_offset - start_offset;
+                                if range_size < best_range_size {
+                                    best_range_size = range_size;
+                                    best_match = Some((classlike_name, member_name));
+                                }
+                            }
+                        }
 
-                            for ((start_offset, end_offset), (classlike_name, member_name)) in
-                                definition_locations
+                        if let Some((classlike_name, member_name)) = best_match {
+                            if let Some(pos) = scan_data
+                                .codebase
+                                .get_symbol_pos(classlike_name, member_name)
                             {
-                                if (offset as u32) >= *start_offset
-                                    && (offset as u32) <= *end_offset
-                                {
-                                    let range_size = end_offset - start_offset;
-                                    if range_size < best_range_size {
-                                        best_range_size = range_size;
-                                        best_match = Some((classlike_name, member_name));
-                                    }
-                                }
+                                return Ok(pos_to_offset(pos, &scan_data.interner));
                             }
 
-                            if let Some((classlike_name, member_name)) = best_match {
-                                if let Some(pos) = scan_data
-                                    .codebase
-                                    .get_symbol_pos(classlike_name, member_name)
-                                {
-                                    return Ok(pos_to_offset(pos, &scan_data.interner));
-                                }
-
-                                return Ok(None);
-                            }
+                            return Ok(None);
                         }
                     }
                 }
@@ -283,7 +281,7 @@ fn pos_to_offset(def_pos: HPos, interner: &Interner) -> Option<GotoDefinitionRes
         }));
     }
 
-    return None;
+    None
 }
 
 impl Backend {
@@ -550,7 +548,7 @@ pub async fn serve_with_plugins<Reader, Writer>(
         }
         None => {
             stderr
-                .write_all_buf(&mut Cursor::new(format!("Using local analysis")))
+                .write_all_buf(&mut Cursor::new("Using local analysis".to_string()))
                 .await
                 .ok();
             None

--- a/src/language_server/server_backend.rs
+++ b/src/language_server/server_backend.rs
@@ -109,7 +109,7 @@ impl ServerBasedBackend {
                     )
                     .await;
 
-                return all_diagnostics;
+                all_diagnostics
             }
             Err(e) => {
                 client
@@ -119,7 +119,7 @@ impl ServerBasedBackend {
                     )
                     .await;
 
-                return FxHashMap::default();
+                FxHashMap::default()
             }
         }
     }
@@ -255,8 +255,8 @@ impl LanguageServer for ServerBasedBackend {
 
         match result {
             Ok(response) => {
-                if response.found {
-                    if let (
+                if response.found
+                    && let (
                         Some(def_file_path),
                         Some(start_line),
                         Some(start_column),
@@ -268,32 +268,32 @@ impl LanguageServer for ServerBasedBackend {
                         response.start_column,
                         response.end_line,
                         response.end_column,
-                    ) {
-                        self.client
-                            .log_message(
-                                MessageType::INFO,
-                                format!(
-                                    "Definition found: {}:{}:{}",
-                                    def_file_path, start_line, start_column
-                                ),
-                            )
-                            .await;
+                    )
+                {
+                    self.client
+                        .log_message(
+                            MessageType::INFO,
+                            format!(
+                                "Definition found: {}:{}:{}",
+                                def_file_path, start_line, start_column
+                            ),
+                        )
+                        .await;
 
-                        if let Ok(def_uri) = Url::from_file_path(&def_file_path) {
-                            return Ok(Some(GotoDefinitionResponse::Scalar(Location {
-                                uri: def_uri,
-                                range: Range {
-                                    start: Position {
-                                        line: start_line - 1, // Convert back to 0-indexed for LSP
-                                        character: (start_column - 1) as u32,
-                                    },
-                                    end: Position {
-                                        line: end_line - 1,
-                                        character: (end_column - 1) as u32,
-                                    },
+                    if let Ok(def_uri) = Url::from_file_path(&def_file_path) {
+                        return Ok(Some(GotoDefinitionResponse::Scalar(Location {
+                            uri: def_uri,
+                            range: Range {
+                                start: Position {
+                                    line: start_line - 1, // Convert back to 0-indexed for LSP
+                                    character: (start_column - 1) as u32,
                                 },
-                            })));
-                        }
+                                end: Position {
+                                    line: end_line - 1,
+                                    character: (end_column - 1) as u32,
+                                },
+                            },
+                        })));
                     }
                 }
                 self.client

--- a/src/language_server/server_client.rs
+++ b/src/language_server/server_client.rs
@@ -41,14 +41,12 @@ impl ServerConnection {
     ) -> io::Result<Self> {
         let socket_path = SocketPath::for_project(project_root);
 
-        if socket_path.server_exists() {
-            if ClientSocket::connect(&socket_path).await.is_ok() {
-                return Ok(Self {
-                    socket_path,
-                    project_root: project_root.to_path_buf(),
-                    hakana_binary: hakana_binary.map(|s| s.to_string()),
-                });
-            }
+        if socket_path.server_exists() && ClientSocket::connect(&socket_path).await.is_ok() {
+            return Ok(Self {
+                socket_path,
+                project_root: project_root.to_path_buf(),
+                hakana_binary: hakana_binary.map(|s| s.to_string()),
+            });
         }
 
         let mut server_process = Self::spawn_server(project_root, hakana_binary)?;
@@ -167,21 +165,18 @@ impl ServerConnection {
                     let log_contents = std::fs::read_to_string(&log_path)
                         .unwrap_or_else(|_| "<no log available>".to_string());
                     log::info!("Server log contents:\n{}", log_contents);
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!(
-                            "Server process exited during startup with status: {}. Check {} for details.",
-                            status,
-                            log_path.display()
-                        ),
-                    ));
+                    return Err(io::Error::other(format!(
+                        "Server process exited during startup with status: {}. Check {} for details.",
+                        status,
+                        log_path.display()
+                    )));
                 }
                 Ok(None) => {}
                 Err(e) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("Failed to check server process status: {}", e),
-                    ));
+                    return Err(io::Error::other(format!(
+                        "Failed to check server process status: {}",
+                        e
+                    )));
                 }
             }
 
@@ -209,15 +204,12 @@ impl ServerConnection {
         let request = Message::Status(StatusRequest);
         match socket.request(&request).await {
             Ok(Message::StatusResult(response)) => Ok(response),
-            Ok(Message::Error(e)) => Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Server error: {}", e.message),
-            )),
+            Ok(Message::Error(e)) => Err(io::Error::other(format!("Server error: {}", e.message))),
             Ok(_) => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Unexpected response type",
             )),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))),
+            Err(e) => Err(io::Error::other(format!("{}", e))),
         }
     }
 
@@ -239,15 +231,12 @@ impl ServerConnection {
 
         match socket.request(&request).await {
             Ok(Message::GetIssuesResult(response)) => Ok(response),
-            Ok(Message::Error(e)) => Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Server error: {}", e.message),
-            )),
+            Ok(Message::Error(e)) => Err(io::Error::other(format!("Server error: {}", e.message))),
             Ok(_) => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Unexpected response type",
             )),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))),
+            Err(e) => Err(io::Error::other(format!("{}", e))),
         }
     }
 
@@ -268,15 +257,12 @@ impl ServerConnection {
 
         match socket.request(&request).await {
             Ok(Message::Ack(_)) => Ok(()),
-            Ok(Message::Error(e)) => Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Server error: {}", e.message),
-            )),
+            Ok(Message::Error(e)) => Err(io::Error::other(format!("Server error: {}", e.message))),
             Ok(_) => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Unexpected response type",
             )),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))),
+            Err(e) => Err(io::Error::other(format!("{}", e))),
         }
     }
 
@@ -295,15 +281,12 @@ impl ServerConnection {
 
         match socket.request(&request).await {
             Ok(Message::GotoDefinitionResult(response)) => Ok(response),
-            Ok(Message::Error(e)) => Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Server error: {}", e.message),
-            )),
+            Ok(Message::Error(e)) => Err(io::Error::other(format!("Server error: {}", e.message))),
             Ok(_) => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Unexpected response type",
             )),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))),
+            Err(e) => Err(io::Error::other(format!("{}", e))),
         }
     }
 
@@ -314,7 +297,7 @@ impl ServerConnection {
         match socket.request(&request).await {
             Ok(Message::Ack(_)) => Ok(()),
             Ok(_) => Ok(()),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))),
+            Err(e) => Err(io::Error::other(format!("{}", e))),
         }
     }
 }

--- a/src/lint/examples/dont_discard_new_expressions.rs
+++ b/src/lint/examples/dont_discard_new_expressions.rs
@@ -41,6 +41,12 @@ impl Linter for DontDiscardNewExpressionsLinter {
     }
 }
 
+impl Default for DontDiscardNewExpressionsLinter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DontDiscardNewExpressionsLinter {
     pub fn new() -> Self {
         Self

--- a/src/lint/examples/must_use_braces_for_control_flow.rs
+++ b/src/lint/examples/must_use_braces_for_control_flow.rs
@@ -41,6 +41,12 @@ impl Linter for MustUseBracesForControlFlowLinter {
     }
 }
 
+impl Default for MustUseBracesForControlFlowLinter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MustUseBracesForControlFlowLinter {
     pub fn new() -> Self {
         Self

--- a/src/lint/examples/no_await_in_loop.rs
+++ b/src/lint/examples/no_await_in_loop.rs
@@ -74,21 +74,18 @@ impl<'a> SyntaxVisitor<'a> for NoAwaitVisitor<'a> {
 
     fn visit_node(&mut self, node: &'a PositionedSyntax<'a>) -> bool {
         // Check if this is an await expression
-        if self.in_loop_depth > 0 {
-            if let Some(token) = node.get_token() {
-                if token.kind() == TokenKind::Await {
-                    let (start, end) = self.ctx.node_full_range(node);
-                    self.errors.borrow_mut().push(
-                        LintError::new(
-                            Severity::Warning,
-                            "Await expression found inside loop. Consider using concurrent operations instead.",
-                            start,
-                            end,
-                            "no-await-in-loop",
-                        )
-                    );
-                }
-            }
+        if self.in_loop_depth > 0
+            && let Some(token) = node.get_token()
+            && token.kind() == TokenKind::Await
+        {
+            let (start, end) = self.ctx.node_full_range(node);
+            self.errors.borrow_mut().push(LintError::new(
+                Severity::Warning,
+                "Await expression found inside loop. Consider using concurrent operations instead.",
+                start,
+                end,
+                "no-await-in-loop",
+            ));
         }
 
         // After processing children, decrement depth for loop statements
@@ -107,6 +104,12 @@ impl<'a> SyntaxVisitor<'a> for NoAwaitVisitor<'a> {
             _ => {}
         }
         true
+    }
+}
+
+impl Default for NoAwaitInLoopLinter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/lint/examples/no_empty_statements.rs
+++ b/src/lint/examples/no_empty_statements.rs
@@ -46,6 +46,12 @@ impl Linter for NoEmptyStatementsLinter {
     }
 }
 
+impl Default for NoEmptyStatementsLinter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NoEmptyStatementsLinter {
     pub fn new() -> Self {
         Self
@@ -62,38 +68,38 @@ impl<'a> NoEmptyStatementsVisitor<'a> {
     /// Handle empty statement that is the body of a control flow statement
     /// Replaces ; with {}
     fn handle_control_flow_empty_body(&mut self, body: &'a PositionedSyntax<'a>) {
-        if let SyntaxVariant::ExpressionStatement(stmt) = &body.children {
-            if matches!(&stmt.expression.children, SyntaxVariant::Missing) {
-                let (start, _) = self.ctx.node_full_range(body);
+        if let SyntaxVariant::ExpressionStatement(stmt) = &body.children
+            && matches!(&stmt.expression.children, SyntaxVariant::Missing)
+        {
+            let (start, _) = self.ctx.node_full_range(body);
 
-                // Mark this statement as handled so we don't process it again
-                self.handled_statements.insert(start);
+            // Mark this statement as handled so we don't process it again
+            self.handled_statements.insert(start);
 
-                // Get error range from the semicolon (including trivia)
-                let (error_start, error_end) = self.ctx.node_full_range(&stmt.semicolon);
+            // Get error range from the semicolon (including trivia)
+            let (error_start, error_end) = self.ctx.node_full_range(&stmt.semicolon);
 
-                let mut error = LintError::new(
-                    Severity::Warning,
-                    "This statement is empty",
-                    error_start,
-                    error_end,
-                    "no-empty-statements",
-                );
+            let mut error = LintError::new(
+                Severity::Warning,
+                "This statement is empty",
+                error_start,
+                error_end,
+                "no-empty-statements",
+            );
 
-                // Add auto-fix to replace with empty compound statement {}
-                if self.ctx.allow_auto_fix {
-                    // Get the semicolon token
-                    if let Some(token) = stmt.semicolon.get_token() {
-                        let mut fix = EditSet::new();
-                        // Replace just the semicolon with {}, preserving leading whitespace
-                        let (token_start, token_end) = self.ctx.token_range(token);
-                        fix.add(Edit::new(token_start, token_end, "{}"));
-                        error = error.with_fix(fix);
-                    }
+            // Add auto-fix to replace with empty compound statement {}
+            if self.ctx.allow_auto_fix {
+                // Get the semicolon token
+                if let Some(token) = stmt.semicolon.get_token() {
+                    let mut fix = EditSet::new();
+                    // Replace just the semicolon with {}, preserving leading whitespace
+                    let (token_start, token_end) = self.ctx.token_range(token);
+                    fix.add(Edit::new(token_start, token_end, "{}"));
+                    error = error.with_fix(fix);
                 }
-
-                self.errors.push(error);
             }
+
+            self.errors.push(error);
         }
     }
 

--- a/src/lint/examples/no_whitespace_at_end_of_line.rs
+++ b/src/lint/examples/no_whitespace_at_end_of_line.rs
@@ -73,6 +73,12 @@ impl Linter for NoWhitespaceAtEndOfLineLinter {
     }
 }
 
+impl Default for NoWhitespaceAtEndOfLineLinter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NoWhitespaceAtEndOfLineLinter {
     pub fn new() -> Self {
         Self

--- a/src/lint/examples/unused_use_clause.rs
+++ b/src/lint/examples/unused_use_clause.rs
@@ -44,6 +44,12 @@ impl Linter for UnusedUseClauseLinter {
     }
 }
 
+impl Default for UnusedUseClauseLinter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl UnusedUseClauseLinter {
     pub fn new() -> Self {
         Self
@@ -182,30 +188,24 @@ impl<'a> SyntaxVisitor<'a> for UnusedUseClauseVisitor<'a> {
                 }
                 // Also extract type arguments: in Foo<Bar, Baz>, we need to mark Bar and Baz as used
                 // The argument_list contains TypeArguments which has a types field
-                if let SyntaxVariant::TypeArguments(args) = &spec.argument_list.children {
-                    if let SyntaxVariant::SyntaxList(types_list) = &args.types.children {
-                        for type_arg in types_list.iter() {
-                            if let SyntaxVariant::ListItem(item) = &type_arg.children {
-                                extract_type_names(
-                                    &item.item,
-                                    self.ctx,
-                                    &mut self.referenced_names,
-                                );
-                            }
+                if let SyntaxVariant::TypeArguments(args) = &spec.argument_list.children
+                    && let SyntaxVariant::SyntaxList(types_list) = &args.types.children
+                {
+                    for type_arg in types_list.iter() {
+                        if let SyntaxVariant::ListItem(item) = &type_arg.children {
+                            extract_type_names(&item.item, self.ctx, &mut self.referenced_names);
                         }
                     }
                 }
             }
             // Qualified name: Foo\Bar\Baz - track first part as namespace
             SyntaxVariant::QualifiedName(qn) => {
-                if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children {
-                    if let Some(first_item) = parts.first() {
-                        if let SyntaxVariant::ListItem(item) = &first_item.children {
-                            if let Some(name) = extract_name_token(&item.item, self.ctx) {
-                                self.referenced_names.namespaces.insert(name);
-                            }
-                        }
-                    }
+                if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children
+                    && let Some(first_item) = parts.first()
+                    && let SyntaxVariant::ListItem(item) = &first_item.children
+                    && let Some(name) = extract_name_token(&item.item, self.ctx)
+                {
+                    self.referenced_names.namespaces.insert(name);
                 }
             }
             // Function call: foo() or foo<Bar>()
@@ -214,16 +214,12 @@ impl<'a> SyntaxVisitor<'a> for UnusedUseClauseVisitor<'a> {
                     self.referenced_names.functions.insert(name);
                 }
                 // Extract type arguments: in Cfg::get<CookiesConfig>(), we need CookiesConfig
-                if let SyntaxVariant::TypeArguments(args) = &call.type_args.children {
-                    if let SyntaxVariant::SyntaxList(types_list) = &args.types.children {
-                        for type_arg in types_list.iter() {
-                            if let SyntaxVariant::ListItem(item) = &type_arg.children {
-                                extract_type_names(
-                                    &item.item,
-                                    self.ctx,
-                                    &mut self.referenced_names,
-                                );
-                            }
+                if let SyntaxVariant::TypeArguments(args) = &call.type_args.children
+                    && let SyntaxVariant::SyntaxList(types_list) = &args.types.children
+                {
+                    for type_arg in types_list.iter() {
+                        if let SyntaxVariant::ListItem(item) = &type_arg.children {
+                            extract_type_names(&item.item, self.ctx, &mut self.referenced_names);
                         }
                     }
                 }
@@ -234,16 +230,12 @@ impl<'a> SyntaxVisitor<'a> for UnusedUseClauseVisitor<'a> {
                     self.referenced_names.functions.insert(name);
                 }
                 // Extract type arguments: in foo_bar<SomeType>, we need SomeType
-                if let SyntaxVariant::TypeArguments(args) = &ptr.type_args.children {
-                    if let SyntaxVariant::SyntaxList(types_list) = &args.types.children {
-                        for type_arg in types_list.iter() {
-                            if let SyntaxVariant::ListItem(item) = &type_arg.children {
-                                extract_type_names(
-                                    &item.item,
-                                    self.ctx,
-                                    &mut self.referenced_names,
-                                );
-                            }
+                if let SyntaxVariant::TypeArguments(args) = &ptr.type_args.children
+                    && let SyntaxVariant::SyntaxList(types_list) = &args.types.children
+                {
+                    for type_arg in types_list.iter() {
+                        if let SyntaxVariant::ListItem(item) = &type_arg.children {
+                            extract_type_names(&item.item, self.ctx, &mut self.referenced_names);
                         }
                     }
                 }
@@ -300,14 +292,12 @@ impl<'a> SyntaxVisitor<'a> for UnusedUseClauseVisitor<'a> {
                     self.referenced_names.types.insert(name);
                 } else if let SyntaxVariant::QualifiedName(qn) = &nameof_expr.target.children {
                     // Qualified name in nameof - extract first part as namespace
-                    if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children {
-                        if let Some(first_item) = parts.first() {
-                            if let SyntaxVariant::ListItem(item) = &first_item.children {
-                                if let Some(name) = extract_name_token(&item.item, self.ctx) {
-                                    self.referenced_names.namespaces.insert(name);
-                                }
-                            }
-                        }
+                    if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children
+                        && let Some(first_item) = parts.first()
+                        && let SyntaxVariant::ListItem(item) = &first_item.children
+                        && let Some(name) = extract_name_token(&item.item, self.ctx)
+                    {
+                        self.referenced_names.namespaces.insert(name);
                     }
                 }
             }
@@ -318,14 +308,12 @@ impl<'a> SyntaxVisitor<'a> for UnusedUseClauseVisitor<'a> {
                     self.referenced_names.types.insert(name);
                 } else if let SyntaxVariant::QualifiedName(qn) = &enum_label.qualifier.children {
                     // Qualified enum name - extract first part as namespace
-                    if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children {
-                        if let Some(first_item) = parts.first() {
-                            if let SyntaxVariant::ListItem(item) = &first_item.children {
-                                if let Some(name) = extract_name_token(&item.item, self.ctx) {
-                                    self.referenced_names.namespaces.insert(name);
-                                }
-                            }
-                        }
+                    if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children
+                        && let Some(first_item) = parts.first()
+                        && let SyntaxVariant::ListItem(item) = &first_item.children
+                        && let Some(name) = extract_name_token(&item.item, self.ctx)
+                    {
+                        self.referenced_names.namespaces.insert(name);
                     }
                 }
             }
@@ -452,7 +440,7 @@ impl<'a> UnusedUseClauseVisitor<'a> {
                 let full_name = if prefix.is_empty() {
                     // No prefix, just use clause path
                     clause_path.clone()
-                } else if prefix == "\\" || prefix == "" {
+                } else if prefix == "\\" || prefix.is_empty() {
                     // Prefix is just "\" (root namespace), prepend to clause path
                     format!("\\{}", clause_path)
                 } else if prefix.ends_with('\\') {
@@ -478,7 +466,7 @@ impl<'a> UnusedUseClauseVisitor<'a> {
 
         // Group consecutive unused clauses to avoid overlapping edits
         // Sort unused clauses by start offset
-        let mut sorted_unused: Vec<&UseClauseInfo> = unused_clauses.iter().copied().collect();
+        let mut sorted_unused: Vec<&UseClauseInfo> = unused_clauses.to_vec();
         sorted_unused.sort_by_key(|c| c.start_offset);
 
         // Group consecutive clauses together
@@ -590,10 +578,10 @@ impl<'a> UnusedUseClauseVisitor<'a> {
                             end += 1;
                         }
                         // Also consume leading space if it exists
-                        if let Some((_, has_space)) = leading_context {
-                            if has_space {
-                                start -= 1;
-                            }
+                        if let Some((_, has_space)) = leading_context
+                            && has_space
+                        {
+                            start -= 1;
                         }
                     } else {
                         // Inline case
@@ -636,15 +624,15 @@ impl<'a> UnusedUseClauseVisitor<'a> {
                 if first_unused.start_offset > 0 {
                     let lookbehind_start = first_unused.start_offset.saturating_sub(100);
                     let lookbehind = &source_bytes[lookbehind_start..first_unused.start_offset];
-                    if let Ok(text) = std::str::from_utf8(lookbehind) {
-                        if text.trim_end().ends_with(',') {
-                            has_leading_comma = true;
-                            // Find the comma position
-                            for i in (lookbehind_start..first_unused.start_offset).rev() {
-                                if source_bytes[i] == b',' {
-                                    comma_start = i;
-                                    break;
-                                }
+                    if let Ok(text) = std::str::from_utf8(lookbehind)
+                        && text.trim_end().ends_with(',')
+                    {
+                        has_leading_comma = true;
+                        // Find the comma position
+                        for i in (lookbehind_start..first_unused.start_offset).rev() {
+                            if source_bytes[i] == b',' {
+                                comma_start = i;
+                                break;
                             }
                         }
                     }
@@ -720,33 +708,33 @@ fn extract_use_clauses(clauses_node: &PositionedSyntax, ctx: &LintContext) -> Ve
 
     if let SyntaxVariant::SyntaxList(list) = &clauses_node.children {
         for item in list.iter() {
-            if let SyntaxVariant::ListItem(list_item) = &item.children {
-                if let SyntaxVariant::NamespaceUseClause(clause) = &list_item.item.children {
-                    // Get the full clause path (what's actually written in the clause)
-                    let full_clause_path = ctx.node_text(&clause.name).trim().to_string();
+            if let SyntaxVariant::ListItem(list_item) = &item.children
+                && let SyntaxVariant::NamespaceUseClause(clause) = &list_item.item.children
+            {
+                // Get the full clause path (what's actually written in the clause)
+                let full_clause_path = ctx.node_text(&clause.name).trim().to_string();
 
-                    // Check if this clause has an alias
-                    let has_alias = !matches!(&clause.alias.children, SyntaxVariant::Missing);
+                // Check if this clause has an alias
+                let has_alias = !matches!(&clause.alias.children, SyntaxVariant::Missing);
 
-                    // Get the imported name (alias or last part of qualified name)
-                    let imported_name = if has_alias {
-                        // Has an alias - use that
-                        ctx.node_text(&clause.alias).trim().to_string()
-                    } else {
-                        // No alias - get last part of the name
-                        extract_last_name_part(&clause.name, ctx)
-                    };
+                // Get the imported name (alias or last part of qualified name)
+                let imported_name = if has_alias {
+                    // Has an alias - use that
+                    ctx.node_text(&clause.alias).trim().to_string()
+                } else {
+                    // No alias - get last part of the name
+                    extract_last_name_part(&clause.name, ctx)
+                };
 
-                    if !imported_name.is_empty() {
-                        let (start, end) = ctx.node_full_range(&list_item.item);
-                        clauses.push(UseClauseInfo {
-                            imported_name,
-                            full_clause_path,
-                            has_alias,
-                            start_offset: start,
-                            end_offset: end,
-                        });
-                    }
+                if !imported_name.is_empty() {
+                    let (start, end) = ctx.node_full_range(&list_item.item);
+                    clauses.push(UseClauseInfo {
+                        imported_name,
+                        full_clause_path,
+                        has_alias,
+                        start_offset: start,
+                        end_offset: end,
+                    });
                 }
             }
         }
@@ -757,17 +745,16 @@ fn extract_use_clauses(clauses_node: &PositionedSyntax, ctx: &LintContext) -> Ve
 
 /// Extract the last part of a name (for determining what was imported)
 fn extract_last_name_part(name_node: &PositionedSyntax, ctx: &LintContext) -> String {
-    if let Some(_) = name_node.get_token() {
+    if name_node.get_token().is_some() {
         // Simple name token
         ctx.node_text(name_node).trim().to_string()
     } else if let SyntaxVariant::QualifiedName(qn) = &name_node.children {
         // Qualified name - get last part
-        if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children {
-            if let Some(last_item) = parts.last() {
-                if let SyntaxVariant::ListItem(item) = &last_item.children {
-                    return ctx.node_text(&item.item).trim().to_string();
-                }
-            }
+        if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children
+            && let Some(last_item) = parts.last()
+            && let SyntaxVariant::ListItem(item) = &last_item.children
+        {
+            return ctx.node_text(&item.item).trim().to_string();
         }
         String::new()
     } else {
@@ -778,11 +765,11 @@ fn extract_last_name_part(name_node: &PositionedSyntax, ctx: &LintContext) -> St
 /// Extract a simple name token's text from a node
 fn extract_name_token(node: &PositionedSyntax, ctx: &LintContext) -> Option<String> {
     // Check if this node is a token
-    if let Some(token) = node.get_token() {
-        if matches!(token.kind(), TokenKind::Name) {
-            // Use ctx to get the text
-            return Some(ctx.node_text(node).trim().to_string());
-        }
+    if let Some(token) = node.get_token()
+        && matches!(token.kind(), TokenKind::Name)
+    {
+        // Use ctx to get the text
+        return Some(ctx.node_text(node).trim().to_string());
     }
     None
 }
@@ -830,14 +817,12 @@ fn extract_type_names(node: &PositionedSyntax, ctx: &LintContext, names: &mut Re
             // Check if the specifier is a qualified name
             if let SyntaxVariant::QualifiedName(qn) = &spec.specifier.children {
                 // Extract first part as namespace
-                if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children {
-                    if let Some(first_item) = parts.first() {
-                        if let SyntaxVariant::ListItem(item) = &first_item.children {
-                            if let Some(name) = extract_name_token(&item.item, ctx) {
-                                names.namespaces.insert(name);
-                            }
-                        }
-                    }
+                if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children
+                    && let Some(first_item) = parts.first()
+                    && let SyntaxVariant::ListItem(item) = &first_item.children
+                    && let Some(name) = extract_name_token(&item.item, ctx)
+                {
+                    names.namespaces.insert(name);
                 }
             } else if let Some(name) = extract_name_token(&spec.specifier, ctx) {
                 // Simple name token
@@ -850,26 +835,24 @@ fn extract_type_names(node: &PositionedSyntax, ctx: &LintContext, names: &mut Re
                 names.types.insert(name);
             }
             // Recursively extract type arguments
-            if let SyntaxVariant::TypeArguments(args) = &spec.argument_list.children {
-                if let SyntaxVariant::SyntaxList(types_list) = &args.types.children {
-                    for type_arg in types_list.iter() {
-                        if let SyntaxVariant::ListItem(item) = &type_arg.children {
-                            extract_type_names(&item.item, ctx, names);
-                        }
+            if let SyntaxVariant::TypeArguments(args) = &spec.argument_list.children
+                && let SyntaxVariant::SyntaxList(types_list) = &args.types.children
+            {
+                for type_arg in types_list.iter() {
+                    if let SyntaxVariant::ListItem(item) = &type_arg.children {
+                        extract_type_names(&item.item, ctx, names);
                     }
                 }
             }
         }
         // Qualified name: Foo\Bar\Baz
         SyntaxVariant::QualifiedName(qn) => {
-            if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children {
-                if let Some(first_item) = parts.first() {
-                    if let SyntaxVariant::ListItem(item) = &first_item.children {
-                        if let Some(name) = extract_name_token(&item.item, ctx) {
-                            names.namespaces.insert(name);
-                        }
-                    }
-                }
+            if let SyntaxVariant::SyntaxList(parts) = &qn.parts.children
+                && let Some(first_item) = parts.first()
+                && let SyntaxVariant::ListItem(item) = &first_item.children
+                && let Some(name) = extract_name_token(&item.item, ctx)
+            {
+                names.namespaces.insert(name);
             }
         }
         // Nullable type: ?Foo

--- a/src/lint/examples/use_statement_without_kind.rs
+++ b/src/lint/examples/use_statement_without_kind.rs
@@ -83,12 +83,12 @@ impl Linter for UseStatementWithoutKindLinter {
             );
 
             // Only add autofix if we can determine the kind unambiguously
-            if ctx.allow_auto_fix {
-                if let Some(kind) = suggested_kind {
-                    let mut fix = EditSet::new();
-                    fix.add(Edit::insert(use_stmt.insert_pos, format!("{} ", kind)));
-                    error = error.with_fix(fix);
-                }
+            if ctx.allow_auto_fix
+                && let Some(kind) = suggested_kind
+            {
+                let mut fix = EditSet::new();
+                fix.add(Edit::insert(use_stmt.insert_pos, format!("{} ", kind)));
+                error = error.with_fix(fix);
             }
 
             errors.push(error);
@@ -99,6 +99,12 @@ impl Linter for UseStatementWithoutKindLinter {
 
     fn supports_auto_fix(&self) -> bool {
         true
+    }
+}
+
+impl Default for UseStatementWithoutKindLinter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -170,23 +176,20 @@ impl<'a> SyntaxVisitor<'a> for UseStatementCollector<'a> {
                     // Collect all clause names
                     if let SyntaxVariant::SyntaxList(clauses) = &group_use.clauses.children {
                         for clause_node in clauses.iter() {
-                            if let SyntaxVariant::ListItem(item) = &clause_node.children {
-                                if let SyntaxVariant::NamespaceUseClause(clause) =
+                            if let SyntaxVariant::ListItem(item) = &clause_node.children
+                                && let SyntaxVariant::NamespaceUseClause(clause) =
                                     &item.item.children
+                            {
+                                // Check if this individual clause has a kind
+                                if !has_kind_keyword(&clause.clause_kind)
+                                    && let Some(clause_name) = extract_name(self.ctx, &clause.name)
                                 {
-                                    // Check if this individual clause has a kind
-                                    if !has_kind_keyword(&clause.clause_kind) {
-                                        if let Some(clause_name) =
-                                            extract_name(self.ctx, &clause.name)
-                                        {
-                                            let full_name = if prefix.is_empty() {
-                                                clause_name
-                                            } else {
-                                                format!("{}\\{}", prefix, clause_name)
-                                            };
-                                            names.push(full_name);
-                                        }
-                                    }
+                                    let full_name = if prefix.is_empty() {
+                                        clause_name
+                                    } else {
+                                        format!("{}\\{}", prefix, clause_name)
+                                    };
+                                    names.push(full_name);
                                 }
                             }
                         }
@@ -348,7 +351,7 @@ fn extract_qualified_namespace<'a>(
 fn get_short_name(full_name: &str) -> String {
     full_name
         .split('\\')
-        .last()
+        .next_back()
         .unwrap_or(full_name)
         .to_string()
 }

--- a/src/lint/hhast_config.rs
+++ b/src/lint/hhast_config.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 /// Configuration for HHAST linting
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct HhastLintConfig {
     /// Root directories to lint
     #[serde(default)]
@@ -105,10 +106,10 @@ impl HhastLintConfig {
         }
 
         // If builtin_linters is "none", only enable explicitly enabled linters
-        if let Some(ref builtin) = self.builtin_linters {
-            if builtin == "none" {
-                return explicitly_enabled;
-            }
+        if let Some(ref builtin) = self.builtin_linters
+            && builtin == "none"
+        {
+            return explicitly_enabled;
         }
 
         enabled
@@ -154,11 +155,7 @@ impl HhastLintConfig {
                     current_pos += part.len();
                 } else if i == parts.len() - 1 {
                     // Last non-empty part must be found somewhere
-                    if path[current_pos..].contains(part) {
-                        return true;
-                    } else {
-                        return false;
-                    }
+                    return path[current_pos..].contains(part);
                 } else {
                     // Middle parts must be found
                     if let Some(pos) = path[current_pos..].find(part) {
@@ -193,21 +190,6 @@ impl HhastLintConfig {
             .into_iter()
             .filter(|linter| self.is_linter_enabled(linter, file_path))
             .collect()
-    }
-}
-
-impl Default for HhastLintConfig {
-    fn default() -> Self {
-        Self {
-            roots: vec![],
-            builtin_linters: None,
-            namespace_aliases: HashMap::new(),
-            extra_linters: vec![],
-            disabled_linters: vec![],
-            disabled_auto_fixes: vec![],
-            disable_all_auto_fixes: false,
-            overrides: vec![],
-        }
     }
 }
 

--- a/src/lint/runner.rs
+++ b/src/lint/runner.rs
@@ -135,7 +135,7 @@ fn parse_suppressions(source: &str) -> SuppressionInfo {
                         // HHAST_FIXME[Linter] or HHAST_IGNORE_ERROR[Linter] - suppress for this line
                         single_instance
                             .entry(line_num)
-                            .or_insert_with(FxHashSet::default)
+                            .or_default()
                             .insert(linter_name.to_string());
                     }
 
@@ -153,7 +153,7 @@ fn parse_suppressions(source: &str) -> SuppressionInfo {
         if !found_any_brackets {
             single_instance
                 .entry(line_num)
-                .or_insert_with(FxHashSet::default)
+                .or_default()
                 .insert(String::new());
         }
     }
@@ -261,19 +261,18 @@ fn is_suppressed_with_boundaries(
 
     // Check for statement-level suppression: if a suppression appears on a line
     // before the statement starts, it suppresses errors throughout the statement
-    if let Some(&(stmt_start, _)) = containing_statement {
-        if stmt_start > 0 {
-            if let Some(linters) = suppressions.single_instance.get(&(stmt_start - 1)) {
-                // Empty string means suppress all linters
-                if linters.contains("") {
-                    return true;
-                }
+    if let Some(&(stmt_start, _)) = containing_statement
+        && stmt_start > 0
+        && let Some(linters) = suppressions.single_instance.get(&(stmt_start - 1))
+    {
+        // Empty string means suppress all linters
+        if linters.contains("") {
+            return true;
+        }
 
-                // Check if this specific linter is suppressed
-                if is_linter_in_set(linters, linter_name, hhast_name) {
-                    return true;
-                }
-            }
+        // Check if this specific linter is suppressed
+        if is_linter_in_set(linters, linter_name, hhast_name) {
+            return true;
         }
     }
 
@@ -306,10 +305,10 @@ fn is_linter_in_set(
             }
 
             // Check without "Linter" suffix
-            if let Some(without_suffix) = last_part.strip_suffix("Linter") {
-                if linters.contains(without_suffix) {
-                    return true;
-                }
+            if let Some(without_suffix) = last_part.strip_suffix("Linter")
+                && linters.contains(without_suffix)
+            {
+                return true;
             }
         }
     }
@@ -369,13 +368,13 @@ fn add_fixme_comments(
             // Insert with newline (will add "/* HHAST_FIXME[...] */\n{indent}" before the statement)
             fixme_insertions
                 .entry((line_start_offset, true))
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(pascal_case_name);
         } else {
             // Add fixme right before the error location (inline)
             fixme_insertions
                 .entry((error_offset, false))
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(pascal_case_name);
         }
     }
@@ -472,12 +471,11 @@ pub fn run_linters(
             continue;
         }
 
-        if let Some(hhast_name) = linter.hhast_name() {
-            if !config.fixme_linters.is_empty()
-                && !config.fixme_linters.contains(&hhast_name.to_string())
-            {
-                continue;
-            }
+        if let Some(hhast_name) = linter.hhast_name()
+            && !config.fixme_linters.is_empty()
+            && !config.fixme_linters.contains(&hhast_name.to_string())
+        {
+            continue;
         }
 
         let start_time = std::time::Instant::now();

--- a/src/orchestrator/analyzer.rs
+++ b/src/orchestrator/analyzer.rs
@@ -169,34 +169,33 @@ fn analyze_file(
             .unwrap()
             .as_micros() as u64;
 
-        if let Some((file_hash, last_updated_time)) = last_hash_and_time {
-            if updated_time != *last_updated_time
-                && get_file_contents_hash(&str_path).unwrap_or(0) != *file_hash
-            {
-                analysis_result.has_invalid_hack_files = true;
-                analysis_result
-                    .changed_during_analysis_files
-                    .insert(file_path);
-                analysis_result.emitted_issues.insert(
-                    file_path,
-                    vec![Issue::new(
-                        IssueKind::InvalidHackFile,
-                        "File changed during analysis".to_string(),
-                        HPos {
-                            file_path,
-                            start_offset: 0,
-                            end_offset: 0,
-                            start_line: 0,
-                            end_line: 0,
-                            start_column: 0,
-                            end_column: 0,
-                        },
-                        &None,
-                    )],
-                );
+        if let Some((file_hash, last_updated_time)) = last_hash_and_time
+            && updated_time != *last_updated_time
+            && get_file_contents_hash(str_path).unwrap_or(0) != *file_hash
+        {
+            analysis_result.has_invalid_hack_files = true;
+            analysis_result
+                .changed_during_analysis_files
+                .insert(file_path);
+            analysis_result.emitted_issues.insert(
+                file_path,
+                vec![Issue::new(
+                    IssueKind::InvalidHackFile,
+                    "File changed during analysis".to_string(),
+                    HPos {
+                        file_path,
+                        start_offset: 0,
+                        end_offset: 0,
+                        start_line: 0,
+                        end_line: 0,
+                        start_column: 0,
+                        end_column: 0,
+                    },
+                    &None,
+                )],
+            );
 
-                return Duration::default();
-            }
+            return Duration::default();
         }
     }
 

--- a/src/orchestrator/file.rs
+++ b/src/orchestrator/file.rs
@@ -230,72 +230,71 @@ impl VirtualFileSystem {
             return;
         };
 
-        if metadata.is_file() {
-            if let Some(extension) = path.extension() {
-                if extension.eq("hack") || extension.eq("php") || extension.eq("hhi") {
-                    let str_path = path.to_str().unwrap().to_string();
+        if metadata.is_file()
+            && let Some(extension) = path.extension()
+            && (extension.eq("hack") || extension.eq("php") || extension.eq("hhi"))
+        {
+            let str_path = path.to_str().unwrap().to_string();
 
-                    for ignore_pattern in ignore_patterns {
-                        if ignore_pattern.matches(&str_path) {
-                            return;
-                        }
-                    }
+            for ignore_pattern in ignore_patterns {
+                if ignore_pattern.matches(&str_path) {
+                    return;
+                }
+            }
 
-                    // Optimization: Only scan files matching the allowlist during cyclomatic complexity analysis.
-                    if config.analyze_cyclomatic_complexity
-                        && !config.cyclomatic_complexity_file_patterns.is_empty()
-                        && !config
-                            .cyclomatic_complexity_file_patterns
-                            .iter()
-                            .any(|pattern| pattern.matches(&str_path))
-                    {
-                        return;
-                    }
+            // Optimization: Only scan files matching the allowlist during cyclomatic complexity analysis.
+            if config.analyze_cyclomatic_complexity
+                && !config.cyclomatic_complexity_file_patterns.is_empty()
+                && !config
+                    .cyclomatic_complexity_file_patterns
+                    .iter()
+                    .any(|pattern| pattern.matches(&str_path))
+            {
+                return;
+            }
 
-                    let interned_file_path = FilePath(interner.intern(str_path.clone()));
+            let interned_file_path = FilePath(interner.intern(str_path.clone()));
 
-                    let updated_time = metadata
-                        .modified()
-                        .unwrap()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap()
-                        .as_micros() as u64;
+            let updated_time = metadata
+                .modified()
+                .unwrap()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_micros() as u64;
 
-                    let file_hash = if let Some(existing_file_system) = existing_file_system {
-                        if let Some((old_contents_hash, old_update_time)) = existing_file_system
-                            .file_hashes_and_times
-                            .get(&interned_file_path)
-                        {
-                            if old_update_time == &updated_time {
-                                *old_contents_hash
-                            } else if calculate_file_hashes {
-                                get_file_contents_hash(&str_path).unwrap_or(0)
-                            } else {
-                                0
-                            }
-                        } else {
-                            0
-                        }
+            let file_hash = if let Some(existing_file_system) = existing_file_system {
+                if let Some((old_contents_hash, old_update_time)) = existing_file_system
+                    .file_hashes_and_times
+                    .get(&interned_file_path)
+                {
+                    if old_update_time == &updated_time {
+                        *old_contents_hash
                     } else if calculate_file_hashes {
                         get_file_contents_hash(&str_path).unwrap_or(0)
                     } else {
                         0
-                    };
-
-                    self.file_hashes_and_times
-                        .insert(interned_file_path, (file_hash, updated_time));
-
-                    files_to_scan.push(str_path.clone());
-
-                    if !extension.eq("hhi") {
-                        if matches!(config.graph_kind, GraphKind::WholeProgram(_)) {
-                            if config.allow_taints_in_file(&str_path) {
-                                files_to_analyze.push(str_path.clone());
-                            }
-                        } else {
-                            files_to_analyze.push(str_path.clone());
-                        }
                     }
+                } else {
+                    0
+                }
+            } else if calculate_file_hashes {
+                get_file_contents_hash(&str_path).unwrap_or(0)
+            } else {
+                0
+            };
+
+            self.file_hashes_and_times
+                .insert(interned_file_path, (file_hash, updated_time));
+
+            files_to_scan.push(str_path.clone());
+
+            if !extension.eq("hhi") {
+                if matches!(config.graph_kind, GraphKind::WholeProgram(_)) {
+                    if config.allow_taints_in_file(&str_path) {
+                        files_to_analyze.push(str_path.clone());
+                    }
+                } else {
+                    files_to_analyze.push(str_path.clone());
                 }
             }
         }

--- a/src/orchestrator/populator.rs
+++ b/src/orchestrator/populator.rs
@@ -270,12 +270,12 @@ fn populate_functionlike_storage(
 
     storage.is_populated = true;
 
-    if !storage.user_defined && !storage.is_closure {
-        if let ReferenceSource::Symbol(true, function_id) = reference_source {
-            if let Some(banned_message) = config.banned_builtin_functions.get(function_id) {
-                storage.banned_function_message = Some(*banned_message);
-            }
-        }
+    if !storage.user_defined
+        && !storage.is_closure
+        && let ReferenceSource::Symbol(true, function_id) = reference_source
+        && let Some(banned_message) = config.banned_builtin_functions.get(function_id)
+    {
+        storage.banned_function_message = Some(*banned_message);
     }
 
     for attribute_info in &storage.attributes {
@@ -470,10 +470,10 @@ fn populate_classlike_storage(
                 .functionlike_infos
                 .get_mut(&(storage.name, *method_name))
                 .unwrap();
-            if let Some(method_storage) = &functionlike_storage.method_info {
-                if !method_storage.is_static {
-                    functionlike_storage.specialize_call = true;
-                }
+            if let Some(method_storage) = &functionlike_storage.method_info
+                && !method_storage.is_static
+            {
+                functionlike_storage.specialize_call = true;
             }
         }
     }
@@ -786,18 +786,17 @@ fn inherit_methods_from_parent(
 
         // A trait method may override an existing method inherited from a parent class
         // (but thankfully not from an earlier trait as that's a type error)
-        if storage.declaring_method_ids.contains_key(method_name) {
-            if !matches!(parent_storage.kind, SymbolKind::Trait)
+        if storage.declaring_method_ids.contains_key(method_name)
+            && (!matches!(parent_storage.kind, SymbolKind::Trait)
                 || codebase
                     .classlike_infos
                     .get(declaring_class)
                     .map(|declaring_classlike_storage| {
                         !matches!(declaring_classlike_storage.kind, SymbolKind::Trait)
                     })
-                    .unwrap_or(true)
-            {
-                continue;
-            }
+                    .unwrap_or(true))
+        {
+            continue;
         }
 
         storage
@@ -829,15 +828,14 @@ fn inherit_properties_from_parent(storage: &mut ClassLikeInfo, parent_storage: &
             continue;
         }
 
-        if !matches!(parent_storage.kind, SymbolKind::Trait) {
-            if let Some(parent_property_storage) = parent_storage.properties.get(property_name) {
-                if matches!(
-                    parent_property_storage.visibility,
-                    MemberVisibility::Private
-                ) {
-                    continue;
-                }
-            }
+        if !matches!(parent_storage.kind, SymbolKind::Trait)
+            && let Some(parent_property_storage) = parent_storage.properties.get(property_name)
+            && matches!(
+                parent_property_storage.visibility,
+                MemberVisibility::Private
+            )
+        {
+            continue;
         }
 
         let is_trait = matches!(storage.kind, SymbolKind::Trait);
@@ -861,15 +859,14 @@ fn inherit_properties_from_parent(storage: &mut ClassLikeInfo, parent_storage: &
             continue;
         }
 
-        if !matches!(parent_storage.kind, SymbolKind::Trait) {
-            if let Some(parent_property_storage) = parent_storage.properties.get(property_name) {
-                if matches!(
-                    parent_property_storage.visibility,
-                    MemberVisibility::Private
-                ) {
-                    continue;
-                }
-            }
+        if !matches!(parent_storage.kind, SymbolKind::Trait)
+            && let Some(parent_property_storage) = parent_storage.properties.get(property_name)
+            && matches!(
+                parent_property_storage.visibility,
+                MemberVisibility::Private
+            )
+        {
+            continue;
         }
 
         storage
@@ -880,13 +877,13 @@ fn inherit_properties_from_parent(storage: &mut ClassLikeInfo, parent_storage: &
     // register inheritance
     for (property_name, inheritable_classlike) in &parent_storage.inheritable_property_ids {
         if !matches!(parent_storage.kind, SymbolKind::Trait) {
-            if let Some(parent_property_storage) = parent_storage.properties.get(property_name) {
-                if matches!(
+            if let Some(parent_property_storage) = parent_storage.properties.get(property_name)
+                && matches!(
                     parent_property_storage.visibility,
                     MemberVisibility::Private
-                ) {
-                    continue;
-                }
+                )
+            {
+                continue;
             }
 
             storage
@@ -906,14 +903,10 @@ fn extend_template_params(storage: &mut ClassLikeInfo, parent_storage: &ClassLik
     if !parent_storage.template_types.is_empty() {
         // Only initialize if not already populated from a more specific source
         // (e.g., from a subclass that already resolved the type params through traits)
-        if !storage
+        storage
             .template_extended_params
-            .contains_key(&parent_storage.name)
-        {
-            storage
-                .template_extended_params
-                .insert(parent_storage.name, IndexMap::new());
-        }
+            .entry(parent_storage.name)
+            .or_insert_with(IndexMap::new);
 
         if let Some(parent_offsets) = storage.template_extended_offsets.get(&parent_storage.name) {
             for (i, extended_type) in parent_offsets.iter().enumerate() {
@@ -977,13 +970,11 @@ fn extend_type(
             param_name,
             ..
         }) = &atomic_type
+            && let Some(ex) = template_extended_params.get(defining_entity)
+            && let Some(referenced_type) = ex.get(param_name)
         {
-            if let Some(ex) = template_extended_params.get(defining_entity) {
-                if let Some(referenced_type) = ex.get(param_name) {
-                    extended_types.extend(referenced_type.types.clone());
-                    continue;
-                }
-            }
+            extended_types.extend(referenced_type.types.clone());
+            continue;
         }
 
         extended_types.push(atomic_type);

--- a/src/orchestrator/scanner.rs
+++ b/src/orchestrator/scanner.rs
@@ -116,19 +116,20 @@ pub fn scan_files(
         resolved_names = FxHashMap::default();
     }
 
-    if existing_file_system.is_none() && use_codebase_cache {
-        if let Some(cache_dir) = cache_dir {
-            existing_file_system = get_file_manifest(cache_dir);
-        };
-    }
+    if existing_file_system.is_none()
+        && use_codebase_cache
+        && let Some(cache_dir) = cache_dir
+    {
+        existing_file_system = get_file_manifest(cache_dir);
+    };
 
     let file_discovery_now = Instant::now();
     let load_from_cache_now = Instant::now();
 
-    if let Some(symbols_path) = &symbols_path {
-        if let Some(cached_interner) = load_cached_interner(symbols_path, use_codebase_cache) {
-            interner = cached_interner;
-        }
+    if let Some(symbols_path) = &symbols_path
+        && let Some(cached_interner) = load_cached_interner(symbols_path, use_codebase_cache)
+    {
+        interner = cached_interner;
     }
 
     let file_system = if let Some(language_server_changes) = language_server_changes {
@@ -170,21 +171,19 @@ pub fn scan_files(
         .collect::<FxHashSet<_>>();
 
     // this needs to come after we've loaded interned strings
-    if !has_starter {
-        if let Some(codebase_path) = &codebase_path {
-            if let Some(cache_codebase) = load_cached_codebase(codebase_path, use_codebase_cache) {
-                codebase = cache_codebase;
-            }
-        }
+    if !has_starter
+        && let Some(codebase_path) = &codebase_path
+        && let Some(cache_codebase) = load_cached_codebase(codebase_path, use_codebase_cache)
+    {
+        codebase = cache_codebase;
     }
 
-    if let Some(aast_names_path) = &aast_names_path {
-        if let Some(cached_resolved_names) =
+    if let Some(aast_names_path) = &aast_names_path
+        && let Some(cached_resolved_names) =
             load_cached_aast_names(aast_names_path, use_codebase_cache)
-        {
-            resolved_names = cached_resolved_names
-        };
-    }
+    {
+        resolved_names = cached_resolved_names
+    };
 
     let load_from_cache_elapsed = load_from_cache_now.elapsed();
 
@@ -224,13 +223,13 @@ pub fn scan_files(
         let mut codebase_diff = get_diff(&codebase.files, &codebase.files);
 
         for (target_file, status) in &file_statuses {
-            if let FileStatus::Deleted = status {
-                if let Some(deleted_file_info) = existing_changed_files.get(target_file) {
-                    for node in &deleted_file_info.ast_nodes {
-                        codebase_diff
-                            .add_or_delete
-                            .insert((node.name, StrId::EMPTY));
-                    }
+            if let FileStatus::Deleted = status
+                && let Some(deleted_file_info) = existing_changed_files.get(target_file)
+            {
+                for node in &deleted_file_info.ast_nodes {
+                    codebase_diff
+                        .add_or_delete
+                        .insert((node.name, StrId::EMPTY));
                 }
             }
         }

--- a/src/orchestrator/unused_symbols.rs
+++ b/src/orchestrator/unused_symbols.rs
@@ -64,7 +64,7 @@ pub(crate) fn find_unused_definitions(
         return;
     }
 
-    check_enum_exclusivity(analysis_result, codebase, interner, &config);
+    check_enum_exclusivity(analysis_result, codebase, interner, config);
 
     let referenced_symbols_and_members = analysis_result.symbol_references.back_references();
     let mut test_symbols = codebase
@@ -370,10 +370,10 @@ pub(crate) fn find_unused_definitions(
                             && matches!(method_storage.visibility, MemberVisibility::Private)
                         {
                             let stmt_pos = &functionlike_storage.def_location;
-                            if let Some(name_pos) = &functionlike_storage.name_location {
-                                if stmt_pos.end_line - name_pos.start_line <= 1 {
-                                    continue;
-                                }
+                            if let Some(name_pos) = &functionlike_storage.name_location
+                                && stmt_pos.end_line - name_pos.start_line <= 1
+                            {
+                                continue;
                             }
                         }
 
@@ -522,10 +522,10 @@ pub(crate) fn find_unused_definitions(
                     if !referenced_symbols_and_members.contains(&pair)
                         && !referenced_overridden_class_members.contains(&pair)
                     {
-                        if let Some(suppressed_issues) = &property_storage.suppressed_issues {
-                            if suppressed_issues.contains_key(&IssueKind::UnusedPrivateProperty) {
-                                continue;
-                            }
+                        if let Some(suppressed_issues) = &property_storage.suppressed_issues
+                            && suppressed_issues.contains_key(&IssueKind::UnusedPrivateProperty)
+                        {
+                            continue;
                         }
 
                         let issue =
@@ -676,7 +676,7 @@ fn add_service_calls_attributes(
     // Get all services that are referenced in CallsService and IndirectlyCallsService attributes
     let mut all_services = FxHashSet::default();
 
-    for (_, functionlike_info) in &codebase.functionlike_infos {
+    for functionlike_info in codebase.functionlike_infos.values() {
         for service in &functionlike_info.service_calls {
             all_services.insert(service.clone());
         }
@@ -712,8 +712,8 @@ fn add_service_calls_attributes(
                 let back_refs = back_refs
                     .iter()
                     .filter(|k| {
-                        !all_service_callers.contains(&k)
-                            && match codebase.functionlike_infos.get(&k) {
+                        !all_service_callers.contains(k)
+                            && match codebase.functionlike_infos.get(k) {
                                 Some(functionlike_info) => {
                                     functionlike_info.is_production_code
                                         && !functionlike_info.generated
@@ -721,7 +721,7 @@ fn add_service_calls_attributes(
                                 None => false,
                             }
                     })
-                    .map(|k| *k)
+                    .copied()
                     .collect::<FxHashSet<_>>();
                 next_new_caller_ids.extend(back_refs.clone());
                 all_service_callers.extend(back_refs);
@@ -840,15 +840,15 @@ fn is_method_referenced_somewhere_else(
         &codebase.symbols,
         &codebase.all_classlike_descendants,
     ) {
-        if let Some(trait_user_classlike_info) = codebase.classlike_infos.get(&trait_user) {
-            if has_upstream_method_call(
+        if let Some(trait_user_classlike_info) = codebase.classlike_infos.get(&trait_user)
+            && has_upstream_method_call(
                 trait_user_classlike_info,
                 method_name_ptr,
                 referenced_symbols_and_members,
                 codebase,
-            ) {
-                return true;
-            }
+            )
+        {
+            return true;
         }
     }
 
@@ -887,16 +887,16 @@ fn get_trait_users(
 ) -> FxHashSet<StrId> {
     let mut base_set = FxHashSet::default();
 
-    if let Some(SymbolKind::Trait) = symbols.all.get(classlike_name) {
-        if let Some(trait_users) = all_classlike_descendants.get(classlike_name) {
-            base_set.extend(trait_users);
-            for classlike_descendant in trait_users {
-                base_set.extend(get_trait_users(
-                    classlike_descendant,
-                    symbols,
-                    all_classlike_descendants,
-                ));
-            }
+    if let Some(SymbolKind::Trait) = symbols.all.get(classlike_name)
+        && let Some(trait_users) = all_classlike_descendants.get(classlike_name)
+    {
+        base_set.extend(trait_users);
+        for classlike_descendant in trait_users {
+            base_set.extend(get_trait_users(
+                classlike_descendant,
+                symbols,
+                all_classlike_descendants,
+            ));
         }
     }
 
@@ -932,34 +932,28 @@ fn check_enum_exclusivity(
                     if let hakana_code_info::t_atomic::TAtomic::TEnum {
                         name: enum_name, ..
                     } = atomic_type
+                        && let Some(enum_info) = codebase.classlike_infos.get(enum_name)
+                        && matches!(
+                            enum_info.kind,
+                            hakana_code_info::codebase_info::symbols::SymbolKind::Enum
+                        )
                     {
-                        if let Some(enum_info) = codebase.classlike_infos.get(enum_name) {
-                            if matches!(
-                                enum_info.kind,
-                                hakana_code_info::codebase_info::symbols::SymbolKind::Enum
-                            ) {
-                                // Check if the constant allows non-exclusive enum values
-                                if const_info.allow_non_exclusive_enum_values {
-                                    // This constant explicitly allows non-exclusive values, skip checks
-                                    continue;
-                                }
-
-                                if const_info
-                                    .suppressed_issues
-                                    .iter()
-                                    .any(|(issue, _)| issue == &IssueKind::ExclusiveEnumValueReused)
-                                {
-                                    continue;
-                                }
-
-                                // Track this for exclusivity checking (we already know it has the exclusive attribute)
-                                abstract_enum_constants.insert((
-                                    *enum_name,
-                                    *class_name,
-                                    *const_name,
-                                ));
-                            }
+                        // Check if the constant allows non-exclusive enum values
+                        if const_info.allow_non_exclusive_enum_values {
+                            // This constant explicitly allows non-exclusive values, skip checks
+                            continue;
                         }
+
+                        if const_info
+                            .suppressed_issues
+                            .iter()
+                            .any(|(issue, _)| issue == &IssueKind::ExclusiveEnumValueReused)
+                        {
+                            continue;
+                        }
+
+                        // Track this for exclusivity checking (we already know it has the exclusive attribute)
+                        abstract_enum_constants.insert((*enum_name, *class_name, *const_name));
                     }
                 }
             }
@@ -997,20 +991,18 @@ fn check_enum_exclusivity(
                     continue;
                 }
 
-                if let Some(inferred_type) = &const_info.inferred_type {
-                    if let hakana_code_info::t_atomic::TAtomic::TEnumLiteralCase {
+                if let Some(inferred_type) = &const_info.inferred_type
+                    && let hakana_code_info::t_atomic::TAtomic::TEnumLiteralCase {
                         enum_name: literal_enum_name,
                         member_name,
                         ..
                     } = inferred_type
-                    {
-                        if *literal_enum_name == enum_name {
-                            implementations
-                                .entry(*member_name)
-                                .or_default()
-                                .push((*class_name, const_info.pos));
-                        }
-                    }
+                    && *literal_enum_name == enum_name
+                {
+                    implementations
+                        .entry(*member_name)
+                        .or_default()
+                        .push((*class_name, const_info.pos));
                 }
             }
         }

--- a/src/orchestrator/wasm.rs
+++ b/src/orchestrator/wasm.rs
@@ -185,10 +185,7 @@ pub fn scan_single_file(
     path: String,
     file_contents: String,
 ) -> std::result::Result<FxHashMap<u32, StrId>, ParserError> {
-    let aast = match get_aast_for_path_and_contents(FilePath(StrId::EMPTY), &path, file_contents) {
-        Ok(aast) => aast,
-        Err(err) => return Err(err),
-    };
+    let aast = get_aast_for_path_and_contents(FilePath(StrId::EMPTY), &path, file_contents)?;
 
     let file_path = FilePath(interner.intern(path.clone()));
 

--- a/src/protocol/serialize.rs
+++ b/src/protocol/serialize.rs
@@ -1032,7 +1032,7 @@ pub async fn read_message<R: tokio::io::AsyncRead + Unpin>(
     reader
         .read_exact(&mut len_buf)
         .await
-        .map_err(|e| ProtocolError::Io(e))?;
+        .map_err(ProtocolError::Io)?;
     let len = u32::from_le_bytes(len_buf);
 
     if len > MAX_MESSAGE_SIZE {
@@ -1043,7 +1043,7 @@ pub async fn read_message<R: tokio::io::AsyncRead + Unpin>(
     reader
         .read_exact(&mut frame)
         .await
-        .map_err(|e| ProtocolError::Io(e))?;
+        .map_err(ProtocolError::Io)?;
 
     if frame.is_empty() {
         return Err(ProtocolError::UnexpectedEof);
@@ -1061,11 +1061,8 @@ pub async fn write_message<W: tokio::io::AsyncWrite + Unpin>(
     msg: &Message,
 ) -> Result<(), ProtocolError> {
     let frame = encode_message(msg);
-    writer
-        .write_all(&frame)
-        .await
-        .map_err(|e| ProtocolError::Io(e))?;
-    writer.flush().await.map_err(|e| ProtocolError::Io(e))?;
+    writer.write_all(&frame).await.map_err(ProtocolError::Io)?;
+    writer.flush().await.map_err(ProtocolError::Io)?;
     Ok(())
 }
 

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -112,21 +112,20 @@ impl RequestHandler {
                 }
             }
 
-            if let Some((classlike_name, member_name)) = best_match {
-                if let Some(pos) = scan_data
+            if let Some((classlike_name, member_name)) = best_match
+                && let Some(pos) = scan_data
                     .codebase
                     .get_symbol_pos(classlike_name, member_name)
-                {
-                    let def_file_path = scan_data.interner.lookup(&pos.file_path.0);
-                    return Message::GotoDefinitionResult(GotoDefinitionResponse {
-                        found: true,
-                        file_path: Some(def_file_path.to_string()),
-                        start_line: Some(pos.start_line),
-                        start_column: Some(pos.start_column),
-                        end_line: Some(pos.end_line),
-                        end_column: Some(pos.end_column),
-                    });
-                }
+            {
+                let def_file_path = scan_data.interner.lookup(&pos.file_path.0);
+                return Message::GotoDefinitionResult(GotoDefinitionResponse {
+                    found: true,
+                    file_path: Some(def_file_path.to_string()),
+                    start_line: Some(pos.start_line),
+                    start_column: Some(pos.start_column),
+                    end_line: Some(pos.end_line),
+                    end_column: Some(pos.end_column),
+                });
             }
         }
 
@@ -267,7 +266,7 @@ impl RequestHandler {
                     .analysis_data
                     .as_ref()
                     .filter(|_| !state.is_analysis_in_progress())
-                    .map(|r| r.clone())
+                    .cloned()
             };
 
             if let Some(analysis_result) = analysis_result {
@@ -315,10 +314,10 @@ impl RequestHandler {
             let file_path_str =
                 file_path.get_relative_path(&scan_data.interner, &self.config.root_dir);
 
-            if let Some(ref filter) = req.filter {
-                if !file_path_str.starts_with(filter) {
-                    continue;
-                }
+            if let Some(ref filter) = req.filter
+                && !file_path_str.starts_with(filter)
+            {
+                continue;
             }
 
             for issue in file_issues {
@@ -330,7 +329,7 @@ impl RequestHandler {
 
         let state = self.state.lock().unwrap();
 
-        return Message::GetIssuesResult(GetIssuesResponse {
+        Message::GetIssuesResult(GetIssuesResponse {
             analysis_complete: true,
             issues,
             files_scanned: state.files_scanned(),
@@ -338,7 +337,7 @@ impl RequestHandler {
             files_analyzed: state.files_analyzed(),
             total_files_to_analyze: state.total_files_to_analyze(),
             phase: "Complete".to_string(),
-        });
+        })
     }
 
     pub fn handle_file_changed(&self, changes: Vec<hakana_protocol::FileChange>) -> Message {

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -290,21 +290,21 @@ impl Server {
 
         if let Some(config_path) = &self.config.config_path {
             let path = Path::new(config_path);
-            if path.exists() {
-                if let Ok(json_config) = json_config::read_from_file(path) {
-                    let ignore_files: Vec<String> = json_config
-                        .ignore_files
-                        .into_iter()
-                        .map(|v| format!("{}/{}", self.config.root_dir, v))
-                        .collect();
-                    if !ignore_files.is_empty() {
-                        info!(
-                            "Watchman will ignore {} path pattern(s)",
-                            ignore_files.len()
-                        );
-                    }
-                    return ignore_files;
+            if path.exists()
+                && let Ok(json_config) = json_config::read_from_file(path)
+            {
+                let ignore_files: Vec<String> = json_config
+                    .ignore_files
+                    .into_iter()
+                    .map(|v| format!("{}/{}", self.config.root_dir, v))
+                    .collect();
+                if !ignore_files.is_empty() {
+                    info!(
+                        "Watchman will ignore {} path pattern(s)",
+                        ignore_files.len()
+                    );
                 }
+                return ignore_files;
             }
         }
         Vec::new()

--- a/src/server/watchman.rs
+++ b/src/server/watchman.rs
@@ -94,7 +94,7 @@ async fn run_subscription(
     log::info!("Connected to watchman, resolving root...");
 
     let canonical_path =
-        CanonicalPath::canonicalize(&root_dir).map_err(watchman_client::Error::ConnectionError)?;
+        CanonicalPath::canonicalize(root_dir).map_err(watchman_client::Error::ConnectionError)?;
 
     let resolved = watchman.resolve_root(canonical_path).await?;
 
@@ -118,7 +118,7 @@ async fn run_subscription(
         log::info!("Watching config file: {:?}", rel_path);
     }
 
-    let expression = build_expression(&ignore_files, &project_root, config_relative_path.as_ref());
+    let expression = build_expression(ignore_files, &project_root, config_relative_path.as_ref());
 
     let subscribe_request = SubscribeRequest {
         since: last_clock.take(),
@@ -147,7 +147,7 @@ async fn run_subscription(
             &project_root,
             last_clock,
             &config_relative_path,
-            &tx,
+            tx,
             subscription.next().await,
         )
         .await
@@ -198,12 +198,12 @@ async fn handle_subscription_event(
                     let file_path = project_root.join(&file_name);
                     let file_path_str = file_path.to_string_lossy().to_string();
 
-                    if let Some(config_rel) = config_relative_path {
-                        if Path::new(&file_name) == config_rel.as_path() {
-                            log::info!("Config file changed: {:?}", file_name);
-                            config_changed = true;
-                            continue;
-                        }
+                    if let Some(config_rel) = config_relative_path
+                        && Path::new(&file_name) == config_rel.as_path()
+                    {
+                        log::info!("Config file changed: {:?}", file_name);
+                        config_changed = true;
+                        continue;
                     }
 
                     // For existing files, treat all as Modified —
@@ -213,15 +213,13 @@ async fn handle_subscription_event(
                             continue;
                         }
                         FileStatus::Modified(0, 0)
+                    } else if file_path_str.ends_with(".hack")
+                        || file_path_str.ends_with(".php")
+                        || file_path_str.ends_with(".hhi")
+                    {
+                        FileStatus::Deleted
                     } else {
-                        if file_path_str.ends_with(".hack")
-                            || file_path_str.ends_with(".php")
-                            || file_path_str.ends_with(".hhi")
-                        {
-                            FileStatus::Deleted
-                        } else {
-                            FileStatus::DeletedDir
-                        }
+                        FileStatus::DeletedDir
                     };
 
                     if file_path_str.ends_with(".hack")


### PR DESCRIPTION
Run `cargo clippy --fix --allow-dirty --workspace` and reformat.
The nicest thing here is that this automatically hoists nested `if`s into a parent `if let` and viceversa if applicable which reduces nesting appreciably.