### PR TITLE
Don't flag direct constructor calls as unused MustUse values

### DIFF
--- a/src/analyzer/stmt_analyzer.rs
+++ b/src/analyzer/stmt_analyzer.rs
@@ -454,6 +454,12 @@ fn has_unused_must_use(
                         }
                     }
                     FunctionLikeIdentifier::Method(method_class, method_name) => {
+                        // A direct constructor call (e.g. parent::__construct()) does not
+                        // return a usable value, so the MustUse attribute does not apply.
+                        if method_name == StrId::CONSTRUCT {
+                            return None;
+                        }
+
                         let resolved_method_class = match method_class {
                             StrId::SELF | StrId::STATIC => context.function_context.calling_class,
                             StrId::PARENT => context

--- a/tests/unused/UnusedExpression/unusedMustUseConstructor/input.hack
+++ b/tests/unused/UnusedExpression/unusedMustUseConstructor/input.hack
@@ -1,0 +1,11 @@
+<<__Sealed(Child::class)>>
+class Base {
+    <<Hakana\MustUse>>
+    public function __construct() {}
+}
+
+final class Child extends Base {
+    public function __construct() {
+        parent::__construct();
+    }
+}


### PR DESCRIPTION
A `parent::__construct()` call to a constructor annotated with `Hakana\MustUse` was falsely reported as UnusedFunctionCall. A direct constructor invocation does not produce a usable return value, so the MustUse attribute should not apply.