### PR TITLE
Fix running `hakana analyze` with `--root`

### DIFF
--- a/src/analyzer/config/mod.rs
+++ b/src/analyzer/config/mod.rs
@@ -101,6 +101,11 @@ impl Config {
         }
     }
 
+    /// Get the root path of the project being analyzed.
+    pub fn root_path(&self) -> &Path {
+        Path::new(&self.root_dir)
+    }
+
     pub fn update_from_file(
         &mut self,
         cwd: &String,

--- a/src/analyzer/expr/include_analyzer.rs
+++ b/src/analyzer/expr/include_analyzer.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use crate::expression_analyzer;
 use crate::function_analysis_data::FunctionAnalysisData;
 use crate::scope::BlockContext;
@@ -56,7 +54,7 @@ pub(crate) fn analyze(
     if let Some(first_arg_type) = analysis_data.get_rc_expr_type(expr.pos()).cloned()
         && let Some(value) = first_arg_type.get_single_literal_string_value()
     {
-        let path = Path::new(&value);
+        let path = statements_analyzer.get_config().root_path().join(&value);
         if !path.exists() {
             analysis_data.maybe_add_issue(
                 Issue::new(

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -130,7 +130,7 @@ pub fn get_subcommand() -> Command<'static> {
 pub async fn handle(
     sub_matches: &clap::ArgMatches,
     all_custom_issues: FxHashSet<String>,
-    root_dir: &str,
+    root_dir: &String,
     mut analysis_hooks: Vec<Box<dyn CustomHook>>,
     config_path: Option<&Path>,
     cwd: &String,
@@ -326,7 +326,7 @@ pub async fn handle(
 
     if config_path.exists() {
         config
-            .update_from_file(cwd, config_path, &mut interner)
+            .update_from_file(root_dir, config_path, &mut interner)
             .ok();
     }
 


### PR DESCRIPTION
It's possible to run `hakana analyze --root <path>` to analyze a project other than the current directory, but this doesn't currently work. Update locations that assume that the current working directory holds the project being analyzed to use the configured root dir instead.