### PR TITLE
Fix `<<\Hakana\MustUse>>` checks on inherited methods

### DIFF
--- a/src/analyzer/stmt_analyzer.rs
+++ b/src/analyzer/stmt_analyzer.rs
@@ -450,9 +450,17 @@ fn has_unused_must_use(
                         }
                     }
                     FunctionLikeIdentifier::Method(method_class, method_name) => {
+                        // When checking whether the return value of a method must be used,
+                        // ensure we check on the declaring class since the method may be inherited.
                         if let Some(functionlike_info) = codebase
-                            .functionlike_infos
-                            .get(&(method_class, method_name))
+                            .classlike_infos
+                            .get(&method_class)
+                            .and_then(|c| c.declaring_method_ids.get(&method_name))
+                            .and_then(|declaring_class| {
+                                codebase
+                                    .functionlike_infos
+                                    .get(&(*declaring_class, method_name))
+                            })
                         {
                             return if functionlike_info.must_use {
                                 Some(IssueKind::UnusedMethodCall)

--- a/tests/unused/UnusedExpression/unusedMustUseTrait/input.hack
+++ b/tests/unused/UnusedExpression/unusedMustUseTrait/input.hack
@@ -1,0 +1,46 @@
+final class RootEg {
+	<<\Hakana\MustUse>>
+	public static function apiList(): ApiListEg {
+		return new ApiListEg();
+	}
+}
+
+trait ApiMethodTrait {
+	<<\Hakana\MustUse>>
+	public function apiMethod(): ApiMethodEg {
+		return new ApiMethodEg();
+	}
+}
+
+final class ApiListEg {
+	use ApiMethodTrait;
+}
+
+abstract class ApiBuilderEg {
+	<<\Hakana\MustUse>>
+	public final function getOk(): string {
+		return 'ok';
+	}
+}
+
+final class ApiMethodEg extends ApiBuilderEg {
+	<<\Hakana\MustUse>>
+	public function arg(): ApiMethodEg {
+		return $this;
+	}
+
+}
+
+function main(): void {
+
+	RootEg::apiList();
+
+	RootEg::apiList()->apiMethod();
+
+	RootEg::apiList()->apiMethod()->arg();
+
+	RootEg::apiList()->apiMethod()->arg()->getOk();
+
+	RootEg::apiList()->apiMethod()->arg()->arg()->getOk();
+
+}

--- a/tests/unused/UnusedExpression/unusedMustUseTrait/output.txt
+++ b/tests/unused/UnusedExpression/unusedMustUseTrait/output.txt
@@ -1,0 +1,5 @@
+ERROR: UnusedMethodCall - input.hack:36:2 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedMethodCall - input.hack:38:2 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedMethodCall - input.hack:40:2 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedMethodCall - input.hack:42:2 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedMethodCall - input.hack:44:2 - This is annotated with MustUse but the returned value is not used


### PR DESCRIPTION
When checking whether the return value of a method must be used due to it being annotated with `<<\Hakana\MustUse>>`, we were only checking the case where the method is directly defined in the class it's being called on. Fix it so we also correctly consider inherited methods.