### PR TITLE
Add issue and autofix for `preg_match` calls with literal regexes

### DIFF
--- a/src/analyzer/expr/call/function_call_analyzer.rs
+++ b/src/analyzer/expr/call/function_call_analyzer.rs
@@ -506,6 +506,52 @@ pub(crate) fn analyze(
                 }
             }
         }
+        StrId::PREG_MATCH => {
+            // preg_match("literal pattern", $haystack) can be rewritten to the
+            // type-safe Regex\matches($haystack, re"literal pattern").
+            if expr.2.len() == 2 {
+                let first_arg = expr.2[0].to_expr_ref();
+
+                if matches!(first_arg.2, aast::Expr_::String(..)) {
+                    let issue = Issue::new(
+                        IssueKind::PHPStandardLibrary,
+                        "Use HH\\Lib\\Regex\\matches instead of preg_match".to_string(),
+                        statements_analyzer.get_hpos(pos),
+                        &context.function_context.calling_functionlike_id,
+                    );
+
+                    if statements_analyzer.should_autofix(context, analysis_data, &issue) {
+                        let file_contents =
+                            &statements_analyzer.file_analyzer.file_source.file_contents;
+                        let second_arg = expr.2[1].to_expr_ref();
+
+                        // Raw source of the pattern literal with its surrounding
+                        // quotes.
+                        let pattern_src = &file_contents
+                            [first_arg.pos().start_offset()..first_arg.pos().end_offset()];
+
+                        // Raw source of the haystack expression preserves arbitrary
+                        // expressions (variables, calls, etc.) exactly.
+                        let haystack_src = &file_contents
+                            [second_arg.pos().start_offset()..second_arg.pos().end_offset()];
+
+                        analysis_data.add_replacement(
+                            (pos.start_offset() as u32, pos.end_offset() as u32),
+                            Replacement::Substitute(format!(
+                                "\\HH\\Lib\\Regex\\matches({}, re{})",
+                                haystack_src, pattern_src
+                            )),
+                        );
+                    } else {
+                        analysis_data.maybe_add_issue(
+                            issue,
+                            statements_analyzer.get_config(),
+                            statements_analyzer.get_file_path_actual(),
+                        );
+                    }
+                }
+            }
+        }
         StrId::ASIO_JOIN => {
             if context.inside_async {
                 let issue = Issue::new(

--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -162,7 +162,7 @@ pub enum IssueKind {
     VariableDefinedOutsideIf,
 }
 
-static AUTOFIXABLE_ISSUES: [IssueKind; 24] = [
+static AUTOFIXABLE_ISSUES: [IssueKind; 25] = [
     IssueKind::UnusedClass,
     IssueKind::UnusedTypeDefinition,
     IssueKind::UnusedFunction,
@@ -187,6 +187,7 @@ static AUTOFIXABLE_ISSUES: [IssueKind; 24] = [
     IssueKind::NonBoolCondition,
     IssueKind::MissingIndirectServiceCallsAttribute,
     IssueKind::RedundantIssetCheck,
+    IssueKind::PHPStandardLibrary,
 ];
 
 impl IssueKind {

--- a/src/orchestrator/analyzer.rs
+++ b/src/orchestrator/analyzer.rs
@@ -276,7 +276,7 @@ fn analyze_loaded_ast(
         file_path,
         hh_fixmes: &aast.1.fixmes,
         comments: &aast.1.comments,
-        file_contents: if !config.migration_symbols.is_empty() {
+        file_contents: if !config.migration_symbols.is_empty() || !config.issues_to_fix.is_empty() {
             match fs::read_to_string(str_path) {
                 Ok(str_file) => str_file,
                 Err(_) => panic!("Could not read {}", str_path),

--- a/tests/fix/PHPStandardLibrary/pregMatchBasic/input.hack
+++ b/tests/fix/PHPStandardLibrary/pregMatchBasic/input.hack
@@ -1,0 +1,4 @@
+function takes_string(string $haystack): void {
+    preg_match("/^foo$/", $haystack);
+    preg_match('/^foo$/', $haystack);
+}

--- a/tests/fix/PHPStandardLibrary/pregMatchBasic/output.txt
+++ b/tests/fix/PHPStandardLibrary/pregMatchBasic/output.txt
@@ -1,0 +1,4 @@
+function takes_string(string $haystack): void {
+    \HH\Lib\Regex\matches($haystack, re"/^foo$/");
+    \HH\Lib\Regex\matches($haystack, re'/^foo$/');
+}

--- a/tests/fix/PHPStandardLibrary/pregMatchNonLiteralSkipped/input.hack
+++ b/tests/fix/PHPStandardLibrary/pregMatchNonLiteralSkipped/input.hack
@@ -1,0 +1,4 @@
+function takes_string(string $pattern, string $haystack, string $foo): void {
+    preg_match($pattern, $haystack);
+    preg_match("/test{$foo}/", $haystack);
+}

--- a/tests/fix/PHPStandardLibrary/pregMatchNonLiteralSkipped/output.txt
+++ b/tests/fix/PHPStandardLibrary/pregMatchNonLiteralSkipped/output.txt
@@ -1,0 +1,4 @@
+function takes_string(string $pattern, string $haystack, string $foo): void {
+    preg_match($pattern, $haystack);
+    preg_match("/test{$foo}/", $haystack);
+}

--- a/tests/fix/PHPStandardLibrary/pregMatchThreeArgsSkipped/input.hack
+++ b/tests/fix/PHPStandardLibrary/pregMatchThreeArgsSkipped/input.hack
@@ -1,0 +1,3 @@
+function takes_string(string $haystack): void {
+    preg_match_with_matches("/^foo$/", $haystack, inout $matches);
+}

--- a/tests/fix/PHPStandardLibrary/pregMatchThreeArgsSkipped/output.txt
+++ b/tests/fix/PHPStandardLibrary/pregMatchThreeArgsSkipped/output.txt
@@ -1,0 +1,3 @@
+function takes_string(string $haystack): void {
+    preg_match_with_matches("/^foo$/", $haystack, inout $matches);
+}

--- a/tests/inference/FunctionCall/pregMatch/output.txt
+++ b/tests/inference/FunctionCall/pregMatch/output.txt
@@ -1,0 +1,1 @@
+ERROR: PHPStandardLibrary - input.hack:3:10 - Use HH\Lib\Regex\matches instead of preg_match


### PR DESCRIPTION
`preg_match()` is an annoying function for the truthiness migration because it is typed as returning `int` but actually returns `int|false`, i.e. the number of matches or `false` if the pattern wasn't valid. To reduce the amount of time we need to deal with this, raise an issue and implement an autofix for the common case where `preg_match` is called with a literal regex, since this can be converted to use the HSL `Regex\matches` function instead.