### PR TITLE
Fix return type inference for `this` when called via `self::`

### DIFF
--- a/src/analyzer/expr/call/static_call_analyzer.rs
+++ b/src/analyzer/expr/call/static_call_analyzer.rs
@@ -44,7 +44,14 @@ fn resolve_id(
 
             *classlike_name = Some(self_name);
 
-            get_named_object(self_name, None)
+            let classlike_storage = codebase.classlike_infos.get(&self_name).unwrap();
+
+            wrap_atomic(TAtomic::TNamedObject(TNamedObject {
+                name: self_name,
+                type_params: None,
+                is_this: !classlike_storage.is_final,
+                remapped_params: false,
+            }))
         }
         StrId::PARENT => {
             let self_name = if let Some(calling_class) = &context.function_context.calling_class {
@@ -184,7 +191,14 @@ pub(crate) fn analyze(
 
             classlike_name = Some(*self_name);
 
-            get_named_object(*self_name, None)
+            let classlike_storage = codebase.classlike_infos.get(self_name).unwrap();
+
+            wrap_atomic(TAtomic::TNamedObject(TNamedObject {
+                name: *self_name,
+                type_params: None,
+                is_this: !classlike_storage.is_final,
+                remapped_params: false,
+            }))
         }
         _ => {
             panic!("got unexpected expression: {:?}", expr.0.2);

--- a/tests/inference/ReturnType/returnStaticThis/input.hack
+++ b/tests/inference/ReturnType/returnStaticThis/input.hack
@@ -4,6 +4,14 @@ abstract class A {
     public function getThis() : this {
         return $this;
     }
+
+    public static function create(): this {
+        return self::createImpl();
+    }
+
+    private static function createImpl(): this {
+        return new static();
+    }
 }
 
 final class B extends A {


### PR DESCRIPTION
When resolving `self::` in static method calls, set `is_this: true` on the TNamedObject for non-final classes. This matches the existing behavior of `parent::` and `static::` and ensures that a `this` return type from a method called via `self::` correctly propagates as `ClassName&static` rather than collapsing to just `ClassName`.