### PR TITLE
Serve `migration-candidates` from server if possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
 name = "hakana-server"
 version = "0.1.0"
 dependencies = [
+ "glob",
  "hakana-analyzer",
  "hakana-code-info",
  "hakana-orchestrator",

--- a/src/cli/commands/migration_candidates.rs
+++ b/src/cli/commands/migration_candidates.rs
@@ -1,6 +1,8 @@
 use clap::{Command, arg};
 use hakana_analyzer::config;
 use hakana_analyzer::custom_hook::CustomHook;
+use hakana_language_server::server_client::ServerConnection;
+use hakana_protocol::{ClientSocket, GetMigrationCandidatesRequest, Message, SocketPath};
 use hakana_str::{Interner, StrId};
 use rustc_hash::FxHashSet;
 use std::path::Path;
@@ -36,13 +38,23 @@ pub fn get_subcommand() -> Command<'static> {
                 .help("Only return migration candidates matching this glob expression"),
         )
         .arg(
+            arg!(--"standalone")
+                .required(false)
+                .help("Run analysis directly without connecting to server (default for CI)"),
+        )
+        .arg(
+            arg!(--"with-server")
+                .required(false)
+                .help("Use server mode: connect to existing server or spawn one if needed"),
+        )
+        .arg(
             arg!(--"debug")
                 .required(false)
                 .help("Add output for debugging"),
         )
 }
 
