### PR TITLE
Make Hakana MCP `goto_definition` take a symbol name rather than a position

### DIFF
--- a/src/code_info/codebase_info/mod.rs
+++ b/src/code_info/codebase_info/mod.rs
@@ -465,6 +465,13 @@ impl CodebaseInfo {
             return Some(name_pos);
         }
 
+        // Fall back to top-level/global constants (e.g. `NS\SOME_CONST`).
+        if *member_name == StrId::EMPTY
+            && let Some(constant_info) = self.constant_infos.get(classlike_name)
+        {
+            return Some(constant_info.pos);
+        }
+
         None
     }
 

--- a/src/code_info/symbol_references_utils.rs
+++ b/src/code_info/symbol_references_utils.rs
@@ -46,6 +46,27 @@ fn format_symbol_name(symbol_id: StrId, member_id: StrId, interner: &Interner) -
     }
 }
 
+/// Resolve a fully-qualified symbol name to its interned `(symbol_id, member_id)`.
+///
+/// Supported forms mirror the MCP tooling:
+/// - `NS\Class`, `NS\func`, `NS\TypeAlias`, `NS\CONST` -> `(id, StrId::EMPTY)`
+/// - `NS\Class::method`, `NS\Class::CONST`, `NS\Class::$prop` -> `(class_id, member_id)`
+///
+/// The leading `$` on property names is stripped before interning. Returns `None`
+/// if any component is not present in the interner.
+pub fn resolve_symbol_name(symbol_name: &str, interner: &Interner) -> Option<(StrId, StrId)> {
+    if let Some(idx) = symbol_name.rfind("::") {
+        let class_name = &symbol_name[..idx];
+        let member_name = symbol_name[idx + 2..].trim_start_matches('$');
+        let symbol_id = interner.get(class_name)?;
+        let member_id = interner.get(member_name)?;
+        Some((symbol_id, member_id))
+    } else {
+        let symbol_id = interner.get(symbol_name)?;
+        Some((symbol_id, StrId::EMPTY))
+    }
+}
+
 /// Get all references grouped by symbol name.
 ///
 /// Returns a map from symbol name to list of reference locations.

--- a/src/mcp_server/protocol.rs
+++ b/src/mcp_server/protocol.rs
@@ -1,7 +1,7 @@
 use crate::tools::Tool;
 use hakana_analyzer::custom_hook::CustomHook;
 use hakana_protocol::{
-    ClientSocket, FindSymbolReferencesRequest, GotoDefinitionRequest, Message, SocketPath,
+    ClientSocket, FindSymbolReferencesRequest, GotoDefinitionByNameRequest, Message, SocketPath,
     StatusRequest,
 };
 use serde::{Deserialize, Serialize};
