### PR TITLE
Add `--update-snapshots` flag to `hakana test`

### DIFF
--- a/src/cli/commands/test.rs
+++ b/src/cli/commands/test.rs
@@ -36,6 +36,11 @@ pub fn get_subcommand() -> Command<'static> {
                 .required(false)
                 .help("How many times to repeat the test (useful for profiling)"),
         )
+        .arg(
+            arg!(--"update-snapshots")
+                .required(false)
+                .help("Rewrite expectation files for tests whose output changed"),
+        )
         .arg(arg!(<TEST> "The test to run"))
         .arg_required_else_help(true)
 }
@@ -73,5 +78,6 @@ pub fn handle(
         header,
         repeat,
         random_seed,
+        sub_matches.is_present("update-snapshots"),
     );
 }

--- a/src/cli/test_runners/integration_test.rs
+++ b/src/cli/test_runners/integration_test.rs
@@ -20,57 +20,72 @@ pub struct TestContext<'a> {
     pub hooks_provider: &'a dyn HooksProvider,
 }
 
-/// Outcome of a single integration test execution.
-pub struct TestResult {
-    /// (`"."` pass, `"F"` fail, `"S"` skipped)
-    pub status_char: String,
+/// One snapshot a test produces, together with the rules for verifying it
+/// against — and rewriting — its committed expectation file.
+///
+/// A single test may produce several of these (e.g. `diff` checks both
+/// `output.txt` and `definition_locations.json`, and the linter checks one
+/// snapshot per `.in` file). The runner verifies each and, when
+/// `--update-snapshots` is passed, rewrites the ones that don't match.
+pub trait TestOutput {
+    /// Path to the committed expectation file this output is compared against.
+    /// The runner reports it alongside any failure so multi-snapshot tests make
+    /// clear which file didn't match.
+    fn expect_path(&self) -> String;
+
+    /// `Ok(())` if the actual output matches the committed expectation,
+    /// otherwise `Err(diagnostic)` describing the mismatch.
+    fn verify(&self) -> Result<(), String>;
+
+    /// Rewrite the expectation file with the actual output (for
+    /// `--update-snapshots`). Returns `Err` for outputs that cannot be
+    /// regenerated so the runner still reports
+    /// them as failures even in update mode.
+    fn update(&self) -> Result<(), String>;
+}
+
+/// Artifacts produced by a single integration test execution.
+///
+/// `scan_data`/`analysis_result` are threaded to the next test when codebase
+/// reuse is enabled. `outputs` holds the snapshot comparisons the runner should
+/// verify (empty means there is nothing to compare). `skipped` preserves the
+/// `"S"` status char for skipped tests.
+pub struct TestArtifacts {
     pub scan_data: Option<SuccessfulScanData>,
     pub analysis_result: Option<AnalysisResult>,
     pub time_in_analysis: Duration,
-    pub diagnostic: Option<(String, String)>,
+    pub outputs: Vec<Box<dyn TestOutput>>,
+    pub skipped: bool,
 }
 
-impl TestResult {
-    pub fn pass(
+impl TestArtifacts {
+    /// Artifacts for a regular test with a set of snapshot outputs to verify.
+    pub fn new(
         scan_data: Option<SuccessfulScanData>,
         analysis_result: Option<AnalysisResult>,
         time_in_analysis: Duration,
+        outputs: Vec<Box<dyn TestOutput>>,
     ) -> Self {
-        TestResult {
-            status_char: ".".to_string(),
+        TestArtifacts {
             scan_data,
             analysis_result,
             time_in_analysis,
-            diagnostic: None,
+            outputs,
+            skipped: false,
         }
     }
 
-    pub fn fail(
-        dir: String,
-        diagnostic: String,
-        scan_data: Option<SuccessfulScanData>,
-        analysis_result: Option<AnalysisResult>,
-        time_in_analysis: Duration,
-    ) -> Self {
-        TestResult {
-            status_char: "F".to_string(),
-            scan_data,
-            analysis_result,
-            time_in_analysis,
-            diagnostic: Some((dir, diagnostic)),
-        }
-    }
-
+    /// Artifacts for a skipped test (renders as `"S"`, threads scan data along).
     pub fn skipped(
         scan_data: Option<SuccessfulScanData>,
         analysis_result: Option<AnalysisResult>,
     ) -> Self {
-        TestResult {
-            status_char: "S".to_string(),
+        TestArtifacts {
             scan_data,
             analysis_result,
             time_in_analysis: Duration::default(),
-            diagnostic: None,
+            outputs: vec![],
+            skipped: true,
         }
     }
 }
@@ -81,7 +96,11 @@ impl TestResult {
 /// this trait. The test runner selects the appropriate implementation based
 /// on directory-name conventions and delegates execution via [`IntegrationTest::run`].
 pub trait IntegrationTest {
-    fn run(&self, ctx: TestContext) -> TestResult;
+    /// Run the test, returning its artifacts (snapshots to verify) on success,
+    /// or `Err(diagnostic)` for a hard scan/analysis failure that has no
+    /// snapshot to compare. A hard error always fails the test, even under
+    /// `--update-snapshots`.
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String>;
 }
 
 /// Determine what type of integration test to run for a given directory.

--- a/src/cli/test_runners/mod.rs
+++ b/src/cli/test_runners/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod config;
 pub mod core_test_runner;
 mod integration_test;
+mod outputs;
 pub mod test_runner;
 mod tests;
 pub mod utils;

--- a/src/cli/test_runners/outputs.rs
+++ b/src/cli/test_runners/outputs.rs
@@ -1,0 +1,225 @@
+//! [`TestOutput`] implementations: one per kind of snapshot a test can produce.
+//!
+//! Each type owns the path to its committed expectation file plus the actual
+//! output to compare against it. `verify` reads the expectation lazily and
+//! reports a mismatch; `update` rewrites the expectation with the actual output
+//! (used by `--update-snapshots`).
+
+use std::fs;
+use std::path::Path;
+
+use similar::{ChangeTag, TextDiff};
+
+use crate::test_runners::integration_test::TestOutput;
+
+/// Issue output compared against `<dir>/output.txt` using the fuzzy
+/// (trim-exact, single-line substring) rules in [`compare_issues_to_expected`].
+///
+/// A missing `output.txt` is treated as "expect no issues" — matching the
+/// long-standing behavior of standard analysis tests.
+pub struct IssueSnapshot {
+    pub dir: String,
+    pub actual: Vec<String>,
+}
+
+impl TestOutput for IssueSnapshot {
+    fn expect_path(&self) -> String {
+        format!("{}/output.txt", self.dir)
+    }
+
+    fn verify(&self) -> Result<(), String> {
+        let expected_output_path = self.dir.clone() + "/output.txt";
+        let expected_output = if Path::new(&expected_output_path).exists() {
+            let expected = fs::read_to_string(expected_output_path)
+                .unwrap()
+                .trim()
+                .to_string();
+            Some(expected)
+        } else {
+            None
+        };
+
+        let passed = if let Some(expected_output) = &expected_output {
+            if expected_output == self.actual.join("").trim() {
+                true
+            } else {
+                !expected_output.is_empty()
+                    && self.actual.len() == 1
+                    && expected_output
+                        .as_bytes()
+                        .iter()
+                        .filter(|&&c| c == b'\n')
+                        .count()
+                        == 0
+                    && self.actual.iter().any(|s| s.contains(expected_output))
+            }
+        } else {
+            self.actual.is_empty()
+        };
+
+        if passed {
+            return Ok(());
+        }
+        let diagnostic = if let Some(expected_output) = &expected_output {
+            format_diff(expected_output, &self.actual.join(""))
+        } else {
+            format_diff("", &self.actual.join(""))
+        };
+        Err(diagnostic)
+    }
+
+    fn update(&self) -> Result<(), String> {
+        let contents = self.actual.join("");
+        write_snapshot(&self.expect_path(), contents.trim())
+    }
+}
+
+/// Output compared byte-for-byte against an expectation file. Used for
+/// code-transformation tests where whitespace is significant.
+pub struct ExactSnapshot {
+    pub path: String,
+    pub actual: String,
+}
+
+impl TestOutput for ExactSnapshot {
+    fn expect_path(&self) -> String {
+        self.path.clone()
+    }
+
+    fn verify(&self) -> Result<(), String> {
+        let expected = fs::read_to_string(&self.path).unwrap_or_default();
+        if expected == self.actual {
+            Ok(())
+        } else {
+            Err(format_diff(&expected, &self.actual))
+        }
+    }
+
+    fn update(&self) -> Result<(), String> {
+        write_snapshot(&self.path, &self.actual)
+    }
+}
+
+/// A JSON value compared structurally against an expectation file, with a
+/// pretty-printed diff on mismatch. Used for `definition_locations.json`,
+/// `references.json`, the executable-code-finder, and the linter snapshots.
+///
+/// A missing expectation file is a verification failure: snapshots are only
+/// written under `--update-snapshots`. Tests that expect no output commit an
+/// empty-array (`[]`) expectation file.
+pub struct JsonValueSnapshot {
+    pub path: String,
+    pub actual: serde_json::Value,
+}
+
+impl JsonValueSnapshot {
+    fn pretty(value: &serde_json::Value) -> String {
+        serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+    }
+}
+
+impl TestOutput for JsonValueSnapshot {
+    fn expect_path(&self) -> String {
+        self.path.clone()
+    }
+
+    fn verify(&self) -> Result<(), String> {
+        if !Path::new(&self.path).exists() {
+            return Err(format_diff("", &Self::pretty(&self.actual)));
+        }
+
+        let contents = fs::read_to_string(&self.path).map_err(|e| e.to_string())?;
+        let expected: serde_json::Value = serde_json::from_str(&contents)
+            .map_err(|e| format!("Failed to parse {}: {}", self.path, e))?;
+
+        if expected == self.actual {
+            Ok(())
+        } else {
+            Err(format_diff(
+                &Self::pretty(&expected),
+                &Self::pretty(&self.actual),
+            ))
+        }
+    }
+
+    fn update(&self) -> Result<(), String> {
+        write_snapshot(&self.path, &Self::pretty(&self.actual))
+    }
+}
+
+/// Migration candidates compared as a set against `<dir>/candidates.txt`,
+/// reporting unexpected and missing entries separately.
+pub struct CandidatesSnapshot {
+    pub path: String,
+    pub actual: Vec<String>,
+}
+
+impl TestOutput for CandidatesSnapshot {
+    fn expect_path(&self) -> String {
+        self.path.clone()
+    }
+
+    fn verify(&self) -> Result<(), String> {
+        let expected = fs::read_to_string(&self.path)
+            .unwrap_or_default()
+            .lines()
+            .map(String::from)
+            .collect::<Vec<String>>();
+
+        let missing = expected
+            .iter()
+            .filter(|item| !self.actual.contains(item))
+            .cloned()
+            .collect::<Vec<String>>();
+        let unexpected = self
+            .actual
+            .iter()
+            .filter(|item| !expected.contains(item))
+            .cloned()
+            .collect::<Vec<String>>();
+
+        let mut diagnostics = vec![];
+        if !unexpected.is_empty() {
+            diagnostics.push(format!(
+                "Found unexpected candidates: {}",
+                unexpected.join("\n")
+            ));
+        }
+        if !missing.is_empty() {
+            diagnostics.push(format!(
+                "Missing expected candidates: {}",
+                missing.join("\n")
+            ));
+        }
+
+        if diagnostics.is_empty() {
+            Ok(())
+        } else {
+            Err(diagnostics.join("\n"))
+        }
+    }
+
+    fn update(&self) -> Result<(), String> {
+        write_snapshot(&self.path, &self.actual.join("\n"))
+    }
+}
+
+fn write_snapshot(path: &str, contents: &str) -> Result<(), String> {
+    fs::write(path, contents).map_err(|e| format!("Failed to write {}: {}", path, e))
+}
+
+fn format_diff(expected: &str, actual: &str) -> String {
+    let diff = TextDiff::from_lines(expected, actual);
+    let mut output = String::new();
+
+    for change in diff.iter_all_changes() {
+        let sign = match change.tag() {
+            ChangeTag::Delete => "-",
+            ChangeTag::Insert => "+",
+            ChangeTag::Equal => " ",
+        };
+        output.push_str(&format!("{}{}", sign, change));
+    }
+
+    output
+}

--- a/src/cli/test_runners/test_runner.rs
+++ b/src/cli/test_runners/test_runner.rs
@@ -33,6 +33,7 @@ impl TestRunner {
         build_checksum: &str,
         repeat: u16,
         random_seed: Option<u64>,
+        update_snapshots: bool,
     ) {
         let candidate_test_folders = match get_all_test_folders(test_or_test_dir.clone()) {
             Ok(folders) => folders,
@@ -44,6 +45,7 @@ impl TestRunner {
         };
 
         let mut test_diagnostics = vec![];
+        let mut updated_count = 0usize;
 
         let starter_data =
             if candidate_test_folders.len() > 1 && !test_or_test_dir.ends_with("/diff") {
@@ -100,6 +102,7 @@ impl TestRunner {
                 let cwd = env::current_dir().unwrap().to_str().unwrap().to_string();
 
                 let test = select_test_type(&test_folder);
+                let dir = test_folder.clone();
                 let ctx = TestContext {
                     dir: test_folder,
                     cwd,
@@ -109,24 +112,84 @@ impl TestRunner {
                     previous_analysis_result,
                     hooks_provider: &*self.0,
                 };
-                let result = test.run(ctx);
+                let status_char = match test.run(ctx) {
+                    Err(diagnostic) => {
+                        // A hard scan/analysis error: no snapshot to compare, so
+                        // it always fails — even under --update-snapshots. Drop
+                        // any reusable codebase so the next test starts fresh.
+                        last_scan_data = None;
+                        last_analysis_result = None;
+                        test_diagnostics.push((dir.clone(), diagnostic));
+                        *had_error = true;
+                        "F"
+                    }
+                    Ok(artifacts) => {
+                        time_in_analysis += artifacts.time_in_analysis;
+                        last_scan_data = artifacts.scan_data;
+                        last_analysis_result = artifacts.analysis_result;
 
-                time_in_analysis += result.time_in_analysis;
+                        if artifacts.skipped {
+                            "S"
+                        } else {
+                            let mut failed = false;
+                            let mut updated_this_test = false;
 
-                if let Some(diagnostic) = result.diagnostic {
-                    test_diagnostics.push(diagnostic);
-                    *had_error = true;
-                }
+                            for output in &artifacts.outputs {
+                                if let Err(diagnostic) = output.verify() {
+                                    if update_snapshots {
+                                        match output.update() {
+                                            Ok(()) => {
+                                                updated_count += 1;
+                                                updated_this_test = true;
+                                            }
+                                            Err(e) => {
+                                                test_diagnostics.push((
+                                                    dir.clone(),
+                                                    format!(
+                                                        "=== {} ===\n{}",
+                                                        output.expect_path(),
+                                                        e
+                                                    ),
+                                                ));
+                                                failed = true;
+                                            }
+                                        }
+                                    } else {
+                                        test_diagnostics.push((
+                                            dir.clone(),
+                                            format!(
+                                                "=== {} ===\n{}",
+                                                output.expect_path(),
+                                                diagnostic
+                                            ),
+                                        ));
+                                        failed = true;
+                                    }
+                                }
+                            }
 
-                last_scan_data = result.scan_data;
-                last_analysis_result = result.analysis_result;
+                            if failed {
+                                *had_error = true;
+                                "F"
+                            } else if updated_this_test {
+                                "U"
+                            } else {
+                                "."
+                            }
+                        }
+                    }
+                };
 
-                print!("{}", result.status_char);
+                print!("{}", status_char);
                 io::stdout().flush().unwrap();
             }
         }
 
         println!("\n\nTotal analysis time:  {:.2?}", time_in_analysis);
+
+        if update_snapshots && updated_count > 0 {
+            println!("Updated {} snapshot(s)", updated_count);
+        }
 
         println!(
             "\n{}",

--- a/src/cli/test_runners/tests/code_transform.rs
+++ b/src/cli/test_runners/tests/code_transform.rs
@@ -5,8 +5,9 @@ use rustc_hash::FxHashSet;
 use std::fs;
 use std::sync::Arc;
 
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
-use crate::test_runners::utils::{augment_with_local_config, default_config_for_test, format_diff};
+use crate::test_runners::integration_test::{IntegrationTest, TestArtifacts, TestContext};
+use crate::test_runners::outputs::ExactSnapshot;
+use crate::test_runners::utils::{augment_with_local_config, default_config_for_test};
 
 /// Handles code-transformation tests under `tests/fix/`, `tests/migrations/`,
 /// `tests/add-fixmes/`, and `tests/remove-unused-fixmes/`.
@@ -16,7 +17,7 @@ use crate::test_runners::utils::{augment_with_local_config, default_config_for_t
 pub struct CodeTransformTest;
 
 impl IntegrationTest for CodeTransformTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
         let cwd = &ctx.cwd;
 
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
@@ -61,9 +62,8 @@ impl IntegrationTest for CodeTransformTest {
         let output_file = format!("{}/output.txt", ctx.dir);
         let actual_file = format!("{}/actual.txt", ctx.dir);
         let input_contents = fs::read_to_string(&input_file).unwrap();
-        let expected_output_contents = fs::read_to_string(output_file).unwrap();
 
-        let mut result = result.unwrap();
+        let mut result = result.map_err(|error| error.to_string())?;
 
         let time_in_analysis = result.0.time_in_analysis;
 
@@ -79,18 +79,18 @@ impl IntegrationTest for CodeTransformTest {
             input_contents
         };
 
+        // `actual.txt` is always written as a debugging aid for inspecting the
+        // transform's output regardless of pass/fail.
         fs::write(actual_file, &output_contents).unwrap();
 
-        if output_contents == expected_output_contents {
-            TestResult::pass(Some(result.1), Some(result.0), time_in_analysis)
-        } else {
-            TestResult::fail(
-                ctx.dir,
-                format_diff(&expected_output_contents, &output_contents),
-                Some(result.1),
-                Some(result.0),
-                time_in_analysis,
-            )
-        }
+        Ok(TestArtifacts::new(
+            Some(result.1),
+            Some(result.0),
+            time_in_analysis,
+            vec![Box::new(ExactSnapshot {
+                path: output_file,
+                actual: output_contents,
+            })],
+        ))
     }
 }

--- a/src/cli/test_runners/tests/cyclomatic_complexity.rs
+++ b/src/cli/test_runners/tests/cyclomatic_complexity.rs
@@ -3,10 +3,9 @@ use rustc_hash::FxHashSet;
 
 use std::sync::Arc;
 
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
-use crate::test_runners::utils::{
-    augment_with_local_config, compare_issues_to_expected, default_config_for_test,
-};
+use crate::test_runners::integration_test::{IntegrationTest, TestArtifacts, TestContext};
+use crate::test_runners::outputs::IssueSnapshot;
+use crate::test_runners::utils::{augment_with_local_config, default_config_for_test};
 
 /// Runs cyclomatic complexity analysis on `tests/cyclomatic-complexity/` directories.
 ///
@@ -15,7 +14,7 @@ use crate::test_runners::utils::{
 pub struct CyclomaticComplexityTest;
 
 impl IntegrationTest for CyclomaticComplexityTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
         let cwd = &ctx.cwd;
 
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
@@ -61,27 +60,17 @@ impl IntegrationTest for CyclomaticComplexityTest {
                     .map(|c| c.to_string(&run_data.interner) + "\n")
                     .collect();
 
-                let (passed, diagnostic) = compare_issues_to_expected(&ctx.dir, &output);
-
-                if passed {
-                    TestResult::pass(None, None, time_in_analysis)
-                } else {
-                    TestResult::fail(
-                        ctx.dir,
-                        diagnostic.unwrap_or_default(),
-                        None,
-                        None,
-                        time_in_analysis,
-                    )
-                }
+                Ok(TestArtifacts::new(
+                    None,
+                    None,
+                    time_in_analysis,
+                    vec![Box::new(IssueSnapshot {
+                        dir: ctx.dir,
+                        actual: output,
+                    })],
+                ))
             }
-            Err(error) => TestResult::fail(
-                ctx.dir,
-                error.to_string(),
-                None,
-                None,
-                std::time::Duration::default(),
-            ),
+            Err(error) => Err(error.to_string()),
         }
     }
 }

--- a/src/cli/test_runners/tests/diff.rs
+++ b/src/cli/test_runners/tests/diff.rs
@@ -5,10 +5,13 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
+use crate::test_runners::integration_test::{
+    IntegrationTest, TestArtifacts, TestContext, TestOutput,
+};
+use crate::test_runners::outputs::{IssueSnapshot, JsonValueSnapshot};
 use crate::test_runners::utils::{
-    augment_with_local_config, compare_issues_to_expected, copy_recursively,
-    default_config_for_test, format_diff, generate_definition_locations_json,
+    augment_with_local_config, copy_recursively, default_config_for_test,
+    generate_definition_locations_json,
 };
 
 /// Runs incremental (diff) analysis tests under `tests/diff/`.
@@ -21,7 +24,7 @@ use crate::test_runners::utils::{
 pub struct DiffTest;
 
 impl IntegrationTest for DiffTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
         let cwd = &ctx.cwd;
 
         log::debug!("running test {}", ctx.dir);
@@ -102,13 +105,7 @@ impl IntegrationTest for DiffTest {
                     previous_analysis_result = Some(run_result.0);
                 }
                 Err(error) => {
-                    return TestResult::fail(
-                        ctx.dir,
-                        error.to_string(),
-                        None,
-                        None,
-                        std::time::Duration::default(),
-                    );
+                    return Err(error.to_string());
                 }
             }
         }
@@ -131,42 +128,25 @@ impl IntegrationTest for DiffTest {
         let definition_locations_json =
             generate_definition_locations_json(&analysis_result, &run_data.interner);
         let definition_locations_path = ctx.dir.clone() + "/definition_locations.json";
+        let definition_locations = serde_json::from_str(&definition_locations_json)
+            .map_err(|e| format!("Failed to serialize definition locations: {}", e))?;
 
-        if Path::new(&definition_locations_path).exists() {
-            let expected_definition_locations = fs::read_to_string(&definition_locations_path)
-                .unwrap()
-                .trim()
-                .to_string();
+        let outputs: Vec<Box<dyn TestOutput>> = vec![
+            Box::new(JsonValueSnapshot {
+                path: definition_locations_path,
+                actual: definition_locations,
+            }),
+            Box::new(IssueSnapshot {
+                dir: ctx.dir,
+                actual: test_output,
+            }),
+        ];
 
-            if expected_definition_locations.trim() != definition_locations_json.trim() {
-                return TestResult::fail(
-                    ctx.dir,
-                    format_diff(&expected_definition_locations, &definition_locations_json),
-                    Some(run_data),
-                    Some(analysis_result),
-                    std::time::Duration::default(),
-                );
-            }
-        } else if let Err(e) = fs::write(&definition_locations_path, definition_locations_json) {
-            eprintln!("Warning: Failed to write definition_locations.json: {}", e);
-        }
-
-        let (passed, diagnostic) = compare_issues_to_expected(&ctx.dir, &test_output);
-
-        if passed {
-            TestResult::pass(
-                Some(run_data),
-                Some(analysis_result),
-                std::time::Duration::default(),
-            )
-        } else {
-            TestResult::fail(
-                ctx.dir,
-                diagnostic.unwrap_or_default(),
-                Some(run_data),
-                Some(analysis_result),
-                std::time::Duration::default(),
-            )
-        }
+        Ok(TestArtifacts::new(
+            Some(run_data),
+            Some(analysis_result),
+            std::time::Duration::default(),
+            outputs,
+        ))
     }
 }

--- a/src/cli/test_runners/tests/executable_code_finder.rs
+++ b/src/cli/test_runners/tests/executable_code_finder.rs
@@ -1,11 +1,8 @@
-use executable_finder::ExecutableLines;
-
-use std::fs;
-use std::path::Path;
 use std::sync::Arc;
 
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
-use crate::test_runners::utils::{augment_with_local_config, default_config_for_test, format_diff};
+use crate::test_runners::integration_test::{IntegrationTest, TestArtifacts, TestContext};
+use crate::test_runners::outputs::JsonValueSnapshot;
+use crate::test_runners::utils::{augment_with_local_config, default_config_for_test};
 
 /// Runs the executable-code-finder on `tests/executable-code-finder/` directories.
 ///
@@ -14,57 +11,24 @@ use crate::test_runners::utils::{augment_with_local_config, default_config_for_t
 pub struct ExecutableCodeFinderTest;
 
 impl IntegrationTest for ExecutableCodeFinderTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
         augment_with_local_config(&ctx.dir, &mut analysis_config);
 
         let config = Arc::new(analysis_config);
 
-        match executable_finder::scan_files(&vec![ctx.dir.clone()], None, &config, 1, false) {
-            Ok(test_output) => {
-                let expected_output_path = ctx.dir.clone() + "/output.txt";
-                let expected_output = if Path::new(&expected_output_path).exists() {
-                    let file_contents = fs::read_to_string(expected_output_path)
-                        .unwrap()
-                        .trim()
-                        .to_string();
-                    let j: Vec<ExecutableLines> = serde_json::from_str(&file_contents).unwrap();
-                    Some(j)
-                } else {
-                    None
-                };
-                if let Some(expected_output) = &expected_output {
-                    if test_output == *expected_output {
-                        TestResult::pass(None, None, std::time::Duration::default())
-                    } else {
-                        let expected_output_str =
-                            serde_json::to_string_pretty(&expected_output).unwrap();
-                        let test_output_str = serde_json::to_string_pretty(&test_output).unwrap();
-                        TestResult::fail(
-                            ctx.dir,
-                            format_diff(&expected_output_str, &test_output_str),
-                            None,
-                            None,
-                            std::time::Duration::default(),
-                        )
-                    }
-                } else {
-                    TestResult::fail(
-                        ctx.dir,
-                        "No output.txt found".to_string(),
-                        None,
-                        None,
-                        std::time::Duration::default(),
-                    )
-                }
-            }
-            Err(_) => TestResult::fail(
-                ctx.dir,
-                "executable code finder failed".to_string(),
-                None,
-                None,
-                std::time::Duration::default(),
-            ),
-        }
+        let test_output =
+            executable_finder::scan_files(&vec![ctx.dir.clone()], None, &config, 1, false)
+                .map_err(|_| "executable code finder failed".to_string())?;
+
+        Ok(TestArtifacts::new(
+            None,
+            None,
+            std::time::Duration::default(),
+            vec![Box::new(JsonValueSnapshot {
+                path: ctx.dir.clone() + "/output.txt",
+                actual: serde_json::to_value(&test_output).unwrap(),
+            })],
+        ))
     }
 }

--- a/src/cli/test_runners/tests/goto_definition.rs
+++ b/src/cli/test_runners/tests/goto_definition.rs
@@ -1,22 +1,20 @@
-use std::fs;
-use std::path::Path;
 use std::sync::Arc;
 
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
+use crate::test_runners::integration_test::{IntegrationTest, TestArtifacts, TestContext};
+use crate::test_runners::outputs::JsonValueSnapshot;
 use crate::test_runners::utils::{
-    augment_with_local_config, default_config_for_test, format_diff,
-    generate_definition_locations_json,
+    augment_with_local_config, default_config_for_test, generate_definition_locations_json,
 };
 
 /// Validates go-to-definition results for `tests/goto-definition/` directories.
 ///
 /// Runs analysis with `collect_goto_definition_locations` enabled, then
 /// compares the generated `definition_locations.json` against the expected
-/// snapshot. If no snapshot exists yet, one is written automatically.
+/// snapshot. Run with `--update-snapshots` to (re)generate the snapshot.
 pub struct GotoDefinitionTest;
 
 impl IntegrationTest for GotoDefinitionTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
         augment_with_local_config(&ctx.dir, &mut analysis_config);
 
@@ -38,44 +36,24 @@ impl IntegrationTest for GotoDefinitionTest {
             || {},
         );
 
-        let result = match result {
-            Ok(result) => result,
-            Err(e) => {
-                return TestResult::fail(
-                    ctx.dir,
-                    e.to_string(),
-                    None,
-                    None,
-                    std::time::Duration::default(),
-                );
-            }
-        };
+        let result = result.map_err(|e| e.to_string())?;
 
         let time_in_analysis = result.0.time_in_analysis;
 
         let definition_locations_json =
             generate_definition_locations_json(&result.0, &result.1.interner);
         let definition_locations_path = ctx.dir.clone() + "/definition_locations.json";
+        let actual = serde_json::from_str(&definition_locations_json)
+            .map_err(|e| format!("Failed to serialize definition locations: {}", e))?;
 
-        if Path::new(&definition_locations_path).exists() {
-            let expected_definition_locations = fs::read_to_string(&definition_locations_path)
-                .unwrap()
-                .trim()
-                .to_string();
-
-            if expected_definition_locations.trim() != definition_locations_json.trim() {
-                return TestResult::fail(
-                    ctx.dir,
-                    format_diff(&expected_definition_locations, &definition_locations_json),
-                    Some(result.1),
-                    Some(result.0),
-                    time_in_analysis,
-                );
-            }
-        } else if let Err(e) = fs::write(&definition_locations_path, definition_locations_json) {
-            eprintln!("Warning: Failed to write definition_locations.json: {}", e);
-        }
-
-        TestResult::pass(Some(result.1), Some(result.0), time_in_analysis)
+        Ok(TestArtifacts::new(
+            Some(result.1),
+            Some(result.0),
+            time_in_analysis,
+            vec![Box::new(JsonValueSnapshot {
+                path: definition_locations_path,
+                actual,
+            })],
+        ))
     }
 }

--- a/src/cli/test_runners/tests/linter.rs
+++ b/src/cli/test_runners/tests/linter.rs
@@ -1,8 +1,10 @@
 use std::fs;
 use std::path::Path;
 
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
-use crate::test_runners::utils::format_diff;
+use crate::test_runners::integration_test::{
+    IntegrationTest, TestArtifacts, TestContext, TestOutput,
+};
+use crate::test_runners::outputs::{ExactSnapshot, JsonValueSnapshot};
 
 /// Runs HHAST-style linter tests under `tests/hhast_tests/`.
 ///
@@ -13,17 +15,14 @@ use crate::test_runners::utils::format_diff;
 pub struct LinterTest;
 
 impl IntegrationTest for LinterTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
         let provided_linters = ctx.hooks_provider.get_linters_for_test(&ctx.dir);
 
         if provided_linters.is_empty() {
-            return TestResult::fail(
-                ctx.dir.clone(),
-                format!("No matching linter found for directory: {}", ctx.dir),
-                None,
-                None,
-                std::time::Duration::default(),
-            );
+            return Err(format!(
+                "No matching linter found for directory: {}",
+                ctx.dir
+            ));
         }
 
         let linters: Vec<&dyn hakana_lint::Linter> = provided_linters
@@ -60,13 +59,7 @@ impl IntegrationTest for LinterTest {
             let entries = match fs::read_dir(&ctx.dir) {
                 Ok(entries) => entries,
                 Err(e) => {
-                    return TestResult::fail(
-                        ctx.dir,
-                        format!("Failed to read directory: {}", e),
-                        None,
-                        None,
-                        std::time::Duration::default(),
-                    );
+                    return Err(format!("Failed to read directory: {}", e));
                 }
             };
 
@@ -83,19 +76,13 @@ impl IntegrationTest for LinterTest {
         };
 
         if in_files.is_empty() {
-            return TestResult::fail(
-                ctx.dir,
-                "No .in files found".to_string(),
-                None,
-                None,
-                std::time::Duration::default(),
-            );
+            return Err("No .in files found".to_string());
         }
 
         let mut in_files = in_files;
         in_files.sort();
-        let mut all_passed = true;
-        let mut errors_output = String::new();
+
+        let mut outputs: Vec<Box<dyn TestOutput>> = vec![];
 
         for in_path in in_files {
             let test_name = in_path.file_name().unwrap().to_string_lossy().to_string();
@@ -103,43 +90,20 @@ impl IntegrationTest for LinterTest {
             let input_contents = match fs::read_to_string(&in_path) {
                 Ok(contents) => contents,
                 Err(e) => {
-                    errors_output.push_str(&format!(
-                        "\n=== {} ===\nFailed to read input file: {}\n",
+                    return Err(format!(
+                        "=== {} ===\nFailed to read input file: {}",
                         test_name, e
                     ));
-                    all_passed = false;
-                    continue;
                 }
             };
 
             let expect_path = in_path.to_string_lossy().replace(".in", ".expect");
-            let expected_errors: Vec<serde_json::Value> = if Path::new(&expect_path).exists() {
-                match fs::read_to_string(&expect_path) {
-                    Ok(json_str) => match serde_json::from_str(&json_str) {
-                        Ok(json) => json,
-                        Err(e) => {
-                            errors_output.push_str(&format!(
-                                "\n=== {} ===\nFailed to parse .expect file: {}\n",
-                                test_name, e
-                            ));
-                            all_passed = false;
-                            continue;
-                        }
-                    },
-                    Err(_) => vec![],
-                }
-            } else {
-                vec![]
-            };
 
             let result =
                 match hakana_lint::run_linters(&in_path, &input_contents, &linters, &config) {
                     Ok(r) => r,
                     Err(e) => {
-                        errors_output
-                            .push_str(&format!("\n=== {} ===\nLinter error: {}\n", test_name, e));
-                        all_passed = false;
-                        continue;
+                        return Err(format!("=== {} ===\nLinter error: {}", test_name, e));
                     }
                 };
 
@@ -166,33 +130,14 @@ impl IntegrationTest for LinterTest {
                 })
                 .collect();
 
-            if expected_errors != actual_errors_json {
-                errors_output.push_str(&format!("\n=== {} ===\n", test_name));
-
-                let expected_json_str = serde_json::to_string_pretty(&expected_errors)
-                    .unwrap_or_else(|_| format!("{:?}", expected_errors));
-                let actual_json_str = serde_json::to_string_pretty(&actual_errors_json)
-                    .unwrap_or_else(|_| format!("{:?}", actual_errors_json));
-
-                errors_output.push_str(&format_diff(&expected_json_str, &actual_json_str));
-                all_passed = false;
-            }
+            outputs.push(Box::new(JsonValueSnapshot {
+                path: expect_path,
+                actual: serde_json::Value::Array(actual_errors_json),
+            }));
 
             // Test autofix if .autofix.expect file exists
             let autofix_expect_path = in_path.to_string_lossy().replace(".in", ".autofix.expect");
             if Path::new(&autofix_expect_path).exists() {
-                let expected_autofix = match fs::read_to_string(&autofix_expect_path) {
-                    Ok(content) => content,
-                    Err(e) => {
-                        errors_output.push_str(&format!(
-                            "\n=== {} ===\nFailed to read .autofix.expect file: {}\n",
-                            test_name, e
-                        ));
-                        all_passed = false;
-                        continue;
-                    }
-                };
-
                 let autofix_config = hakana_lint::LintConfig {
                     allow_auto_fix: true,
                     apply_auto_fix: true,
@@ -211,12 +156,10 @@ impl IntegrationTest for LinterTest {
                 ) {
                     Ok(r) => r,
                     Err(e) => {
-                        errors_output.push_str(&format!(
-                            "\n=== {} ===\nAutofix linter error: {}\n",
+                        return Err(format!(
+                            "=== {} ===\nAutofix linter error: {}",
                             test_name, e
                         ));
-                        all_passed = false;
-                        continue;
                     }
                 };
 
@@ -224,42 +167,16 @@ impl IntegrationTest for LinterTest {
                     .modified_source
                     .unwrap_or(input_contents.clone());
 
-                if expected_autofix != actual_autofix {
-                    errors_output.push_str(&format!("\n=== {} (autofix) ===\n", test_name));
-                    errors_output.push_str(&format_diff(&expected_autofix, &actual_autofix));
-                    all_passed = false;
-                }
+                outputs.push(Box::new(ExactSnapshot {
+                    path: autofix_expect_path,
+                    actual: actual_autofix,
+                }));
 
                 // Check for file operations if .autofix.files.expect exists
                 let files_expect_path = in_path
                     .to_string_lossy()
                     .replace(".in", ".autofix.files.expect");
                 if Path::new(&files_expect_path).exists() {
-                    let expected_files_json = match fs::read_to_string(&files_expect_path) {
-                        Ok(content) => content,
-                        Err(e) => {
-                            errors_output.push_str(&format!(
-                                "\n=== {} ===\nFailed to read .autofix.files.expect: {}\n",
-                                test_name, e
-                            ));
-                            all_passed = false;
-                            continue;
-                        }
-                    };
-
-                    let expected_files: serde_json::Value =
-                        match serde_json::from_str(&expected_files_json) {
-                            Ok(json) => json,
-                            Err(e) => {
-                                errors_output.push_str(&format!(
-                                    "\n=== {} ===\nFailed to parse .autofix.files.expect: {}\n",
-                                    test_name, e
-                                ));
-                                all_passed = false;
-                                continue;
-                            }
-                        };
-
                     let mut actual_files = serde_json::json!({});
                     for file_op in &autofix_result.file_operations {
                         let file_name = file_op.path.to_string_lossy().to_string();
@@ -268,29 +185,19 @@ impl IntegrationTest for LinterTest {
                         }
                     }
 
-                    if expected_files != actual_files {
-                        errors_output
-                            .push_str(&format!("\n=== {} (autofix files) ===\n", test_name));
-                        errors_output.push_str(&format_diff(
-                            &serde_json::to_string_pretty(&expected_files).unwrap(),
-                            &serde_json::to_string_pretty(&actual_files).unwrap(),
-                        ));
-                        all_passed = false;
-                    }
+                    outputs.push(Box::new(JsonValueSnapshot {
+                        path: files_expect_path,
+                        actual: actual_files,
+                    }));
                 }
             }
         }
 
-        if all_passed {
-            TestResult::pass(None, None, std::time::Duration::default())
-        } else {
-            TestResult::fail(
-                ctx.dir,
-                errors_output,
-                None,
-                None,
-                std::time::Duration::default(),
-            )
-        }
+        Ok(TestArtifacts::new(
+            None,
+            None,
+            std::time::Duration::default(),
+            outputs,
+        ))
     }
 }

--- a/src/cli/test_runners/tests/migration_candidates.rs
+++ b/src/cli/test_runners/tests/migration_candidates.rs
@@ -2,10 +2,10 @@ use hakana_analyzer::custom_hook::CustomHook;
 use hakana_str::Interner;
 use rustc_hash::FxHashSet;
 
-use std::fs;
 use std::sync::Arc;
 
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
+use crate::test_runners::integration_test::{IntegrationTest, TestArtifacts, TestContext};
+use crate::test_runners::outputs::CandidatesSnapshot;
 use crate::test_runners::utils::{augment_with_local_config, default_config_for_test};
 
 /// Validates migration-candidate detection for `tests/migration-candidates/` directories.
@@ -16,7 +16,7 @@ use crate::test_runners::utils::{augment_with_local_config, default_config_for_t
 pub struct MigrationCandidatesTest;
 
 impl IntegrationTest for MigrationCandidatesTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
         let cwd = &ctx.cwd;
 
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
@@ -57,14 +57,7 @@ impl IntegrationTest for MigrationCandidatesTest {
             || {},
         );
 
-        let candidates_file = format!("{}/candidates.txt", ctx.dir);
-        let expected_candidates = fs::read_to_string(candidates_file)
-            .unwrap()
-            .lines()
-            .map(String::from)
-            .collect::<Vec<String>>();
-
-        let result = result.unwrap();
+        let result = result.map_err(|error| error.to_string())?;
 
         let time_in_analysis = result.0.time_in_analysis;
 
@@ -77,41 +70,16 @@ impl IntegrationTest for MigrationCandidatesTest {
             }
         }
 
-        let missing_candidates = expected_candidates
-            .iter()
-            .filter(|item| !migration_candidates.contains(item))
-            .cloned()
-            .collect::<Vec<String>>();
-        let unexpected_candidates = migration_candidates
-            .iter()
-            .filter(|item| !expected_candidates.contains(item))
-            .cloned()
-            .collect::<Vec<String>>();
+        let candidates_file = format!("{}/candidates.txt", ctx.dir);
 
-        let mut diagnostics = vec![];
-        if !unexpected_candidates.is_empty() {
-            diagnostics.push(format!(
-                "Found unexpected candidates: {}",
-                unexpected_candidates.join("\n")
-            ));
-        }
-        if !missing_candidates.is_empty() {
-            diagnostics.push(format!(
-                "Missing expected candidates: {}",
-                missing_candidates.join("\n")
-            ));
-        }
-
-        if diagnostics.is_empty() {
-            TestResult::pass(Some(result.1), Some(result.0), time_in_analysis)
-        } else {
-            TestResult::fail(
-                ctx.dir,
-                diagnostics.join("\n"),
-                Some(result.1),
-                Some(result.0),
-                time_in_analysis,
-            )
-        }
+        Ok(TestArtifacts::new(
+            Some(result.1),
+            Some(result.0),
+            time_in_analysis,
+            vec![Box::new(CandidatesSnapshot {
+                path: candidates_file,
+                actual: migration_candidates,
+            })],
+        ))
     }
 }

--- a/src/cli/test_runners/tests/references.rs
+++ b/src/cli/test_runners/tests/references.rs
@@ -1,21 +1,20 @@
 use hakana_code_info::symbol_references_utils::generate_references_json;
 
-use std::fs;
-use std::path::Path;
 use std::sync::Arc;
 
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
-use crate::test_runners::utils::{augment_with_local_config, default_config_for_test, format_diff};
+use crate::test_runners::integration_test::{IntegrationTest, TestArtifacts, TestContext};
+use crate::test_runners::outputs::JsonValueSnapshot;
+use crate::test_runners::utils::{augment_with_local_config, default_config_for_test};
 
 /// Validates symbol-reference results for `tests/references/` directories.
 ///
 /// Runs analysis and generates a `references.json` that groups usages by
-/// symbol name, then compares it against the expected snapshot. If no
-/// snapshot exists yet, one is written automatically.
+/// symbol name, then compares it against the expected snapshot. Run with
+/// `--update-snapshots` to (re)generate the snapshot.
 pub struct ReferencesTest;
 
 impl IntegrationTest for ReferencesTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
         augment_with_local_config(&ctx.dir, &mut analysis_config);
 
@@ -37,43 +36,23 @@ impl IntegrationTest for ReferencesTest {
             || {},
         );
 
-        let result = match result {
-            Ok(result) => result,
-            Err(e) => {
-                return TestResult::fail(
-                    ctx.dir,
-                    e.to_string(),
-                    None,
-                    None,
-                    std::time::Duration::default(),
-                );
-            }
-        };
+        let result = result.map_err(|e| e.to_string())?;
 
         let time_in_analysis = result.0.time_in_analysis;
 
         let references_json = generate_references_json(&result.0, &result.1.interner);
         let references_path = ctx.dir.clone() + "/references.json";
+        let actual = serde_json::from_str(&references_json)
+            .map_err(|e| format!("Failed to serialize references: {}", e))?;
 
-        if Path::new(&references_path).exists() {
-            let expected_references = fs::read_to_string(&references_path)
-                .unwrap()
-                .trim()
-                .to_string();
-
-            if expected_references.trim() != references_json.trim() {
-                return TestResult::fail(
-                    ctx.dir,
-                    format_diff(&expected_references, &references_json),
-                    Some(result.1),
-                    Some(result.0),
-                    time_in_analysis,
-                );
-            }
-        } else if let Err(e) = fs::write(&references_path, references_json) {
-            eprintln!("Warning: Failed to write references.json: {}", e);
-        }
-
-        TestResult::pass(Some(result.1), Some(result.0), time_in_analysis)
+        Ok(TestArtifacts::new(
+            Some(result.1),
+            Some(result.0),
+            time_in_analysis,
+            vec![Box::new(JsonValueSnapshot {
+                path: references_path,
+                actual,
+            })],
+        ))
     }
 }

--- a/src/cli/test_runners/tests/skipped.rs
+++ b/src/cli/test_runners/tests/skipped.rs
@@ -1,9 +1,12 @@
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
+use crate::test_runners::integration_test::{IntegrationTest, TestArtifacts, TestContext};
 
 pub struct SkippedTest;
 
 impl IntegrationTest for SkippedTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
-        TestResult::skipped(ctx.previous_scan_data, ctx.previous_analysis_result)
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
+        Ok(TestArtifacts::skipped(
+            ctx.previous_scan_data,
+            ctx.previous_analysis_result,
+        ))
     }
 }

--- a/src/cli/test_runners/tests/standard_analysis.rs
+++ b/src/cli/test_runners/tests/standard_analysis.rs
@@ -3,10 +3,9 @@ use rustc_hash::FxHashSet;
 
 use std::sync::Arc;
 
-use crate::test_runners::integration_test::{IntegrationTest, TestContext, TestResult};
-use crate::test_runners::utils::{
-    augment_with_local_config, compare_issues_to_expected, default_config_for_test,
-};
+use crate::test_runners::integration_test::{IntegrationTest, TestArtifacts, TestContext};
+use crate::test_runners::outputs::IssueSnapshot;
+use crate::test_runners::utils::{augment_with_local_config, default_config_for_test};
 
 /// The default integration test type.
 ///
@@ -15,7 +14,7 @@ use crate::test_runners::utils::{
 pub struct StandardAnalysisTest;
 
 impl IntegrationTest for StandardAnalysisTest {
-    fn run(&self, ctx: TestContext) -> TestResult {
+    fn run(&self, ctx: TestContext) -> Result<TestArtifacts, String> {
         let cwd = &ctx.cwd;
 
         let mut analysis_config = default_config_for_test(&ctx.dir, ctx.hooks_provider);
@@ -69,27 +68,17 @@ impl IntegrationTest for StandardAnalysisTest {
                     }
                 }
 
-                let (passed, diagnostic) = compare_issues_to_expected(&ctx.dir, &output);
-
-                if passed {
-                    TestResult::pass(Some(run_data), Some(analysis_result), time_in_analysis)
-                } else {
-                    TestResult::fail(
-                        ctx.dir,
-                        diagnostic.unwrap_or_default(),
-                        Some(run_data),
-                        Some(analysis_result),
-                        time_in_analysis,
-                    )
-                }
+                Ok(TestArtifacts::new(
+                    Some(run_data),
+                    Some(analysis_result),
+                    time_in_analysis,
+                    vec![Box::new(IssueSnapshot {
+                        dir: ctx.dir,
+                        actual: output,
+                    })],
+                ))
             }
-            Err(error) => TestResult::fail(
-                ctx.dir,
-                error.to_string(),
-                None,
-                None,
-                std::time::Duration::default(),
-            ),
+            Err(error) => Err(error.to_string()),
         }
     }
 }

--- a/src/cli/test_runners/utils.rs
+++ b/src/cli/test_runners/utils.rs
@@ -5,7 +5,6 @@ use hakana_code_info::data_flow::graph::WholeProgramKind;
 use hakana_code_info::issue::IssueKind;
 use hakana_str::{Interner, StrId};
 use rustc_hash::FxHashSet;
-use similar::{ChangeTag, TextDiff};
 
 use std::fs;
 use std::io;
@@ -13,22 +12,6 @@ use std::path::Path;
 use std::str::FromStr;
 
 use super::test_runner::HooksProvider;
-
-pub fn format_diff(expected: &str, actual: &str) -> String {
-    let diff = TextDiff::from_lines(expected, actual);
-    let mut output = String::new();
-
-    for change in diff.iter_all_changes() {
-        let sign = match change.tag() {
-            ChangeTag::Delete => "-",
-            ChangeTag::Insert => "+",
-            ChangeTag::Equal => " ",
-        };
-        output.push_str(&format!("{}{}", sign, change));
-    }
-
-    output
-}
 
 pub fn augment_with_local_config(dir: &str, analysis_config: &mut config::Config) {
     let config_path_str = format!("{}/config.json", dir);
@@ -200,46 +183,4 @@ pub fn default_config_for_test(dir: &str, hooks_provider: &dyn HooksProvider) ->
     }
 
     analysis_config
-}
-
-pub fn compare_issues_to_expected(dir: &str, test_output: &[String]) -> (bool, Option<String>) {
-    let expected_output_path = dir.to_string() + "/output.txt";
-    let expected_output = if Path::new(&expected_output_path).exists() {
-        let expected = fs::read_to_string(expected_output_path)
-            .unwrap()
-            .trim()
-            .to_string();
-        Some(expected)
-    } else {
-        None
-    };
-
-    let passed = if let Some(expected_output) = &expected_output {
-        if expected_output == test_output.join("").trim() {
-            true
-        } else {
-            !expected_output.is_empty()
-                && test_output.len() == 1
-                && expected_output
-                    .as_bytes()
-                    .iter()
-                    .filter(|&&c| c == b'\n')
-                    .count()
-                    == 0
-                && test_output.iter().any(|s| s.contains(expected_output))
-        }
-    } else {
-        test_output.is_empty()
-    };
-
-    if passed {
-        (true, None)
-    } else {
-        let diagnostic = if let Some(expected_output) = &expected_output {
-            format_diff(expected_output, &test_output.join(""))
-        } else {
-            format_diff("", &test_output.join(""))
-        };
-        (false, Some(diagnostic))
-    }
 }


### PR DESCRIPTION
It is often desirable to update many test snapshots at once, e.g. when improving an error message or shifting the position of an existing error ever so slightly.
This currently requires either mind-numbing tedium or token waste by outsourcing said tedium to a coding agent, neither of which are a good use of resources.

So, add an `--update-snapshots` flag to `hakana test` that does what the name suggests. For this to work, centralize the implementation of different snapshot types (JSON, raw issues etc.) in the test runner and introduce a base trait so that the test runner can either verify or update them depending on whether the flag was passed. This also conveniently reduces a good deal of duplication between different tests that were using the same kind of snapshots.