### PR TITLE
Fix some bugs around reified generics inference

### DIFF
--- a/src/code_info/t_atomic.rs
+++ b/src/code_info/t_atomic.rs
@@ -1512,36 +1512,39 @@ impl TAtomic {
 
     pub fn get_intersection_types(&self) -> (Vec<&TAtomic>, Vec<TAtomic>) {
         match self {
-            TAtomic::TObjectIntersection { types } => (types.iter().collect(), vec![]),
-            _ => {
-                if let TAtomic::TGenericParam(TGenericParam { as_type, .. }) = self {
-                    for as_atomic in &as_type.types {
-                        // T1 as T2 as object becomes (T1 as object) & (T2 as object)
+            TAtomic::TObjectIntersection { types } => return (types.iter().collect(), vec![]),
+            TAtomic::TGenericParam(TGenericParam { as_type, .. }) => {
+                for as_atomic in &as_type.types {
+                    // T1 as T2 as object becomes (T1 as object) & (T2 as object)
+                    if let TAtomic::TGenericParam(TGenericParam {
+                        as_type: extends_as_type,
+                        ..
+                    }) = as_atomic
+                    {
+                        let mut new_intersection_types = vec![];
+                        let intersection_types = as_atomic.get_intersection_types();
+                        new_intersection_types.extend(intersection_types.1);
+                        let mut type_part = self.clone();
                         if let TAtomic::TGenericParam(TGenericParam {
-                            as_type: extends_as_type,
-                            ..
-                        }) = as_atomic
+                            ref mut as_type, ..
+                        }) = type_part
                         {
-                            let mut new_intersection_types = vec![];
-                            let intersection_types = as_atomic.get_intersection_types();
-                            new_intersection_types.extend(intersection_types.1);
-                            let mut type_part = self.clone();
-                            if let TAtomic::TGenericParam(TGenericParam {
-                                ref mut as_type, ..
-                            }) = type_part
-                            {
-                                as_type.clone_from(extends_as_type);
-                            }
-                            new_intersection_types.push(type_part);
-
-                            return (intersection_types.0, new_intersection_types);
+                            as_type.clone_from(extends_as_type);
                         }
+                        new_intersection_types.push(type_part);
+
+                        return (intersection_types.0, new_intersection_types);
+                    }
+
+                    if let TAtomic::TNamedObject(..) = as_atomic {
+                        return (vec![], vec![as_atomic.clone()]);
                     }
                 }
-
-                (vec![self], vec![])
             }
+            _ => {}
         }
+
+        (vec![self], vec![])
     }
 
     /// Creates an intersection type from two atomic types.

--- a/tests/inference/ReturnType/reified/input.hack
+++ b/tests/inference/ReturnType/reified/input.hack
@@ -1,0 +1,16 @@
+<<__ConsistentConstruct>>
+abstract class A {}
+
+final class B extends A {}
+
+final class C {}
+
+final class D<<<__Newable>> reify TParam as A> {
+    public function factory(): TParam {
+        return new TParam();
+    }
+
+    public function bad(): TParam {
+        return new C();
+    }
+}

--- a/tests/inference/ReturnType/reified/output.txt
+++ b/tests/inference/ReturnType/reified/output.txt
@@ -1,0 +1,1 @@
+ERROR: InvalidReturnStatement - input.hack:14:16 - The type C does not match the declared return type TParam:D for D::bad

--- a/tests/nopanic/reified/input.hack
+++ b/tests/nopanic/reified/input.hack
@@ -1,0 +1,18 @@
+abstract class A {
+    public static function foo(): string {
+        return "test";
+    }
+
+    public function work(): void {}
+}
+
+final class B<reify TParam as A> {
+    public function run(): void {
+        $t = new TParam();
+        $t->work();
+    }
+
+    public function call(): string {
+        return TParam::foo();
+    }
+}


### PR DESCRIPTION
The Hack parser upgrade revealed we were missing coverage around `new T() / T::foo()` where `T` is a reified generic parameter, so add corresponding tests. Also fix a return type inference bug revealed in doing so.