### PR TITLE
Ensure templated closures' return types factor into type resolution

### DIFF
--- a/src/analyzer/expr/call/arguments_analyzer.rs
+++ b/src/analyzer/expr/call/arguments_analyzer.rs
@@ -329,8 +329,14 @@ pub(crate) fn check_arguments_match(
             .cloned()
             .unwrap_or(get_mixed_any());
 
-        if let aast::Expr_::Lfun(_) | aast::Expr_::Efun(_) = arg_expr.2 {
-            handle_closure_arg(
+        let closure_param_type = if let aast::Expr_::Lfun(_) | aast::Expr_::Efun(_) = arg_expr.2 {
+            Some(param_type.clone())
+        } else {
+            None
+        };
+
+        if let Some(closure_param_type) = &closure_param_type {
+            let _ = handle_closure_arg(
                 statements_analyzer,
                 analysis_data,
                 context,
@@ -338,7 +344,8 @@ pub(crate) fn check_arguments_match(
                 template_result,
                 args,
                 arg_expr,
-                &param_type,
+                closure_param_type,
+                *argument_offset,
             );
 
             expression_analyzer::analyze(
@@ -368,6 +375,30 @@ pub(crate) fn check_arguments_match(
             statements_analyzer,
             functionlike_id,
         );
+
+        if let Some(closure_param_type) = &closure_param_type
+            && let Some(resolved_closure_type) = handle_closure_arg(
+                statements_analyzer,
+                analysis_data,
+                context,
+                functionlike_id,
+                template_result,
+                args,
+                arg_expr,
+                closure_param_type,
+                *argument_offset,
+            )
+        {
+            param_type = resolved_closure_type;
+
+            expression_analyzer::analyze(
+                statements_analyzer,
+                arg_expr,
+                analysis_data,
+                context,
+                false,
+            )?;
+        }
 
         param_types.insert(argument_offset, param_type);
     }
@@ -918,7 +949,8 @@ fn handle_closure_arg(
     args: &[aast::Argument<(), ()>],
     closure_expr: &aast::Expr<(), ()>,
     param_type: &TUnion,
-) {
+    argument_offset: usize,
+) -> Option<TUnion> {
     let codebase = statements_analyzer.codebase;
 
     let mut replace_template_result = TemplateResult::new(
@@ -931,13 +963,26 @@ fn handle_closure_arg(
                     template_map
                         .iter()
                         .map(|(map_key, lower_bounds)| {
-                            (
-                                *map_key,
-                                Arc::new(template::standin_type_replacer::get_most_specific_type_from_bounds(
+                            let mut resolved_type =
+                                template::standin_type_replacer::get_most_specific_type_from_bounds(
                                     lower_bounds,
                                     codebase,
-                                )),
-                            )
+                                );
+
+                            // Nested closure returns normally lose to shallower bounds, but they
+                            // must still widen parameters inferred for this closure's body.
+                            for closure_bound in lower_bounds
+                                .iter()
+                                .filter(|bound| bound.arg_offset == Some(argument_offset))
+                            {
+                                resolved_type = add_optional_union_type(
+                                    closure_bound.bound_type.clone(),
+                                    Some(&resolved_type),
+                                    codebase,
+                                );
+                            }
+
+                            (*map_key, Arc::new(resolved_type))
                         })
                         .collect::<Vec<_>>(),
                 )
@@ -971,7 +1016,7 @@ fn handle_closure_arg(
             closure_expr.1.start_offset(),
         ) {
             None => {
-                return;
+                return None;
             }
             Some(value) => value,
         }
@@ -1044,9 +1089,25 @@ fn handle_closure_arg(
         }
     }
 
+    let params_changed = match analysis_data.closures.get(closure_expr.pos()) {
+        Some(existing_storage) => {
+            existing_storage.params.len() != closure_storage.params.len()
+                || existing_storage
+                    .params
+                    .iter()
+                    .zip(&closure_storage.params)
+                    .any(|(existing_param, new_param)| {
+                        existing_param.signature_type != new_param.signature_type
+                    })
+        }
+        None => true,
+    };
+
     analysis_data
         .closures
         .insert(closure_expr.pos().clone(), closure_storage);
+
+    params_changed.then_some(replaced_type)
 }
 
 fn map_class_generic_params(

--- a/tests/inference/Lambda/reduceAccumulatorWidenedByClosureReturn/input.hack
+++ b/tests/inference/Lambda/reduceAccumulatorWidenedByClosureReturn/input.hack
@@ -1,0 +1,39 @@
+<<__Sealed(HasGet::class, NoGet::class)>>
+abstract class Base {}
+
+final class HasGet extends Base {
+	public function __construct(private string $s) {}
+	public function get(): string {
+		return $this->s;
+	}
+}
+
+final class NoGet extends Base {
+	public function reason(): int {
+		return 0;
+	}
+}
+
+function reduce<Tv, Ta>(
+	Traversable<Tv> $_,
+	(function(Ta, Tv): Ta) $_,
+	Ta $initial,
+): Ta {
+	return $initial;
+}
+
+function test(vec<int> $items): Base {
+	return reduce(
+		$items,
+		($accum, $item) ==> {
+			if ($item > 0) {
+				return new NoGet();
+			}
+			// A prior iteration can return NoGet, so $accum is not provably
+			// HasGet here: its type is the union HasGet|NoGet, and get() exists
+			// only on HasGet.
+			return new HasGet($accum->get());
+		},
+		new HasGet("init"),
+	);
+}

--- a/tests/inference/Lambda/reduceAccumulatorWidenedByClosureReturn/output.txt
+++ b/tests/inference/Lambda/reduceAccumulatorWidenedByClosureReturn/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonExistentMethod - input.hack:35:22 - Method NoGet::get does not exist


### PR DESCRIPTION
Currently type resolution for templated closures where a template type is shared by the closure's return type and a different parameter, e.g. `reduce<Tv, Ta>(Traversable<Tv>, (function(Ta, Tv): Ta), Ta $initial): Ta` is narrowed down only to the type of the parameter. This is incorrect if the closure may produce a wider range of return types, e.g.:

```hack
function test(vec<int> $items): Base {
    return reduce(
        $items,
        ($accum, $item) ==> {
            if ($item > 0) {
                return new NoGet();          // accumulator can become NoGet...
            }
            return new HasGet($accum->get()); // ...so $accum is not provably HasGet
        },
        new HasGet("init"),
    );
}
```

So do a second closure analysis if the inferred param type widens.