### PR TITLE
Widen reduce-style accumulator params from the closure's return type

### DIFF
--- a/src/analyzer/expr/call/arguments_analyzer.rs
+++ b/src/analyzer/expr/call/arguments_analyzer.rs
@@ -330,6 +330,61 @@ pub(crate) fn check_arguments_match(
             .unwrap_or(get_mixed_any());
 
         if let aast::Expr_::Lfun(_) | aast::Expr_::Efun(_) = arg_expr.2 {
+            // For a "reduce accumulator" closure (a parameter typed as a template
+            // that also appears in the return type), run a throwaway probe pass on
+            // clones to learn the closure's return type, then feed the bounds it
+            // discovers back into the real template result before analyzing for
+            // real. This widens the accumulator parameter to the full union it can
+            // hold across iterations, rather than freezing it at the initial value.
+            if closure_param_feeds_return(&param_type) {
+                let mut probe_data = analysis_data.clone();
+                let mut probe_context = context.clone();
+                let mut probe_template_result = template_result.clone();
+                let mut probe_param_type = param_type.clone();
+
+                handle_closure_arg(
+                    statements_analyzer,
+                    &mut probe_data,
+                    &mut probe_context,
+                    functionlike_id,
+                    &mut probe_template_result,
+                    args,
+                    arg_expr,
+                    &probe_param_type,
+                );
+
+                if expression_analyzer::analyze(
+                    statements_analyzer,
+                    arg_expr,
+                    &mut probe_data,
+                    &mut probe_context,
+                    false,
+                )
+                .is_ok()
+                {
+                    let probe_value_type = probe_data
+                        .get_expr_type(arg_expr.pos())
+                        .cloned()
+                        .unwrap_or(get_mixed_any());
+
+                    adjust_param_type(
+                        &class_generic_params,
+                        &mut probe_param_type,
+                        codebase,
+                        statements_analyzer.get_file_path(),
+                        probe_value_type,
+                        *argument_offset,
+                        arg_expr.pos(),
+                        &mut probe_context,
+                        &mut probe_template_result,
+                        statements_analyzer,
+                        functionlike_id,
+                    );
+
+                    template_result.lower_bounds = probe_template_result.lower_bounds;
+                }
+            }
+
             handle_closure_arg(
                 statements_analyzer,
                 analysis_data,
@@ -907,6 +962,50 @@ fn get_param_type(
     } else {
         get_mixed_any()
     }
+}
+
+/// Detects the "reduce accumulator" closure shape: a closure parameter whose
+/// declared type is a template parameter that also appears in the closure's
+/// return type, e.g. `(function(Ta, Tv): Ta)` in `reduce`. For such closures
+/// the accumulator parameter's type depends on the closure's own return type,
+/// so analyzing the body once with the accumulator frozen at its initial lower
+/// bound (from `$initial`) under-approximates it: a value first produced by the
+/// closure on a later iteration is never reflected back into the parameter.
+fn closure_param_feeds_return(param_type: &TUnion) -> bool {
+    for atomic in &param_type.types {
+        if let TAtomic::TClosure(closure) = atomic {
+            let Some(return_type) = &closure.return_type else {
+                continue;
+            };
+
+            let return_templates = return_type
+                .get_template_types()
+                .into_iter()
+                .filter_map(|t| match t {
+                    TAtomic::TGenericParam(p) => Some((p.param_name, p.defining_entity)),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            if return_templates.is_empty() {
+                continue;
+            }
+
+            for param in &closure.params {
+                if let Some(signature_type) = &param.signature_type {
+                    for t in signature_type.get_template_types() {
+                        if let TAtomic::TGenericParam(p) = t
+                            && return_templates.contains(&(p.param_name, p.defining_entity))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    false
 }
 
 fn handle_closure_arg(

--- a/src/analyzer/function_analysis_data.rs
+++ b/src/analyzer/function_analysis_data.rs
@@ -22,6 +22,7 @@ pub struct TypeVariableBounds {
     pub upper_bounds: Vec<TemplateBound>,
 }
 
+#[derive(Clone)]
 pub struct FunctionAnalysisData {
     pub expr_types: FxHashMap<(u32, u32), Rc<TUnion>>,
     pub if_true_assertions: FxHashMap<(u32, u32), FxHashMap<String, Vec<Assertion>>>,

--- a/tests/inference/Lambda/reduceAccumulatorWidenedByClosureReturn/input.hack
+++ b/tests/inference/Lambda/reduceAccumulatorWidenedByClosureReturn/input.hack
@@ -1,0 +1,39 @@
+<<__Sealed(HasGet::class, NoGet::class)>>
+abstract class Base {}
+
+final class HasGet extends Base {
+	public function __construct(private string $s) {}
+	public function get(): string {
+		return $this->s;
+	}
+}
+
+final class NoGet extends Base {
+	public function reason(): int {
+		return 0;
+	}
+}
+
+function reduce<Tv, Ta>(
+	Traversable<Tv> $_,
+	(function(Ta, Tv): Ta) $_,
+	Ta $initial,
+): Ta {
+	return $initial;
+}
+
+function test(vec<int> $items): Base {
+	return reduce(
+		$items,
+		($accum, $item) ==> {
+			if ($item > 0) {
+				return new NoGet();
+			}
+			// A prior iteration can return NoGet, so $accum is not provably
+			// HasGet here: its type is the union HasGet|NoGet, and get() exists
+			// only on HasGet.
+			return new HasGet($accum->get());
+		},
+		new HasGet("init"),
+	);
+}

--- a/tests/inference/Lambda/reduceAccumulatorWidenedByClosureReturn/output.txt
+++ b/tests/inference/Lambda/reduceAccumulatorWidenedByClosureReturn/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonExistentMethod - input.hack:35:22 - Method NoGet::get does not exist


### PR DESCRIPTION
## Problem

hakana under-approximates the type of a **fold/reduce accumulator** — a closure parameter whose type is a template that also appears in the closure's return type, e.g. `reduce<Tv, Ta>(Traversable<Tv>, (function(Ta, Tv): Ta), Ta $initial): Ta`. The accumulator's type is bound only from `$initial`, so a value the closure itself first produces on a later iteration is never reflected back into it. Method calls on the accumulator are therefore checked against a type that is narrower than what it can actually hold at runtime, so real errors go unreported. `hh_client` types the accumulator as the union and flags them.

```hack
function test(vec<int> $items): Base {
    return reduce(
        $items,
        ($accum, $item) ==> {
            if ($item > 0) {
                return new NoGet();          // accumulator can become NoGet...
            }
            return new HasGet($accum->get()); // ...so $accum is not provably HasGet
        },
        new HasGet("init"),
    );
}
```

Here `$accum->get()` should be an error (`NoGet` has no `get()`), because `$accum` is `HasGet|NoGet`. hakana previously froze `$accum` at `HasGet` (the initial value) and reported nothing.

## Solution

Closures are analyzed last, and the closure's inferred return type is only folded into the template bounds *after* its body is analyzed — too late to widen a parameter that the return type feeds. There is no fixpoint, so a single pass under-approximates the accumulator.

Detect this closure shape (an un-annotated parameter typed as a template that also appears in the return position) and, only then, run a throwaway **probe pass** on clones of the analysis state to learn the closure's return type. Feed the bounds the probe discovers back into the template result, then analyze the closure for real — now the accumulator parameter is typed as the full union it can hold across iterations.

The probe runs only for closures matching this shape; all other calls take the existing single-pass path unchanged.

## Verification

- New regression test `Lambda/reduceAccumulatorWidenedByClosureReturn` **fails without the fix** (no error — accumulator frozen at the initial type) and passes with it (`NonExistentMethod` on the union member that lacks the method). Verified both directions by toggling the guard.
- Full `tests/inference` (1019 cases), plus `tests/unused`, `tests/nopanic`, `tests/security` — all green.
- Perf A/B on a large real-world codebase (~95k files, cold cache, 3 rounds): **≈1% CPU** (51.6s vs 51.0s mean, within run-to-run noise) and **≈0.4% peak RSS** (10.75 vs 10.70 GB). The probe's clones are short-lived and gated to the accumulator shape, so they don't accumulate into peak.

<details><summary>Mechanism, and why the probe is contained</summary>

The two-pass lives in the closure branch of `arguments_analyzer::check_arguments_match`:

1. `closure_param_feeds_return(param_type)` returns true only when a `TClosure` parameter's declared type is a `TGenericParam` that also appears among the return type's template params.
2. When it matches, clone `FunctionAnalysisData`, the `BlockContext`, the `TemplateResult`, and the param type; run `handle_closure_arg` + `expression_analyzer::analyze` + `adjust_param_type` on the clones. All side effects (issues, data-flow edges, expr types) land on the discarded clones.
3. Copy the probe's widened `lower_bounds` into the real `TemplateResult`, then run the real pass. `handle_closure_arg` now sees the union bound and types the accumulator parameter accordingly.

`FunctionAnalysisData` gains `#[derive(Clone)]` so the probe can run in isolation. The clone (including the data-flow graph) is dropped as soon as the probe finishes, which is why peak memory is essentially unchanged.

Containment: the entire path is behind the `closure_param_feeds_return` guard, so non-fold/reduce calls are byte-for-byte on the prior code path. Confirmed by the full inference/unused/nopanic/security suites staying green.

</details>
