### PR TITLE
Install rust-analyzer for toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2025-12-05"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
Otherwise the VSCode plugin won't find it