-pub fn handle(
+pub async fn handle(
     sub_matches: &clap::ArgMatches,
     root_dir: &str,
     all_custom_issues: FxHashSet<String>,
@@ -55,6 +67,136 @@ pub fn handle(
 ) {
     let migration_name = sub_matches.value_of("migration").unwrap().to_string();
 
+    // Validate the filter glob up front so an invalid pattern fails identically
+    // regardless of whether we run against a server or standalone.
+    let filter = sub_matches
+        .value_of("filter")
+        .map(|f| glob::Pattern::new(f).expect(&format!("Invalid filter pattern {}", f)));
+
+    // Prefer a running server unless --standalone was passed. This mirrors the
+    // behavior of the `analyze` command.
+    let standalone = sub_matches.is_present("standalone");
+    let with_server = sub_matches.is_present("with-server");
+    let project_root = Path::new(root_dir);
+    let socket_path = SocketPath::for_project(project_root);
+    let use_server = if standalone {
+        false
+    } else if with_server {
+        if !socket_path.server_exists() {
+            ServerConnection::connect_or_spawn(project_root, None)
+                .await
+                .inspect_err(|e| {
+                    println!(
+                        "Failed to spawn server: {}. Falling back to standalone analysis.",
+                        e
+                    )
+                })
+                .is_ok()
+        } else {
+            true
+        }
+    } else {
+        socket_path.server_exists()
+    };
+
+    if use_server
+        && handle_via_server(
+            &socket_path,
+            &migration_name,
+            sub_matches.value_of("filter"),
+        )
+        .await
+    {
+        return;
+    }
+
+    handle_standalone(
+        migration_name,
+        filter,
+        all_custom_issues,
+        migration_hooks,
+        config_path,
+        cwd,
+        threads,
+        show_progress,
+        header,
+        root_dir,
+    );
+}
+
+/// Request migration candidates from a running server. Returns `true` if the request
+/// completed (whether or not candidates were found); `false` if we should fall back to
+/// a standalone analysis (e.g. the connection dropped).
+async fn handle_via_server(
+    socket_path: &SocketPath,
+    migration_name: &str,
+    filter: Option<&str>,
+) -> bool {
+    use std::time::Duration;
+
+    let request = Message::GetMigrationCandidates(GetMigrationCandidatesRequest {
+        migration: migration_name.to_string(),
+        filter: filter.map(|f| f.to_string()),
+        block_until_next_analysis: false,
+    });
+
+    loop {
+        let mut client = match ClientSocket::connect(socket_path).await {
+            Ok(c) => c,
+            Err(e) => {
+                println!("Error connecting to server: {}", e);
+                return false;
+            }
+        };
+
+        match client.request(&request).await {
+            Ok(Message::GetMigrationCandidatesResult(result)) => {
+                if !result.analysis_complete {
+                    // Analysis is still running; wait and retry.
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+
+                if !result.migration_recognized {
+                    println!("Migration {} not recognised", migration_name);
+                    exit(1);
+                }
+
+                tty_println!("\nSymbols to migrate:\n");
+                for candidate in result.candidates {
+                    println!("{}", candidate);
+                }
+                return true;
+            }
+            Ok(Message::Error(err)) => {
+                println!("Server error: {} - {}", err.code as u32, err.message);
+                exit(1);
+            }
+            Ok(_) => {
+                println!("Unexpected response from server");
+                exit(1);
+            }
+            Err(e) => {
+                println!("Error communicating with server: {}", e);
+                return false;
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_standalone(
+    migration_name: String,
+    filter: Option<glob::Pattern>,
+    all_custom_issues: FxHashSet<String>,
+    migration_hooks: Vec<Box<dyn CustomHook>>,
+    config_path: Option<&Path>,
+    cwd: &String,
+    threads: u8,
+    show_progress: bool,
+    header: &str,
+    root_dir: &str,
+) {
     let mut config = config::Config::new(root_dir.to_string(), all_custom_issues);
     config.hooks = migration_hooks
         .into_iter()
@@ -88,10 +230,6 @@ pub fn handle(
     config.allowed_issues = None;
 
     let config = Arc::new(config);
-
-    let filter = sub_matches
-        .value_of("filter")
-        .map(|f| glob::Pattern::new(f).expect(&format!("Invalid filter pattern {}", f)));
 
     let result = hakana_orchestrator::scan_and_analyze(
         Vec::new(),

--- a/src/cli/commands/server.rs
+++ b/src/cli/commands/server.rs
@@ -38,6 +38,7 @@ pub async fn handle(
     threads: u8,
     header: &str,
     analysis_hooks: Vec<Box<dyn CustomHook>>,
+    migration_hooks: Vec<Box<dyn CustomHook>>,
 ) {
     use hakana_protocol::{Message, ShutdownRequest, SocketPath, StatusRequest};
     use hakana_server::{Server, ServerConfig};
@@ -98,12 +99,15 @@ pub async fn handle(
         .unwrap_or_else(|| format!("{}/hakana.json", root_dir));
 
     let plugins: Vec<Arc<dyn CustomHook>> = analysis_hooks.into_iter().map(Arc::from).collect();
+    let migration_hooks: Vec<Arc<dyn CustomHook>> =
+        migration_hooks.into_iter().map(Arc::from).collect();
 
     let server_config = ServerConfig {
         root_dir: root_dir.to_string(),
         threads,
         config_path: Some(config_path),
         plugins,
+        migration_hooks,
         header: header.to_string(),
         chaos_monkey: None,
     };

--- a/src/cli/lib.rs
+++ b/src/cli/lib.rs
@@ -228,7 +228,8 @@ pub async fn init(
                 threads,
                 show_progress,
                 header,
-            );
+            )
+            .await;
         }
         Some(("codegen", sub_matches)) => {
             commands::codegen::handle(
@@ -299,7 +300,15 @@ pub async fn init(
             commands::lint::handle(sub_matches, &root_dir, &mut had_error, custom_linters);
         }
         Some(("server", sub_matches)) => {
-            commands::server::handle(sub_matches, &root_dir, threads, header, analysis_hooks).await;
+            commands::server::handle(
+                sub_matches,
+                &root_dir,
+                threads,
+                header,
+                analysis_hooks,
+                migration_hooks,
+            )
+            .await;
         }
         Some(("cyclomatic-complexity", sub_matches)) => {
             commands::cyclomatic_complexity::handle(

--- a/src/protocol/serialize.rs
+++ b/src/protocol/serialize.rs
@@ -758,6 +758,67 @@ impl Deserialize for GetIssuesResponse {
     }
 }
 
+// GetMigrationCandidatesRequest
+
+impl Serialize for GetMigrationCandidatesRequest {
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        write_string(buf, &self.migration);
+        write_option_string(buf, &self.filter);
+        write_bool(buf, self.block_until_next_analysis);
+    }
+}
+
+impl Deserialize for GetMigrationCandidatesRequest {
+    fn deserialize(data: &[u8]) -> Result<(Self, &[u8]), ProtocolError> {
+        let (migration, rest) = read_string(data)?;
+        let (filter, rest) = read_option_string(rest)?;
+        let (block_until_next_analysis, rest) = read_bool(rest)?;
+        Ok((
+            Self {
+                migration,
+                filter,
+                block_until_next_analysis,
+            },
+            rest,
+        ))
+    }
+}
+
+// GetMigrationCandidatesResponse
+
+impl Serialize for GetMigrationCandidatesResponse {
+    fn serialize(&self, buf: &mut Vec<u8>) {
+        write_bool(buf, self.analysis_complete);
+        write_bool(buf, self.migration_recognized);
+        write_u32(buf, self.candidates.len() as u32);
+        for candidate in &self.candidates {
+            write_string(buf, candidate);
+        }
+    }
+}
+
+impl Deserialize for GetMigrationCandidatesResponse {
+    fn deserialize(data: &[u8]) -> Result<(Self, &[u8]), ProtocolError> {
+        let (analysis_complete, rest) = read_bool(data)?;
+        let (migration_recognized, rest) = read_bool(rest)?;
+        let (len, mut rest) = read_u32(rest)?;
+        let mut candidates = Vec::with_capacity(len as usize);
+        for _ in 0..len {
+            let (candidate, r) = read_string(rest)?;
+            candidates.push(candidate);
+            rest = r;
+        }
+        Ok((
+            Self {
+                analysis_complete,
+                migration_recognized,
+                candidates,
+            },
+            rest,
+        ))
+    }
+}
+
 // StatusRequest (empty)
 
 impl Serialize for StatusRequest {
@@ -889,6 +950,7 @@ impl Serialize for Message {
                 }
             }
             Self::GetIssues(req) => req.serialize(buf),
+            Self::GetMigrationCandidates(req) => req.serialize(buf),
             Self::Status(req) => req.serialize(buf),
             Self::Shutdown(req) => req.serialize(buf),
             Self::AnalyzeResult(res) => res.serialize(buf),
@@ -897,6 +959,7 @@ impl Serialize for Message {
             Self::FindReferencesResult(res) => res.serialize(buf),
             Self::FindSymbolReferencesResult(res) => res.serialize(buf),
             Self::GetIssuesResult(res) => res.serialize(buf),
+            Self::GetMigrationCandidatesResult(res) => res.serialize(buf),
             Self::StatusResult(res) => res.serialize(buf),
             Self::Ack(res) => res.serialize(buf),
             Self::Error(res) => res.serialize(buf),
@@ -949,6 +1012,10 @@ impl Message {
                 let (req, _) = GetIssuesRequest::deserialize(data)?;
                 Self::GetIssues(req)
             }
+            MessageType::GetMigrationCandidatesRequest => {
+                let (req, _) = GetMigrationCandidatesRequest::deserialize(data)?;
+                Self::GetMigrationCandidates(req)
+            }
             MessageType::StatusRequest => {
                 let (req, _) = StatusRequest::deserialize(data)?;
                 Self::Status(req)
@@ -980,6 +1047,10 @@ impl Message {
             MessageType::GetIssuesResponse => {
                 let (res, _) = GetIssuesResponse::deserialize(data)?;
                 Self::GetIssuesResult(res)
+            }
+            MessageType::GetMigrationCandidatesResponse => {
+                let (res, _) = GetMigrationCandidatesResponse::deserialize(data)?;
+                Self::GetMigrationCandidatesResult(res)
             }
             MessageType::StatusResponse => {
                 let (res, _) = StatusResponse::deserialize(data)?;
@@ -1166,6 +1237,52 @@ mod tests {
         let encoded = encode_message(&msg);
         let (decoded, _) = decode_message(&encoded).unwrap();
         assert!(matches!(decoded, Message::Status(_)));
+    }
+
+    #[test]
+    fn test_roundtrip_migration_candidates_request() {
+        let req = GetMigrationCandidatesRequest {
+            migration: "my-migration".to_string(),
+            filter: Some("src/**/*.hack".to_string()),
+            block_until_next_analysis: true,
+        };
+
+        let msg = Message::GetMigrationCandidates(req.clone());
+        let encoded = encode_message(&msg);
+        let (decoded, rest) = decode_message(&encoded).unwrap();
+        assert!(rest.is_empty());
+
+        if let Message::GetMigrationCandidates(decoded_req) = decoded {
+            assert_eq!(decoded_req.migration, req.migration);
+            assert_eq!(decoded_req.filter, req.filter);
+            assert_eq!(
+                decoded_req.block_until_next_analysis,
+                req.block_until_next_analysis
+            );
+        } else {
+            panic!("Expected GetMigrationCandidatesRequest");
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_migration_candidates_response() {
+        let res = GetMigrationCandidatesResponse {
+            analysis_complete: true,
+            migration_recognized: true,
+            candidates: vec!["Foo::bar".to_string(), "Baz".to_string()],
+        };
+
+        let msg = Message::GetMigrationCandidatesResult(res.clone());
+        let encoded = encode_message(&msg);
+        let (decoded, _) = decode_message(&encoded).unwrap();
+
+        if let Message::GetMigrationCandidatesResult(decoded_res) = decoded {
+            assert_eq!(decoded_res.analysis_complete, res.analysis_complete);
+            assert_eq!(decoded_res.migration_recognized, res.migration_recognized);
+            assert_eq!(decoded_res.candidates, res.candidates);
+        } else {
+            panic!("Expected GetMigrationCandidatesResponse");
+        }
     }
 
     #[test]

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -15,6 +15,7 @@ pub enum MessageType {
     GetIssuesRequest = 0x06,
     FindSymbolReferencesRequest = 0x07,
     GotoDefinitionByNameRequest = 0x08,
+    GetMigrationCandidatesRequest = 0x09,
     StatusRequest = 0x10,
     ShutdownRequest = 0x0F,
 
@@ -25,6 +26,7 @@ pub enum MessageType {
     FindReferencesResponse = 0x84,
     GetIssuesResponse = 0x85,
     FindSymbolReferencesResponse = 0x86,
+    GetMigrationCandidatesResponse = 0x87,
     StatusResponse = 0x90,
     AckResponse = 0x8F,
 
@@ -45,6 +47,7 @@ impl TryFrom<u8> for MessageType {
             0x06 => Ok(Self::GetIssuesRequest),
             0x07 => Ok(Self::FindSymbolReferencesRequest),
             0x08 => Ok(Self::GotoDefinitionByNameRequest),
+            0x09 => Ok(Self::GetMigrationCandidatesRequest),
             0x10 => Ok(Self::StatusRequest),
             0x0F => Ok(Self::ShutdownRequest),
             0x81 => Ok(Self::AnalyzeResponse),
@@ -53,6 +56,7 @@ impl TryFrom<u8> for MessageType {
             0x84 => Ok(Self::FindReferencesResponse),
             0x85 => Ok(Self::GetIssuesResponse),
             0x86 => Ok(Self::FindSymbolReferencesResponse),
+            0x87 => Ok(Self::GetMigrationCandidatesResponse),
             0x90 => Ok(Self::StatusResponse),
             0x8F => Ok(Self::AckResponse),
             0xFF => Ok(Self::ErrorResponse),
@@ -268,6 +272,28 @@ pub struct GetIssuesResponse {
     pub phase: String,
 }
 
+/// Request for the migration candidates of a given migration.
+#[derive(Debug, Clone, Default)]
+pub struct GetMigrationCandidatesRequest {
+    /// The migration name (matched against each hook's `get_migration_name()`).
+    pub migration: String,
+    /// Only return candidates whose definition path matches this glob pattern.
+    pub filter: Option<String>,
+    /// Whether to wait until the next analysis run.
+    pub block_until_next_analysis: bool,
+}
+
+/// Response with the migration candidates.
+#[derive(Debug, Clone)]
+pub struct GetMigrationCandidatesResponse {
+    /// Whether analysis is complete (false = still in progress).
+    pub analysis_complete: bool,
+    /// Whether the migration name was recognised by the server.
+    pub migration_recognized: bool,
+    /// Candidate symbol names (bare name or `ClassName::memberName`).
+    pub candidates: Vec<String>,
+}
+
 /// Request for server status.
 #[derive(Debug, Clone, Copy)]
 pub struct StatusRequest;
@@ -358,6 +384,7 @@ pub enum Message {
     FindSymbolReferences(FindSymbolReferencesRequest),
     FileChanged(Vec<FileChange>),
     GetIssues(GetIssuesRequest),
+    GetMigrationCandidates(GetMigrationCandidatesRequest),
     Status(StatusRequest),
     Shutdown(ShutdownRequest),
 
@@ -368,6 +395,7 @@ pub enum Message {
     FindReferencesResult(FindReferencesResponse),
     FindSymbolReferencesResult(FindSymbolReferencesResponse),
     GetIssuesResult(GetIssuesResponse),
+    GetMigrationCandidatesResult(GetMigrationCandidatesResponse),
     StatusResult(StatusResponse),
     Ack(AckResponse),
     Error(ErrorResponse),
@@ -385,6 +413,7 @@ impl Message {
             Self::FindSymbolReferences(_) => MessageType::FindSymbolReferencesRequest,
             Self::FileChanged(_) => MessageType::FileChangedNotification,
             Self::GetIssues(_) => MessageType::GetIssuesRequest,
+            Self::GetMigrationCandidates(_) => MessageType::GetMigrationCandidatesRequest,
             Self::Status(_) => MessageType::StatusRequest,
             Self::Shutdown(_) => MessageType::ShutdownRequest,
             Self::AnalyzeResult(_) => MessageType::AnalyzeResponse,
@@ -393,6 +422,7 @@ impl Message {
             Self::FindReferencesResult(_) => MessageType::FindReferencesResponse,
             Self::FindSymbolReferencesResult(_) => MessageType::FindSymbolReferencesResponse,
             Self::GetIssuesResult(_) => MessageType::GetIssuesResponse,
+            Self::GetMigrationCandidatesResult(_) => MessageType::GetMigrationCandidatesResponse,
             Self::StatusResult(_) => MessageType::StatusResponse,
             Self::Ack(_) => MessageType::AckResponse,
             Self::Error(_) => MessageType::ErrorResponse,
@@ -411,6 +441,7 @@ impl Message {
                 | Self::FindSymbolReferences(_)
                 | Self::FileChanged(_)
                 | Self::GetIssues(_)
+                | Self::GetMigrationCandidates(_)
                 | Self::Status(_)
                 | Self::Shutdown(_)
         )

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -9,6 +9,7 @@ hakana-orchestrator = { path = "../orchestrator" }
 hakana-analyzer = { path = "../analyzer" }
 hakana-code-info = { path = "../code_info" }
 hakana-str = { path = "../str" }
+glob = "0.3"
 log = "0.4"
 rustc-hash = "1.1.0"
 watchman_client = "0.9"

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -1,15 +1,18 @@
 //! Request handlers for the hakana server.
 
 use crate::{ServerConfig, ServerState};
+use hakana_analyzer::custom_hook::CustomHook;
 use hakana_code_info::analysis_result::AnalysisResult;
 use hakana_orchestrator::SuccessfulScanData;
 use hakana_orchestrator::file::FileStatus;
 use hakana_protocol::GetIssuesResponse;
 use hakana_protocol::{
     AckResponse, FindReferencesRequest, FindReferencesResponse, FindSymbolReferencesRequest,
-    FindSymbolReferencesResponse, GotoDefinitionByNameRequest, GotoDefinitionRequest,
-    GotoDefinitionResponse, Message, ProtocolIssue, ReferenceLocation, StatusResponse,
+    FindSymbolReferencesResponse, GetMigrationCandidatesResponse, GotoDefinitionByNameRequest,
+    GotoDefinitionRequest, GotoDefinitionResponse, Message, ProtocolIssue, ReferenceLocation,
+    StatusResponse,
 };
+use hakana_str::StrId;
 use log::info;
 use rustc_hash::FxHashMap;
 use std::sync::{Arc, Mutex};
@@ -379,6 +382,120 @@ impl RequestHandler {
             files_analyzed: state.files_analyzed(),
             total_files_to_analyze: state.total_files_to_analyze(),
             phase: "Complete".to_string(),
+        })
+    }
+
+    /// Compute the migration candidates for the requested migration against the warm
+    /// analysis result.
+    ///
+    /// Note: the server's warm analysis always runs in normal mode (`in_migration = false`),
+    /// whereas the standalone `migration-candidates` path runs with `in_migration = true`.
+    /// Because that flag changes some analysis behavior, server-computed candidates may differ
+    /// from the standalone result; use `--standalone` to get the exact migration-mode result.
+    pub async fn handle_get_migration_candidates(
+        &self,
+        analysis_rx: &mut tokio::sync::broadcast::Receiver<
+            Result<Arc<(AnalysisResult, SuccessfulScanData)>, String>,
+        >,
+        req: hakana_protocol::GetMigrationCandidatesRequest,
+    ) -> Message {
+        let hooks: Vec<Arc<dyn CustomHook>> = self
+            .config
+            .migration_hooks
+            .iter()
+            .filter(|h| h.get_migration_name() == Some(req.migration.as_str()))
+            .cloned()
+            .collect();
+
+        if hooks.is_empty() {
+            return Message::GetMigrationCandidatesResult(GetMigrationCandidatesResponse {
+                analysis_complete: true,
+                migration_recognized: false,
+                candidates: vec![],
+            });
+        }
+
+        if !req.block_until_next_analysis {
+            let analysis_data = {
+                let state = self.state.lock().unwrap();
+                state
+                    .analysis_data
+                    .as_ref()
+                    .filter(|_| !state.is_analysis_in_progress())
+                    .cloned()
+            };
+
+            if let Some(analysis_data) = analysis_data {
+                return self.create_migration_candidates_response(&req, &hooks, &analysis_data);
+            }
+        }
+
+        if let Ok(result) = analysis_rx.recv().await
+            && let Ok(result) = result.as_ref()
+        {
+            return self.create_migration_candidates_response(&req, &hooks, result);
+        }
+
+        Message::GetMigrationCandidatesResult(GetMigrationCandidatesResponse {
+            analysis_complete: false,
+            migration_recognized: true,
+            candidates: vec![],
+        })
+    }
+
+    fn create_migration_candidates_response(
+        &self,
+        req: &hakana_protocol::GetMigrationCandidatesRequest,
+        hooks: &[Arc<dyn CustomHook>],
+        result: &Arc<(AnalysisResult, SuccessfulScanData)>,
+    ) -> Message {
+        let (analysis_result, scan_data) = result.as_ref();
+
+        let filter = req
+            .filter
+            .as_ref()
+            .and_then(|f| glob::Pattern::new(f).ok());
+
+        let mut candidates = Vec::new();
+        for hook in hooks {
+            for candidate in
+                hook.get_candidates(&scan_data.codebase, &scan_data.interner, analysis_result)
+            {
+                let (classlike_id, member_id) = if let Some((classlike_name, member_name)) =
+                    candidate.split_once("::")
+                {
+                    (
+                        scan_data.interner.get(classlike_name),
+                        scan_data.interner.get(member_name),
+                    )
+                } else {
+                    (scan_data.interner.get(&candidate), Some(StrId::EMPTY))
+                };
+
+                // If a filter expression is given, only yield candidates that match it.
+                if let Some(classlike_id) = classlike_id
+                    && let Some(member_id) = member_id
+                    && let Some(location) =
+                        scan_data.codebase.get_symbol_pos(&classlike_id, &member_id)
+                {
+                    let relative_definition_path = location
+                        .file_path
+                        .get_relative_path(&scan_data.interner, &self.config.root_dir);
+
+                    if filter
+                        .as_ref()
+                        .is_none_or(|f| f.matches(&relative_definition_path))
+                    {
+                        candidates.push(candidate);
+                    }
+                }
+            }
+        }
+
+        Message::GetMigrationCandidatesResult(GetMigrationCandidatesResponse {
+            analysis_complete: true,
+            migration_recognized: true,
+            candidates,
         })
     }
 

--- a/src/server/lib.rs
+++ b/src/server/lib.rs
@@ -30,6 +30,10 @@ pub struct ServerConfig {
     pub threads: u8,
     pub config_path: Option<String>,
     pub plugins: Vec<Arc<dyn CustomHook>>,
+    /// Migration hooks, consulted only when computing migration candidates.
+    /// These are intentionally kept out of the analysis hooks so the warm
+    /// analysis stays in normal (non-migration) mode.
+    pub migration_hooks: Vec<Arc<dyn CustomHook>>,
     pub header: String,
     pub chaos_monkey: Option<Arc<dyn Fn() + Send + Sync>>,
 }
@@ -41,6 +45,7 @@ impl ServerConfig {
             threads: 8,
             config_path: None,
             plugins: Vec::new(),
+            migration_hooks: Vec::new(),
             header: String::new(),
             chaos_monkey: None,
         }
@@ -335,6 +340,11 @@ impl Server {
                     Message::GetIssues(req) => {
                         handler.handle_get_issues(&mut analysis_rx, req).await
                     }
+                    Message::GetMigrationCandidates(req) => {
+                        handler
+                            .handle_get_migration_candidates(&mut analysis_rx, req)
+                            .await
+                    }
                     Message::Status(_) => handler.handle_status(),
                     Message::Shutdown(_) => handler.handle_shutdown().await,
                     Message::GotoDefinition(req) => handler.handle_goto_definition(req),
@@ -452,7 +462,13 @@ fn run_analysis(
 
 #[cfg(test)]
 mod tests {
-    use hakana_protocol::{ClientSocket, GetIssuesRequest, Message};
+    use hakana_analyzer::custom_hook::{CustomHook, InternalHook};
+    use hakana_code_info::analysis_result::AnalysisResult;
+    use hakana_code_info::codebase_info::CodebaseInfo;
+    use hakana_protocol::{
+        ClientSocket, GetIssuesRequest, GetMigrationCandidatesRequest, Message,
+    };
+    use hakana_str::Interner;
     use std::{
         path::PathBuf,
         sync::{Arc, atomic::AtomicBool},
@@ -463,6 +479,28 @@ mod tests {
         Server, ServerConfig,
         watchman::{self, WatchmanEvent},
     };
+
+    /// A migration hook whose `get_candidates` returns a fixed list, used to exercise
+    /// the server-side migration-candidate path.
+    #[derive(Debug)]
+    struct StubMigrationHook;
+
+    impl InternalHook for StubMigrationHook {
+        fn get_migration_name(&self) -> Option<&str> {
+            Some("stub-migration")
+        }
+
+        fn get_candidates(
+            &self,
+            _codebase: &CodebaseInfo,
+            _interner: &Interner,
+            _analysis_result: &AnalysisResult,
+        ) -> Vec<String> {
+            vec!["main".to_string()]
+        }
+    }
+
+    impl CustomHook for StubMigrationHook {}
 
     #[tokio::test]
     async fn handles_file_changes_during_analysis() -> std::io::Result<()> {
@@ -488,6 +526,7 @@ mod tests {
             threads: 2,
             config_path: Some(config_path.to_str().unwrap().to_string()),
             plugins: vec![],
+            migration_hooks: vec![],
             header: "".to_string(),
             chaos_monkey: Some(Arc::new(move || {
                 // Simulate a file change between the first scan and first analysis
@@ -552,6 +591,117 @@ mod tests {
             )
         } else {
             panic!("Expected GetIssuesResult, got {:?}", response);
+        }
+
+        shutdown_tx
+            .send(true)
+            .await
+            .expect("failed to shutdown server");
+
+        server_task.await.expect("failed to join server task");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn serves_migration_candidates() -> std::io::Result<()> {
+        let tmp = tempfile::Builder::new()
+            .prefix("hakana-test")
+            .tempdir()
+            .expect("failed to create temp dir");
+        let hack_file = tmp.path().join("index.hack");
+        let config_path = tmp.path().join("hakana.json");
+        fs::write(hack_file.clone(), "function main(): void {}")
+            .await
+            .expect("failed to create test file");
+        fs::write(config_path.clone(), "{}")
+            .await
+            .expect("failed to create test file");
+
+        let server_config = ServerConfig {
+            root_dir: tmp.path().to_str().unwrap().to_string(),
+            threads: 2,
+            config_path: Some(config_path.to_str().unwrap().to_string()),
+            plugins: vec![],
+            migration_hooks: vec![Arc::new(StubMigrationHook)],
+            header: "".to_string(),
+            chaos_monkey: None,
+        };
+
+        let mut watchman_handle = watchman::start_subscription(
+            PathBuf::from(&server_config.root_dir),
+            vec![],
+            server_config.config_path.as_ref().map(&PathBuf::from),
+        )
+        .await;
+
+        let mut server = Server::new(server_config).expect("failed to create server");
+
+        let socket_path = server.socket_path().clone();
+        let shutdown_tx = server.shutdown_tx.clone();
+
+        let server_task =
+            tokio::spawn(async move { server.run().await.expect("failed to run server") });
+
+        while let Some(event) = watchman_handle.recv().await {
+            if matches!(event, WatchmanEvent::FileChanges(..)) {
+                break;
+            }
+        }
+
+        let mut client = ClientSocket::connect(&socket_path)
+            .await
+            .expect("failed to connect");
+
+        // A recognised migration returns the hook's candidates, waiting for analysis.
+        let request = Message::GetMigrationCandidates(GetMigrationCandidatesRequest {
+            migration: "stub-migration".to_string(),
+            filter: None,
+            block_until_next_analysis: false,
+        });
+
+        let response = loop {
+            let mut client = ClientSocket::connect(&socket_path)
+                .await
+                .expect("failed to connect");
+            let response = client
+                .request(&request)
+                .await
+                .expect("failed to send request");
+            if let Message::GetMigrationCandidatesResult(ref result) = response
+                && !result.analysis_complete
+            {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                continue;
+            }
+            break response;
+        };
+
+        if let Message::GetMigrationCandidatesResult(result) = response {
+            assert!(result.analysis_complete);
+            assert!(result.migration_recognized);
+            assert_eq!(vec!["main".to_string()], result.candidates);
+        } else {
+            panic!("Expected GetMigrationCandidatesResult, got {:?}", response);
+        }
+
+        // An unrecognised migration reports migration_recognized = false.
+        let unknown = client
+            .request(&Message::GetMigrationCandidates(
+                GetMigrationCandidatesRequest {
+                    migration: "does-not-exist".to_string(),
+                    filter: None,
+                    block_until_next_analysis: false,
+                },
+            ))
+            .await
+            .expect("failed to send request");
+
+        if let Message::GetMigrationCandidatesResult(result) = unknown {
+            assert!(!result.migration_recognized);
+            assert!(result.candidates.is_empty());
+        } else {
+            panic!("Expected GetMigrationCandidatesResult, got {:?}", unknown);
         }
 
         shutdown_tx


### PR DESCRIPTION
`migration-candidates` is backed by a custom hook that operates on a preexisting analysis result, so it's a good candidate to be offloaded to the server if one is running instead of needing to run an analysis.

Sadly we can't do the same for `migrate` proper because that functionality relies on custom analysis hooks and so requires an analysis to be run.