### PR TITLE
Fix Enum::getNames inference

### DIFF
--- a/src/code_info/ttype/mod.rs
+++ b/src/code_info/ttype/mod.rs
@@ -498,6 +498,16 @@ fn intersect_atomic_with_atomic_simple(
         (_, TAtomic::TObject) => {
             return None;
         }
+        (
+            enum_type @ (TAtomic::TEnum { .. } | TAtomic::TEnumLiteralCase { .. }),
+            TAtomic::TArraykey { .. },
+        )
+        | (
+            TAtomic::TArraykey { .. },
+            enum_type @ (TAtomic::TEnum { .. } | TAtomic::TEnumLiteralCase { .. }),
+        ) => {
+            return Some(enum_type.clone());
+        }
         (type_1_atomic, TAtomic::TArraykey { .. }) => {
             if type_1_atomic.is_mixed() {
                 return Some(TAtomic::TArraykey { from_any: false });

--- a/tests/inference/Enum/enumGetNames/input.hack
+++ b/tests/inference/Enum/enumGetNames/input.hack
@@ -1,0 +1,13 @@
+enum MyEnum: string as string {
+    FOO = 'foo';
+    BAR = 'bar';
+}
+
+function foo(): string {
+    $acc = '';
+    $names = MyEnum::getNames();
+    foreach ($names as $key => $_) {
+        $acc .= $key;
+    }
+    return $acc;
+}


### PR DESCRIPTION
The signature of the base method is
```hack
    <<__NoAutoDynamic>>
    final public static function getNames()[]: darray<T, string>
    where
      T as arraykey;
```

Refinement improvements 0550219 exposed that we were never treating enums as equivalent to `arraykey` values, so try and fix that.