### PR TITLE
Fix type inference for optional XHP attributes

### DIFF
--- a/src/code_info_builder/classlike_scanner.rs
+++ b/src/code_info_builder/classlike_scanner.rs
@@ -842,13 +842,11 @@ fn visit_xhp_attribute(
         get_mixed_any()
     };
 
-    let is_required = if let Some(attr_tag) = &xhp_attribute.2 {
-        attr_tag.is_required()
-    } else {
-        false
-    };
+    let is_required = xhp_attribute
+        .2
+        .is_some_and(|attr_tag| attr_tag.is_required());
 
-    if !is_required && !attribute_type.is_mixed() && xhp_attribute.1.expr.is_none() {
+    if !is_required && !attribute_type.is_mixed() {
         attribute_type.types.push(TAtomic::TNull);
     }
 

--- a/tests/inference/XHP/xhpOptionalAttribute/input.hack
+++ b/tests/inference/XHP/xhpOptionalAttribute/input.hack
@@ -1,0 +1,14 @@
+use namespace Facebook\XHP\Core as x;
+use type Facebook\XHP\HTML\{span};
+
+final xhp class foo extends x\element {
+	attribute string target = null;
+	attribute string other;
+
+	<<__Override>>
+	protected async function renderAsync(): Awaitable<x\node> {
+		$foo = \HH\Lib\Str\replace($this->:target,'foo', 'bar');
+        $foo .= \HH\Lib\Str\replace($this->:other,'foo', 'bar');
+		return (<span>$foo</span>);
+	}
+}

--- a/tests/inference/XHP/xhpOptionalAttribute/output.txt
+++ b/tests/inference/XHP/xhpOptionalAttribute/output.txt
@@ -1,0 +1,2 @@
+ERROR: PossiblyInvalidArgument - input.hack:10:30 - Argument 1 of HH\Lib\Str\replace expects string, possibly different type ?string provided
+ERROR: PossiblyInvalidArgument - input.hack:11:37 - Argument 1 of HH\Lib\Str\replace expects string, possibly different type ?string provided


### PR DESCRIPTION
The default value of optional XHP attributes is `null`. Further, even if they have a default, it's valid Hack to pass `null` to the attribute at the call site anyways.
This leads to nonsense like this:
```hack

use namespace Facebook\XHP\Core as x;
use type Facebook\XHP\HTML\{span};

final xhp class foo extends x\element {
	attribute string target = null;
	attribute string other;

	<<__Override>>
	protected async function renderAsync(): Awaitable<x\node> {
		// both attributes need to be nullchecked here!
		$foo = $this->:target.'foo'.$this->:other;
		return (<span>$foo</span>);
	}
}

<<__EntryPoint>>
async function main(): Awaitable<void> {
	$bar = <foo target="baz" />;
	$baz = <foo target={null} />;
	await $bar->toStringAsync();
}
```

So ensure Hakana treats optional XHP attributes as nullable at all times, like the typechecker already does.