### PR TITLE
Don't treat a breakless default case as a switch terminator

### DIFF
--- a/src/analyzer/stmt/control_analyzer.rs
+++ b/src/analyzer/stmt/control_analyzer.rs
@@ -278,6 +278,9 @@ pub(crate) fn get_control_actions(
                     if case_actions.contains(&ControlAction::LeaveSwitch)
                         || case_actions.contains(&ControlAction::Break)
                         || case_actions.contains(&ControlAction::Continue)
+                        // The default case is always last, so falling off its end without a
+                        // break leaves the switch normally, exactly like an explicit break.
+                        || case_actions.contains(&ControlAction::None)
                     {
                         continue 'outer;
                     }

--- a/tests/inference/SwitchType/defaultFallthroughDoesNotNarrowGuard/input.hack
+++ b/tests/inference/SwitchType/defaultFallthroughDoesNotNarrowGuard/input.hack
@@ -1,0 +1,31 @@
+<<__Sealed(HasGet::class, NoGet::class)>>
+abstract class Base {}
+
+final class HasGet extends Base {
+	public function get(): string {
+		return "ok";
+	}
+}
+
+final class NoGet extends Base {
+	public function reason(): int {
+		return 0;
+	}
+}
+
+// The guard block does not return on all paths: its trailing switch has a
+// `default` case that falls off the end without break or return, and there is
+// no return after the switch. So $res must stay HasGet|NoGet after the block
+// and $res->get() must not be treated as always-HasGet.
+function foo(Base $res): string {
+	if (!$res is HasGet) {
+		switch ($res->reason()) {
+			case 1:
+				return "one";
+			default:
+				// no break, no return - control falls through the switch
+		}
+		// no return here either - falls through the guard block
+	}
+	return $res->get();
+}

--- a/tests/inference/SwitchType/defaultFallthroughDoesNotNarrowGuard/output.txt
+++ b/tests/inference/SwitchType/defaultFallthroughDoesNotNarrowGuard/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonExistentMethod - input.hack:30:9 - Method NoGet::get does not exist


### PR DESCRIPTION
## Problem

hakana over-narrows a variable on the path *after* a guard block when that block ends in a `switch` whose `default` case falls off the end without `break`/`return`. It concludes the guard always exits, so it applies the guard's negated type narrowing to the continuation — even though control actually reaches the continuation with the variable still its original (wider) type. `hh_client` types the variable as the union here; hakana should too.

```hack
function foo(Base $x): void {
    if (!$x is Sub) {
        switch (something()) {
            case A: return;
            default: // no break, no return
        }
        // no return here either
    }
    // $x is wrongly narrowed to Sub here, but control can reach this
    // with $x still Base
}
```

## Solution

In `control_analyzer`'s `switch` handling, treat a `default` case whose control actions contain `None` (i.e. it falls off its end) the same as an explicit `break`/`continue`/`LeaveSwitch`: the switch is not a control-flow terminator, so the enclosing block does not always exit. The `default` case is always last, so falling off its end leaves the switch normally.

A reviewer only needs the one added condition in `get_control_actions`; the chain from there to the observed over-narrowing is in the fold.

Regression test `SwitchType/defaultFallthroughDoesNotNarrowGuard` reproduces the exact shape (guard-if ending in a breakless-`default` switch, no trailing return) and asserts the guarded variable stays a union afterward.

## Verification

- New regression test **fails without the fix** (the `NonExistentMethod` that proves the variable is still a union is not emitted) and passes with it.
- Full `tests/inference` (incl. all 40 `SwitchType` cases), `tests/unused`, `tests/nopanic`, and `tests/security` suites green. The one pre-existing `tests/diff/preserveOverlappingDuplicateDefinition` failure reproduces identically on `main` without this change (unrelated to switch control flow).

<details><summary>Mechanism, and how the fix is contained</summary>

**Why the over-narrowing happened.** For a breakless `default` that falls off the end, `get_control_actions` computes `case_actions = {None}`. The pre-fix code:

1. The `break`/`continue`/`LeaveSwitch` check at the top of the default-case block does not match `{None}`, so it doesn't `continue 'outer`.
2. `case_does_end` is `false` (`None` is neither `End` nor `Return`), and `has_ended` stays `false`.
3. But `has_default_terminator = true` is then set unconditionally, and the switch returns its control actions as `{Return}` — dropping `None`.

So the switch is reported as *always returning*. Upstream, `ifelse_analyzer.rs` (~line 263) treats a then/guard block whose statements never yield `None` as always-exiting and applies the else-branch (negated) narrowing to the continuation — narrowing `$x` to `Sub` after the guard, even though control reaches the continuation with `$x` still the original union.

The fix adds `|| case_actions.contains(&ControlAction::None)` to the existing early-`continue 'outer` condition, so a fall-off-end default is handled exactly like a `break`: the switch falls through, `None` is inserted for the block, and the block is no longer seen as always-exiting.

**Containment.** The change only affects the default-case branch, and only when that case falls off its end (`{None}`). Defaults that `break`/`continue`/`return`/`exit` already hit the existing conditions and are unchanged; this only adds the previously-missing fall-off-end case to the same early-exit path. Verified by the full `SwitchType` suite (40 tests) plus the inference/unused/nopanic/security suites staying green.

<!-- ⟦PRDESC-META:v1⟧
{
  "depth": {"call": "medium", "novelty": "low", "complexity": "medium"},
  "stanzas": {"included": ["risk-as-containment"], "omitted": {"why-this": "no in-scope alternative weighed; the fix is the minimal correct condition"}},
  "classifier": {},
  "reasoning_trace": "one-line diff but non-obvious downstream interaction (ifelse narrowing); modifies existing control-flow analysis, so mechanism + containment folded, visible body kept at impact altitude"
}
⟦/PRDESC-META:v1⟧ -->

</details>
