### PR TITLE
Add generic plugin_config pass-through from hakana.json

### DIFF
--- a/src/analyzer/config/json_config.rs
+++ b/src/analyzer/config/json_config.rs
@@ -19,6 +19,8 @@ pub struct JsonConfig {
     pub test_files: Vec<String>,
     #[serde(default)]
     pub strict_falsable_types: bool,
+    #[serde(default)]
+    pub plugins: FxHashMap<String, serde_json::Value>,
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/src/analyzer/config/mod.rs
+++ b/src/analyzer/config/mod.rs
@@ -42,6 +42,7 @@ pub struct Config {
     pub cyclomatic_complexity_threshold: u32,
     pub cyclomatic_complexity_file_patterns: Vec<glob::Pattern>,
     pub strict_falsable_types: bool,
+    pub plugin_config: FxHashMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Debug)]
@@ -98,6 +99,7 @@ impl Config {
             cyclomatic_complexity_threshold: 0,
             cyclomatic_complexity_file_patterns: Vec::new(),
             strict_falsable_types: false,
+            plugin_config: FxHashMap::default(),
         }
     }
 
@@ -187,6 +189,8 @@ impl Config {
         self.security_config.max_depth = json_config.security_analysis.max_depth.unwrap_or(40);
 
         self.strict_falsable_types = json_config.strict_falsable_types;
+
+        self.plugin_config = json_config.plugins;
 
         Ok(())
     }

--- a/src/cli/test_runners/config.rs
+++ b/src/cli/test_runners/config.rs
@@ -1,11 +1,14 @@
 use std::{error::Error, fs::File, io::BufReader, path::Path};
 
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Default)]
 pub struct TestConfig {
     pub max_changes_allowed: Option<usize>,
     pub strict_falsable_types: Option<bool>,
+    #[serde(default)]
+    pub plugins: FxHashMap<String, serde_json::Value>,
 }
 
 pub(crate) fn read_from_file(path: &Path) -> Result<TestConfig, Box<dyn Error>> {

--- a/src/cli/test_runners/utils.rs
+++ b/src/cli/test_runners/utils.rs
@@ -45,6 +45,9 @@ pub fn augment_with_local_config(dir: &str, analysis_config: &mut config::Config
         if let Some(strict_falsable_types) = test_config.strict_falsable_types {
             analysis_config.strict_falsable_types = strict_falsable_types;
         }
+        if !test_config.plugins.is_empty() {
+            analysis_config.plugin_config = test_config.plugins;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a small, generic pass-through so downstream plugins can read their own namespaced slice of `hakana.json`.

- `JsonConfig` gains a `plugins: FxHashMap<String, serde_json::Value>` field, deserialized from a top-level `"plugins"` object.
- `Config` carries `plugin_config: FxHashMap<String, serde_json::Value>`, populated in `update_from_file`.
- The test harness (`TestConfig` + `augment_with_local_config`) can supply `plugins` via a per-test `config.json`.

Core stays agnostic about the contents — plugins own their own typing and validation. There is no behavior change to existing analysis; the field is simply available for plugins that opt to read it.

### Motivation

Custom analysis plugins often need configuration data (rule lists, path allowlists, thresholds, and the like). Without a config hook, that data has to be hard-coded in the plugin, so changing it means rebuilding and redistributing the binary. This pass-through lets a plugin source its configuration from the analyzed project's `hakana.json` instead, under a key it owns — keeping plugin-specific schema out of core while letting projects manage the data themselves.

## Testing

- `cargo build --release` — clean.
- `cargo run --bin hakana --release test tests` — existing suite passes; no behavior change (the new field is opt-in and defaults to empty).

## Risks

Minimal. Additive config field with `#[serde(default)]`; absent `plugins` key is a no-op. No existing config or analysis path is modified.
