### PR TITLE
Add `DOMNode::localName` property type override

### DIFF
--- a/src/analyzer/expr/fetch/atomic_property_fetch_analyzer.rs
+++ b/src/analyzer/expr/fetch/atomic_property_fetch_analyzer.rs
@@ -217,6 +217,20 @@ pub(crate) fn analyze(
     Ok(())
 }
 
+fn get_special_property_type(
+    statements_analyzer: &StatementsAnalyzer,
+    classlike_name: &StrId,
+    property_name: &StrId,
+) -> Option<TUnion> {
+    if *classlike_name == StrId::DOMNODE
+        && statements_analyzer.interner.lookup(property_name) == "localName"
+    {
+        return Some(TUnion::new(vec![TAtomic::TNull, TAtomic::TString]));
+    }
+
+    None
+}
+
 fn get_class_property_type(
     statements_analyzer: &StatementsAnalyzer,
     classlike_name: &StrId,
@@ -226,7 +240,9 @@ fn get_class_property_type(
     analysis_data: &mut FunctionAnalysisData,
 ) -> TUnion {
     let codebase = statements_analyzer.codebase;
-    let class_property_type = codebase.get_property_type(classlike_name, property_name);
+    let class_property_type =
+        get_special_property_type(statements_analyzer, classlike_name, property_name)
+            .or_else(|| codebase.get_property_type(classlike_name, property_name));
 
     let class_storage = codebase.classlike_infos.get(classlike_name).unwrap();
     let declaring_class_storage = codebase

--- a/src/str/build.rs
+++ b/src/str/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<()> {
         "<data attribute>",
         "Codegen",
         "DOMDocument",
+        "DOMNode",
         "DateTime",
         "DateTimeImmutable",
         "Error",

--- a/tests/inference/PropertyType/domNodeLocalName/input.hack
+++ b/tests/inference/PropertyType/domNodeLocalName/input.hack
@@ -1,0 +1,3 @@
+function foo(DOMNode $node): string {
+    return $node->localName ?? $node->nodeName;
+}


### PR DESCRIPTION
The Hack typings claim that `DOMNode::localName` is a `string`, but this is wrong:

```cpp
static Variant domnode_localname_read(const Object& obj) {
  CHECK_NODE(nodep);
  if (nodep->type == XML_ELEMENT_NODE ||
      nodep->type == XML_ATTRIBUTE_NODE ||
      nodep->type == XML_NAMESPACE_DECL) {
    return OptString((char *)(nodep->name), CopyString);
  }
  return init_null();
}
```

Until such time as we can fix the HHI upstream, add an override in Hakana proper like we already do for some methods.