### PR TITLE
Fix name population for function calls using `self`/`static`/`parent`

### DIFF
--- a/src/aast_utils/naming_visitor.rs
+++ b/src/aast_utils/naming_visitor.rs
@@ -152,16 +152,49 @@ impl<'ast> Visitor<'ast> for Scanner<'_> {
         p.recurse(nc, self)
     }
 
-    fn visit_class_id_(
+    fn visit_class_id(
         &mut self,
         nc: &mut NameContext<'ast>,
-        id: &'ast aast::ClassId_<(), ()>,
+        p: &'ast aast::ClassId<(), ()>,
     ) -> Result<(), ()> {
         let was_in_class_id = nc.in_class_id;
 
         nc.in_class_id = true;
 
-        let result = id.recurse(nc, self);
+        let result = match p.2 {
+            aast::ClassId_::CIself | aast::ClassId_::CIstatic => {
+                if let std::collections::hash_map::Entry::Vacant(e) =
+                    self.resolved_names.entry(p.1.start_offset() as u32)
+                {
+                    let name = if matches!(p.2, aast::ClassId_::CIself) {
+                        "self"
+                    } else {
+                        "static"
+                    };
+                    let resolved_name = nc.get_resolved_name(
+                        self.interner,
+                        &name.to_string(),
+                        aast::NsKind::NSClassAndNamespace,
+                        if let Some(symbol_name) = nc.symbol_name {
+                            if let Some(member_name) = nc.member_name {
+                                self.symbol_member_uses
+                                    .entry((symbol_name, member_name))
+                                    .or_default()
+                            } else {
+                                self.symbol_uses.entry(symbol_name).or_default()
+                            }
+                        } else {
+                            &mut self.file_uses
+                        },
+                    );
+
+                    e.insert(resolved_name);
+                }
+
+                Ok(())
+            }
+            _ => p.recurse(nc, self),
+        };
 
         nc.in_class_id = was_in_class_id;
 

--- a/src/analyzer/expr/expression_identifier.rs
+++ b/src/analyzer/expr/expression_identifier.rs
@@ -193,19 +193,12 @@ pub fn get_static_functionlike_id_from_call(
         aast::Expr_::ClassConst(boxed) => {
             let (class_id, rhs_expr) = (&boxed.0, &boxed.1);
 
-            if let aast::ClassId_::CIexpr(lhs_expr) = &class_id.2 {
-                if let aast::Expr_::Id(id) = &lhs_expr.2 {
-                    if let (Some(class_name), Some(method_name)) = (
-                        resolved_names.get(&(id.0.start_offset() as u32)),
-                        interner.get(&rhs_expr.1),
-                    ) {
-                        Some(FunctionLikeIdentifier::Method(*class_name, method_name))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
+            let offset = class_id.1.start_offset() as u32;
+
+            if let Some(class_name) = resolved_names.get(&offset)
+                && let Some(method_name) = interner.get(&rhs_expr.1)
+            {
+                Some(FunctionLikeIdentifier::Method(*class_name, method_name))
             } else {
                 None
             }

--- a/src/analyzer/stmt_analyzer.rs
+++ b/src/analyzer/stmt_analyzer.rs
@@ -292,7 +292,9 @@ fn detect_unused_statement_expressions(
     stmt: &aast::Stmt<(), ()>,
     context: &mut BlockContext,
 ) {
-    if let Some(issue_kind) = has_unused_must_use(boxed, statements_analyzer, analysis_data) {
+    if let Some(issue_kind) =
+        has_unused_must_use(boxed, statements_analyzer, analysis_data, context)
+    {
         analysis_data.maybe_add_issue(
             Issue::new(
                 issue_kind,
@@ -410,6 +412,7 @@ fn has_unused_must_use(
     boxed: &aast::Expr<(), ()>,
     statements_analyzer: &StatementsAnalyzer,
     analysis_data: &mut FunctionAnalysisData,
+    context: &BlockContext,
 ) -> Option<IssueKind> {
     match &boxed.2 {
         aast::Expr_::Call(boxed_call) => {
@@ -431,6 +434,7 @@ fn has_unused_must_use(
                                     arg.to_expr_ref(),
                                     statements_analyzer,
                                     analysis_data,
+                                    context,
                                 );
                                 if has_unused.is_some() {
                                     return has_unused;
@@ -450,11 +454,19 @@ fn has_unused_must_use(
                         }
                     }
                     FunctionLikeIdentifier::Method(method_class, method_name) => {
+                        let resolved_method_class = match method_class {
+                            StrId::SELF | StrId::STATIC => context.function_context.calling_class,
+                            StrId::PARENT => context
+                                .function_context
+                                .calling_class
+                                .and_then(|c| codebase.classlike_infos.get(&c))
+                                .and_then(|c| c.direct_parent_class),
+                            _ => Some(method_class),
+                        };
                         // When checking whether the return value of a method must be used,
                         // ensure we check on the declaring class since the method may be inherited.
-                        if let Some(functionlike_info) = codebase
-                            .classlike_infos
-                            .get(&method_class)
+                        if let Some(functionlike_info) = resolved_method_class
+                            .and_then(|c| codebase.classlike_infos.get(&c))
                             .and_then(|c| c.declaring_method_ids.get(&method_name))
                             .and_then(|declaring_class| {
                                 codebase
@@ -474,7 +486,7 @@ fn has_unused_must_use(
             }
         }
         aast::Expr_::Await(await_expr) | aast::Expr_::Delay(await_expr) => {
-            return has_unused_must_use(await_expr, statements_analyzer, analysis_data);
+            return has_unused_must_use(await_expr, statements_analyzer, analysis_data, context);
         }
         _ => (),
     }

--- a/tests/unused/UnusedExpression/unusedMustUseMethodCall/input.hack
+++ b/tests/unused/UnusedExpression/unusedMustUseMethodCall/input.hack
@@ -1,4 +1,5 @@
-final class UnusedMethodClass {
+<<__Sealed(Child::class)>>
+class UnusedMethodClass {
     <<Hakana\MustUse>>
 	public function getEncodedId(): string {
 		return '';
@@ -7,10 +8,29 @@ final class UnusedMethodClass {
 	public function doWork(): string {
 		return '';
 	}
+
+	<<Hakana\MustUse>>
+	public static function staticMustUse(): string {
+		return '';
+	}
+
+	public function doesNotUse(): void {
+		self::staticMustUse();
+
+		static::staticMustUse();
+	}
+}
+
+final class Child extends UnusedMethodClass {
+	public function childDoesNotUse(): void {
+		parent::getEncodedId();
+	}
 }
 
 function foo(): void {
     $c = new UnusedMethodClass();
     $c->getEncodedId();
     $c->doWork();
+
+	UnusedMethodClass::staticMustUse();
 }

--- a/tests/unused/UnusedExpression/unusedMustUseMethodCall/output.txt
+++ b/tests/unused/UnusedExpression/unusedMustUseMethodCall/output.txt
@@ -1,1 +1,5 @@
-UnusedMethodCall
+ERROR: UnusedMethodCall - input.hack:18:3 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedMethodCall - input.hack:20:3 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedMethodCall - input.hack:26:3 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedMethodCall - input.hack:32:5 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedMethodCall - input.hack:35:2 - This is annotated with MustUse but the returned value is not used


### PR DESCRIPTION
Since the Hack parser update that lowers `self::` to `CIself` rather than a `CIexpr`, this logic has been incorrect, which broke detection of calls to static methods annotated with `<<Hakana\MustUse>>` that did not consume the result. It also seems to have never worked for `parent::`. Expand tests accordingly, fix name population and ensure unused return value detection correctly resolves `self`/`static`/`parent`.