### PR TITLE
Merge UnusedMethodCall into UnusedFunctionCall

### DIFF
--- a/src/analyzer/stmt_analyzer.rs
+++ b/src/analyzer/stmt_analyzer.rs
@@ -463,7 +463,7 @@ fn has_unused_must_use(
                             })
                         {
                             return if functionlike_info.must_use {
-                                Some(IssueKind::UnusedMethodCall)
+                                Some(IssueKind::UnusedFunctionCall)
                             } else {
                                 None
                             };

--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -159,7 +159,6 @@ pub enum IssueKind {
     UnusedInheritedMethod,
     UnusedInoutAssignment,
     UnusedInterface,
-    UnusedMethodCall,
     UnusedParameter,
     UnusedPipeVariable,
     UnusedPrivateMethod,

--- a/tests/unused/UnusedExpression/unusedMethodCallAsync/output.txt
+++ b/tests/unused/UnusedExpression/unusedMethodCallAsync/output.txt
@@ -1,2 +1,2 @@
-ERROR: UnusedMethodCall - input.hack:16:5 - This is annotated with MustUse but the returned value is not used
-ERROR: UnusedMethodCall - input.hack:22:5 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedFunctionCall - input.hack:16:5 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedFunctionCall - input.hack:22:5 - This is annotated with MustUse but the returned value is not used

--- a/tests/unused/UnusedExpression/unusedMustUseMethodCall/output.txt
+++ b/tests/unused/UnusedExpression/unusedMustUseMethodCall/output.txt
@@ -1,1 +1,1 @@
-UnusedMethodCall
+UnusedFunctionCall

--- a/tests/unused/UnusedExpression/unusedMustUseTrait/output.txt
+++ b/tests/unused/UnusedExpression/unusedMustUseTrait/output.txt
@@ -1,5 +1,5 @@
-ERROR: UnusedMethodCall - input.hack:36:2 - This is annotated with MustUse but the returned value is not used
-ERROR: UnusedMethodCall - input.hack:38:2 - This is annotated with MustUse but the returned value is not used
-ERROR: UnusedMethodCall - input.hack:40:2 - This is annotated with MustUse but the returned value is not used
-ERROR: UnusedMethodCall - input.hack:42:2 - This is annotated with MustUse but the returned value is not used
-ERROR: UnusedMethodCall - input.hack:44:2 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedFunctionCall - input.hack:36:2 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedFunctionCall - input.hack:38:2 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedFunctionCall - input.hack:40:2 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedFunctionCall - input.hack:42:2 - This is annotated with MustUse but the returned value is not used
+ERROR: UnusedFunctionCall - input.hack:44:2 - This is annotated with MustUse but the returned value is not used


### PR DESCRIPTION
The distinction between `UnusedMethodCall` and `UnusedFunctionCall` is purely academic. Subsume the former into the latter for simplicity.