### PR TITLE
Add `DOMNamedNodeMap` iterator type override

### DIFF
--- a/src/analyzer/expr/call/method_call_return_type_fetcher.rs
+++ b/src/analyzer/expr/call/method_call_return_type_fetcher.rs
@@ -198,6 +198,21 @@ fn get_special_method_return(method_id: &MethodIdentifier, interner: &Interner) 
                 return Some(false_or_domelement);
             }
         }
+        StrId::DOMNAMED_NODE_MAP => {
+            let method_name = interner.lookup(&method_id.1);
+            if matches!(method_name, "item" | "getNamedItem") {
+                return Some(TUnion::new(vec![
+                    TAtomic::TNamedObject(TNamedObject {
+                        name: StrId::DOMNODE,
+                        type_params: None,
+                        is_this: false,
+                        remapped_params: false,
+                    }),
+                    TAtomic::TFalse,
+                    TAtomic::TNull,
+                ]));
+            }
+        }
         StrId::SIMPLE_XML_ELEMENT => match interner.lookup(&method_id.1) {
             "children" | "attributes" | "addChild" => {
                 let null_or_simplexmlelement = TUnion::new(vec![

--- a/src/analyzer/stmt/foreach_analyzer.rs
+++ b/src/analyzer/stmt/foreach_analyzer.rs
@@ -541,6 +541,24 @@ fn check_iterator_type(
                         ));
                     }
                 }
+                StrId::DOMNAMED_NODE_MAP => {
+                    has_valid_iterator = true;
+                    key_type = Some(combine_optional_union_types(
+                        key_type.as_ref(),
+                        Some(&get_arraykey(true)),
+                        codebase,
+                    ));
+                    value_type = Some(TUnion::new(vec![
+                        TAtomic::TNamedObject(TNamedObject {
+                            name: StrId::DOMNODE,
+                            type_params: None,
+                            is_this: false,
+                            remapped_params: false,
+                        }),
+                        TAtomic::TFalse,
+                        TAtomic::TNull,
+                    ]));
+                }
                 _ => {
                     let Some(classlike_storage) = codebase.classlike_infos.get(name) else {
                         continue;

--- a/src/str/build.rs
+++ b/src/str/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<()> {
         "<data attribute>",
         "Codegen",
         "DOMDocument",
+        "DOMNamedNodeMap",
         "DOMNode",
         "DateTime",
         "DateTimeImmutable",

--- a/tests/inference/ReturnType/domNamedNodeMap/input.hack
+++ b/tests/inference/ReturnType/domNamedNodeMap/input.hack
@@ -1,0 +1,7 @@
+function foo(DOMNamedNodeMap<DOMAttr> $map) {
+    foreach ($map as $item) {
+        if ($item is DOMAttr) {
+            var_dump($item);
+        }
+    }
+}


### PR DESCRIPTION
Lies, damn lies, and ext_domdocument.

```cpp
 if (itemnode) {
    Variant ret = php_dom_create_object(itemnode, data->m_doc);
    if (ret.isNull()) {
      raise_warning("Cannot create required DOM object");
      return false;
    }
    return ret;
  }
  return init_null();
```