### PR TITLE
Narrow XHP optional value type inference

### DIFF
--- a/src/code_info_builder/classlike_scanner.rs
+++ b/src/code_info_builder/classlike_scanner.rs
@@ -846,7 +846,14 @@ fn visit_xhp_attribute(
         .2
         .is_some_and(|attr_tag| attr_tag.is_required());
 
-    if !is_required && !attribute_type.is_mixed() {
+    if !is_required
+        && !attribute_type.is_mixed()
+        && xhp_attribute
+            .1
+            .expr
+            .as_ref()
+            .is_none_or(|default_val| default_val.2.is_null())
+    {
         attribute_type.types.push(TAtomic::TNull);
     }
 

--- a/tests/inference/XHP/xhpOptionalAttribute/input.hack
+++ b/tests/inference/XHP/xhpOptionalAttribute/input.hack
@@ -4,11 +4,13 @@ use type Facebook\XHP\HTML\{span};
 final xhp class foo extends x\element {
 	attribute string target = null;
 	attribute string other;
+	attribute string has-def = "always_string";
 
 	<<__Override>>
 	protected async function renderAsync(): Awaitable<x\node> {
 		$foo = \HH\Lib\Str\replace($this->:target,'foo', 'bar');
         $foo .= \HH\Lib\Str\replace($this->:other,'foo', 'bar');
+		$foo .= \HH\Lib\Str\replace($this->:has-def,'foo', 'bar');
 		return (<span>$foo</span>);
 	}
 }

--- a/tests/inference/XHP/xhpOptionalAttribute/output.txt
+++ b/tests/inference/XHP/xhpOptionalAttribute/output.txt
@@ -1,2 +1,2 @@
-ERROR: PossiblyInvalidArgument - input.hack:10:30 - Argument 1 of HH\Lib\Str\replace expects string, possibly different type ?string provided
-ERROR: PossiblyInvalidArgument - input.hack:11:37 - Argument 1 of HH\Lib\Str\replace expects string, possibly different type ?string provided
+ERROR: PossiblyInvalidArgument - input.hack:11:30 - Argument 1 of HH\Lib\Str\replace expects string, possibly different type ?string provided
+ERROR: PossiblyInvalidArgument - input.hack:12:37 - Argument 1 of HH\Lib\Str\replace expects string, possibly different type ?string provided


### PR DESCRIPTION
The situation thankfully isn't as dire as I feared in #191 because passing `{null}` explicitly as the value of an optional non-nullable XHP attribute with a non-nullable default is a typechecker error. So only consider the case where there's either no default or the default is the literal `null`.