### PR TITLE
Replace `&Box<T>` with plain references

### DIFF
--- a/src/analyzer/expr/nameof_analyzer.rs
+++ b/src/analyzer/expr/nameof_analyzer.rs
@@ -13,7 +13,7 @@ pub(crate) fn analyze(
     analysis_data: &mut FunctionAnalysisData,
     context: &BlockContext,
     expr: &aast::Expr<(), ()>,
-    class_id: &Box<aast::ClassId<(), ()>>,
+    class_id: &aast::ClassId<(), ()>,
 ) -> Result<(), AnalysisError> {
     let resolved_nameof_type =
         resolve_class_name(statements_analyzer, analysis_data, context, class_id).ok_or_else(
@@ -37,7 +37,7 @@ fn resolve_class_name(
     statements_analyzer: &StatementsAnalyzer,
     analysis_data: &mut FunctionAnalysisData,
     context: &BlockContext,
-    class_id: &Box<aast::ClassId<(), ()>>,
+    class_id: &aast::ClassId<(), ()>,
 ) -> Option<TAtomic> {
     let resolved_class_id = match &class_id.2 {
         aast::ClassId_::CIreified(id) => get_id_name(

--- a/src/analyzer/expr/xml_analyzer.rs
+++ b/src/analyzer/expr/xml_analyzer.rs
@@ -34,18 +34,18 @@ use super::fetch::atomic_property_fetch_analyzer;
 
 pub(crate) fn analyze(
     context: &mut BlockContext,
-    boxed: &Box<(
+    parts: &(
         ast_defs::Id,
         Vec<aast::XhpAttribute<(), ()>>,
         Vec<aast::Expr<(), ()>>,
-    )>,
+    ),
     pos: &Pos,
     statements_analyzer: &StatementsAnalyzer,
     analysis_data: &mut FunctionAnalysisData,
 ) -> Result<(), AnalysisError> {
     let resolved_names = statements_analyzer.file_analyzer.resolved_names;
     let xhp_class_name =
-        if let Some(resolved_name) = resolved_names.get(&(boxed.0.0.start_offset() as u32)) {
+        if let Some(resolved_name) = resolved_names.get(&(parts.0.0.start_offset() as u32)) {
             resolved_name
         } else {
             return Err(AnalysisError::InternalError(
@@ -66,8 +66,8 @@ pub(crate) fn analyze(
     {
         analysis_data.definition_locations.insert(
             (
-                boxed.0.0.start_offset() as u32,
-                boxed.0.0.end_offset() as u32,
+                parts.0.0.start_offset() as u32,
+                parts.0.0.end_offset() as u32,
             ),
             (*xhp_class_name, StrId::EMPTY),
         );
@@ -80,7 +80,7 @@ pub(crate) fn analyze(
 
     let codebase = statements_analyzer.codebase;
 
-    for attribute in &boxed.1 {
+    for attribute in &parts.1 {
         match attribute {
             aast::XhpAttribute::XhpSimple(xhp_simple) => {
                 let attribute_name = get_attribute_name(
@@ -193,7 +193,7 @@ pub(crate) fn analyze(
         },
     );
 
-    for inner_expr in &boxed.2 {
+    for inner_expr in &parts.2 {
         expression_analyzer::analyze(
             statements_analyzer,
             inner_expr,

--- a/src/analyzer/expression_analyzer.rs
+++ b/src/analyzer/expression_analyzer.rs
@@ -703,17 +703,17 @@ pub(crate) fn find_expr_logic_issues(
 
 fn analyze_function_pointer(
     statements_analyzer: &StatementsAnalyzer,
-    boxed: &Box<(
+    parts: &(
         aast::FunctionPtrId<(), ()>,
         Vec<aast::Targ<()>>,
         oxidized::nast::FunctionPointerSource,
-    )>,
+    ),
     context: &mut BlockContext,
     analysis_data: &mut FunctionAnalysisData,
     expr: &aast::Expr<(), ()>,
 ) -> Result<(), AnalysisError> {
     let codebase = statements_analyzer.codebase;
-    let id = match &boxed.0 {
+    let id = match &parts.0 {
         aast::FunctionPtrId::FPId(id) => FunctionLikeIdentifier::Function({
             let resolved_names = statements_analyzer.file_analyzer.resolved_names;
 


### PR DESCRIPTION
Rust can automatically deref a `Box<T>` to a `&T`. Since from a consumer's perspective it's irrelevant whether `&T` is on the stack or the heap, simplify `&Box<T>` parameters to take just `&T`.