@@ -383,9 +383,7 @@ impl McpServer {
 
         #[derive(Deserialize)]
         struct GotoDefinitionParams {
-            file_path: String,
-            line: u32,
-            column: u32,
+            symbol_name: String,
         }
 
         let params: GotoDefinitionParams = match serde_json::from_value(arguments) {
@@ -406,19 +404,14 @@ impl McpServer {
             }
         };
 
-        let request = Message::GotoDefinition(GotoDefinitionRequest {
-            file_path: params.file_path.clone(),
-            line: params.line,
-            column: params.column,
+        let request = Message::GotoDefinitionByName(GotoDefinitionByNameRequest {
+            symbol_name: params.symbol_name.clone(),
         });
 
         match client.request(&request).await {
             Ok(Message::GotoDefinitionResult(response)) => {
                 let content = if !response.found {
-                    format!(
-                        "No definition found at {}:{}:{}",
-                        params.file_path, params.line, params.column
-                    )
+                    format!("No definition found for symbol: {}", params.symbol_name)
                 } else {
                     let file_path = response.file_path.unwrap_or_default();
                     let start_line = response.start_line.unwrap_or(0);

--- a/src/mcp_server/tools.rs
+++ b/src/mcp_server/tools.rs
@@ -46,29 +46,28 @@ impl Tool {
     pub fn goto_definition_definition() -> Self {
         Tool {
             name: "goto_definition".to_string(),
-            description: "Go to the definition of a symbol at a specific location in a file. \
-                Given a file path, line, and column, returns the location where the symbol \
-                at that position is defined. Useful for navigating from usages to definitions \
-                of functions, classes, methods, properties, and other symbols."
+            description: "Go to the definition of a symbol given its fully-qualified name. \
+                Returns the file path and location where the symbol is defined. Supports \
+                functions, classes, methods, properties, constants, class constants, and \
+                type aliases."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "file_path": {
+                    "symbol_name": {
                         "type": "string",
-                        "description": "The relative path to the file (relative to project root). \
-                            Example: 'src/MyClass.hack'"
-                    },
-                    "line": {
-                        "type": "integer",
-                        "description": "The 1-indexed line number where the symbol is located"
-                    },
-                    "column": {
-                        "type": "integer",
-                        "description": "The 1-indexed column number where the symbol is located"
+                        "description": "The fully-qualified name of the symbol to locate. \
+                            Examples:\n\
+                            - Function: 'MyNamespace\\myFunction'\n\
+                            - Class: 'MyNamespace\\MyClass'\n\
+                            - Method: 'MyNamespace\\MyClass::myMethod'\n\
+                            - Property: 'MyNamespace\\MyClass::$propertyName'\n\
+                            - Class constant: 'MyNamespace\\MyClass::CONSTANT_NAME'\n\
+                            - Global constant: 'MyNamespace\\CONSTANT_NAME'\n\
+                            - Type alias: 'MyNamespace\\MyTypeAlias'"
                     }
                 },
-                "required": ["file_path", "line", "column"]
+                "required": ["symbol_name"]
             }),
         }
     }

--- a/src/protocol/serialize.rs
+++ b/src/protocol/serialize.rs
@@ -617,6 +617,21 @@ impl Deserialize for FindReferencesResponse {
     }
 }
 
+// GotoDefinitionByNameRequest
+
+impl Serialize for GotoDefinitionByNameRequest {
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        write_string(buf, &self.symbol_name);
+    }
+}
+
+impl Deserialize for GotoDefinitionByNameRequest {
+    fn deserialize(data: &[u8]) -> Result<(Self, &[u8]), ProtocolError> {
+        let (symbol_name, rest) = read_string(data)?;
+        Ok((Self { symbol_name }, rest))
+    }
+}
+
 // FindSymbolReferencesRequest
 
 impl Serialize for FindSymbolReferencesRequest {
@@ -864,6 +879,7 @@ impl Serialize for Message {
             Self::Analyze(req) => req.serialize(buf),
             Self::SecurityCheck(req) => req.serialize(buf),
             Self::GotoDefinition(req) => req.serialize(buf),
+            Self::GotoDefinitionByName(req) => req.serialize(buf),
             Self::FindReferences(req) => req.serialize(buf),
             Self::FindSymbolReferences(req) => req.serialize(buf),
             Self::FileChanged(changes) => {
@@ -906,6 +922,10 @@ impl Message {
             MessageType::GotoDefinitionRequest => {
                 let (req, _) = GotoDefinitionRequest::deserialize(data)?;
                 Self::GotoDefinition(req)
+            }
+            MessageType::GotoDefinitionByNameRequest => {
+                let (req, _) = GotoDefinitionByNameRequest::deserialize(data)?;
+                Self::GotoDefinitionByName(req)
             }
             MessageType::FindReferencesRequest => {
                 let (req, _) = FindReferencesRequest::deserialize(data)?;

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -14,6 +14,7 @@ pub enum MessageType {
     FileChangedNotification = 0x05,
     GetIssuesRequest = 0x06,
     FindSymbolReferencesRequest = 0x07,
+    GotoDefinitionByNameRequest = 0x08,
     StatusRequest = 0x10,
     ShutdownRequest = 0x0F,
 
@@ -43,6 +44,7 @@ impl TryFrom<u8> for MessageType {
             0x05 => Ok(Self::FileChangedNotification),
             0x06 => Ok(Self::GetIssuesRequest),
             0x07 => Ok(Self::FindSymbolReferencesRequest),
+            0x08 => Ok(Self::GotoDefinitionByNameRequest),
             0x10 => Ok(Self::StatusRequest),
             0x0F => Ok(Self::ShutdownRequest),
             0x81 => Ok(Self::AnalyzeResponse),
@@ -174,6 +176,13 @@ pub struct GotoDefinitionRequest {
     pub file_path: String,
     pub line: u32,
     pub column: u32,
+}
+
+/// Request for goto-definition by fully-qualified symbol name.
+#[derive(Debug, Clone)]
+pub struct GotoDefinitionByNameRequest {
+    /// The fully-qualified symbol name (e.g., "Namespace\\Class::method").
+    pub symbol_name: String,
 }
 
 /// Response with definition location.
@@ -344,6 +353,7 @@ pub enum Message {
     Analyze(AnalyzeRequest),
     SecurityCheck(SecurityCheckRequest),
     GotoDefinition(GotoDefinitionRequest),
+    GotoDefinitionByName(GotoDefinitionByNameRequest),
     FindReferences(FindReferencesRequest),
     FindSymbolReferences(FindSymbolReferencesRequest),
     FileChanged(Vec<FileChange>),
@@ -370,6 +380,7 @@ impl Message {
             Self::Analyze(_) => MessageType::AnalyzeRequest,
             Self::SecurityCheck(_) => MessageType::SecurityCheckRequest,
             Self::GotoDefinition(_) => MessageType::GotoDefinitionRequest,
+            Self::GotoDefinitionByName(_) => MessageType::GotoDefinitionByNameRequest,
             Self::FindReferences(_) => MessageType::FindReferencesRequest,
             Self::FindSymbolReferences(_) => MessageType::FindSymbolReferencesRequest,
             Self::FileChanged(_) => MessageType::FileChangedNotification,
@@ -395,6 +406,7 @@ impl Message {
             Self::Analyze(_)
                 | Self::SecurityCheck(_)
                 | Self::GotoDefinition(_)
+                | Self::GotoDefinitionByName(_)
                 | Self::FindReferences(_)
                 | Self::FindSymbolReferences(_)
                 | Self::FileChanged(_)

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -7,8 +7,8 @@ use hakana_orchestrator::file::FileStatus;
 use hakana_protocol::GetIssuesResponse;
 use hakana_protocol::{
     AckResponse, FindReferencesRequest, FindReferencesResponse, FindSymbolReferencesRequest,
-    FindSymbolReferencesResponse, GotoDefinitionRequest, GotoDefinitionResponse, Message,
-    ProtocolIssue, ReferenceLocation, StatusResponse,
+    FindSymbolReferencesResponse, GotoDefinitionByNameRequest, GotoDefinitionRequest,
+    GotoDefinitionResponse, Message, ProtocolIssue, ReferenceLocation, StatusResponse,
 };
 use log::info;
 use rustc_hash::FxHashMap;
@@ -137,6 +137,48 @@ impl RequestHandler {
             end_line: None,
             end_column: None,
         })
+    }
+
+    /// Handle a goto-definition request by fully-qualified symbol name.
+    pub fn handle_goto_definition_by_name(&self, req: GotoDefinitionByNameRequest) -> Message {
+        use hakana_code_info::symbol_references_utils::resolve_symbol_name;
+
+        let not_found = || {
+            Message::GotoDefinitionResult(GotoDefinitionResponse {
+                found: false,
+                file_path: None,
+                start_line: None,
+                start_column: None,
+                end_line: None,
+                end_column: None,
+            })
+        };
+
+        let state = self.state.lock().unwrap();
+        let scan_data = match state.scan_data() {
+            Some(sd) => sd,
+            None => return not_found(),
+        };
+
+        let (symbol_id, member_id) =
+            match resolve_symbol_name(&req.symbol_name, &scan_data.interner) {
+                Some(ids) => ids,
+                None => return not_found(),
+            };
+
+        if let Some(pos) = scan_data.codebase.get_symbol_pos(&symbol_id, &member_id) {
+            let def_file_path = scan_data.interner.lookup(&pos.file_path.0);
+            return Message::GotoDefinitionResult(GotoDefinitionResponse {
+                found: true,
+                file_path: Some(def_file_path.to_string()),
+                start_line: Some(pos.start_line),
+                start_column: Some(pos.start_column),
+                end_line: Some(pos.end_line),
+                end_column: Some(pos.end_column),
+            });
+        }
+
+        not_found()
     }
 
     /// Handle a find-references request.

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -338,6 +338,9 @@ impl Server {
                     Message::Status(_) => handler.handle_status(),
                     Message::Shutdown(_) => handler.handle_shutdown().await,
                     Message::GotoDefinition(req) => handler.handle_goto_definition(req),
+                    Message::GotoDefinitionByName(req) => {
+                        handler.handle_goto_definition_by_name(req)
+                    }
                     Message::FindReferences(req) => handler.handle_find_references(req),
                     Message::FindSymbolReferences(req) => {
                         handler.handle_find_symbol_references(req)


### PR DESCRIPTION


Currently the Hakana MCP `goto_definition` tool mirrors the corresponding LSP functionality in that it takes a symbol position as input rather than a symbol name. This causes coding agents to ignore it in favor of `rg`/`grep` when trying to find where a symbol is defined even though it's much faster. So, have it take a fully-qualified symbol name instead.