### PR TITLE
Add inference and autofix for implicit container -> bool conversions

### DIFF
--- a/src/analyzer/reconciler/simple_assertion_reconciler.rs
+++ b/src/analyzer/reconciler/simple_assertion_reconciler.rs
@@ -611,8 +611,7 @@ fn reconcile_array_access(
     }
 
     new_var_type.types.retain(|atomic| {
-        (allow_int_key
-            && atomic.is_array_accessible_with_int_or_string_key(statements_analyzer.interner))
+        (allow_int_key && atomic.is_array_accessible_with_int_or_string_key())
             || (!allow_int_key
                 && atomic.is_array_accessible_with_string_key(statements_analyzer.interner))
     });

--- a/src/analyzer/truthiness/container_migration.rs
+++ b/src/analyzer/truthiness/container_migration.rs
@@ -1,0 +1,153 @@
+use hakana_code_info::analysis_result::Replacement;
+use hakana_code_info::issue::IssueKind;
+use hakana_code_info::t_atomic::{TAtomic, TDict, TNamedObject, TVec};
+use hakana_code_info::t_union::TUnion;
+use hakana_str::StrId;
+use oxidized::aast;
+use oxidized::ast::Bop;
+use oxidized::pos::Pos;
+
+use crate::function_analysis_data::FunctionAnalysisData;
+use crate::statements_analyzer::StatementsAnalyzer;
+
+use super::implicit_boolean_conversion_migration::ImplicitBooleanConversionMigration;
+
+pub(super) struct ContainerMigration {
+    pub(super) handle_nullable: bool,
+}
+
+impl ImplicitBooleanConversionMigration for ContainerMigration {
+    fn matches(&self, expr_type: &TUnion) -> bool {
+        if self.handle_nullable && !expr_type.is_nullable() {
+            return false;
+        }
+        expr_type
+            .types
+            .iter()
+            .filter(|t| !self.handle_nullable || !matches!(t, TAtomic::TNull))
+            .all(|t| {
+                !matches!(
+                    t,
+                    TAtomic::TDict(TDict {
+                        known_items: Some(..),
+                        ..
+                    }) | TAtomic::TVec(TVec {
+                        known_items: Some(..),
+                        ..
+                    })
+                ) && (t.is_array_accessible_with_int_or_string_key()
+                    || matches!(
+                        t,
+                        TAtomic::TNamedObject(TNamedObject {
+                            name: StrId::MAP
+                                | StrId::IMM_MAP
+                                | StrId::SET
+                                | StrId::IMM_SET
+                                | StrId::VECTOR
+                                | StrId::IMM_VECTOR,
+                            ..
+                        })
+                    ))
+            })
+    }
+
+    fn migrate(
+        &self,
+        statements_analyzer: &StatementsAnalyzer,
+        analysis_data: &mut FunctionAnalysisData,
+        expr: &aast::Expr<(), ()>,
+        pos: &Pos,
+    ) {
+        self.migrate_shared(false, statements_analyzer, analysis_data, expr, pos);
+    }
+
+    fn migrate_negated(
+        &self,
+        statements_analyzer: &StatementsAnalyzer,
+        analysis_data: &mut FunctionAnalysisData,
+        expr: &aast::Expr<(), ()>,
+        pos: &Pos,
+    ) {
+        self.migrate_shared(true, statements_analyzer, analysis_data, expr, pos);
+    }
+
+    fn kind(&self) -> IssueKind {
+        IssueKind::NonBoolContainerCondition
+    }
+}
+
+impl ContainerMigration {
+    fn migrate_shared(
+        &self,
+        negated: bool,
+        statements_analyzer: &StatementsAnalyzer,
+        analysis_data: &mut FunctionAnalysisData,
+        expr: &aast::Expr<(), ()>,
+        pos: &Pos,
+    ) {
+        if !self.handle_nullable {
+            analysis_data.insert_at(
+                pos.start_offset() as u32,
+                format!("{}C\\is_empty(", if negated { "" } else { "!" }),
+            );
+            analysis_data.insert_at(pos.end_offset() as u32, ")".to_string());
+            return;
+        }
+
+        if expr.2.is_call() {
+            analysis_data.insert_at(
+                pos.start_offset() as u32,
+                format!("{}C\\is_empty(", if negated { "" } else { "!" }),
+            );
+            analysis_data.insert_at(pos.end_offset() as u32, " ?? vec[])".to_string());
+            return;
+        }
+
+        if let Some(bin_op) = expr.2.as_binop()
+            && matches!(bin_op.bop, Bop::QuestionQuestion)
+            && bin_op.rhs.2.is_null()
+        {
+            let coalesce_rhs_start = bin_op.rhs.pos().start_offset() as u32;
+            let coalesce_rhs_end = bin_op.rhs.pos().end_offset() as u32;
+            analysis_data.insert_at(
+                pos.start_offset() as u32,
+                format!("{}C\\is_empty(", if negated { "" } else { "!" }),
+            );
+            analysis_data.add_replacement(
+                (coalesce_rhs_start, coalesce_rhs_end),
+                Replacement::Substitute("vec[])".to_string()),
+            );
+            return;
+        }
+
+        if super::is_trivial(expr) {
+            let expr_text = &statements_analyzer.file_analyzer.file_source.file_contents
+                [pos.start_offset()..pos.end_offset()];
+            let close_paren = if !super::is_sole_condition(statements_analyzer, pos) {
+                analysis_data.insert_at(pos.start_offset() as u32, "(".to_string());
+                ")"
+            } else {
+                ""
+            };
+
+            if negated {
+                analysis_data.insert_at(
+                    pos.end_offset() as u32,
+                    format!(" is null || C\\is_empty({expr_text}){close_paren}"),
+                );
+            } else {
+                analysis_data.insert_at(
+                    pos.end_offset() as u32,
+                    format!(" is nonnull && !C\\is_empty({expr_text}){close_paren}"),
+                );
+            }
+            return;
+        }
+
+        analysis_data.insert_at(
+            pos.start_offset() as u32,
+            format!("{}\\HH\\legacy_is_truthy(", if negated { "!" } else { "" }),
+        );
+        analysis_data.insert_at(pos.end_offset() as u32, ")".to_string());
+    }
+}

--- a/src/analyzer/truthiness/mod.rs
+++ b/src/analyzer/truthiness/mod.rs
@@ -3,12 +3,15 @@ use std::sync::LazyLock;
 use hakana_code_info::analysis_result::Replacement;
 use hakana_code_info::issue::Issue;
 use oxidized::aast;
+use oxidized::pos::Pos;
 
 use crate::function_analysis_data::FunctionAnalysisData;
 use crate::scope::BlockContext;
 use crate::scope_analyzer::ScopeAnalyzer;
 use crate::statements_analyzer::StatementsAnalyzer;
+use crate::truthiness::container_migration::ContainerMigration;
 
+mod container_migration;
 mod implicit_boolean_conversion_migration;
 mod int_migration;
 mod nullable_object_migration;
@@ -19,6 +22,25 @@ use int_migration::IntMigration;
 use nullable_object_migration::NullableObjectMigration;
 use nullable_string_migration::NullableStringMigration;
 
+/// Is this a trivial expression that should be fine to repeat?
+fn is_trivial(expr: &aast::Expr<(), ()>) -> bool {
+    matches!(
+        expr.2,
+        aast::Expr_::Lvar(..)
+            | aast::Expr_::ArrayGet(..)
+            | aast::Expr_::ClassGet(..)
+            | aast::Expr_::ObjGet(..)
+    )
+}
+
+/// Is this expression the sole condition in an `if` statement?
+fn is_sole_condition(statements_analyzer: &StatementsAnalyzer, pos: &Pos) -> bool {
+    let file_contents = &statements_analyzer.file_analyzer.file_source.file_contents;
+    (file_contents[..pos.start_offset()].ends_with("if (")
+        || file_contents[..pos.start_offset()].ends_with("if (!"))
+        && file_contents[pos.end_offset()..].starts_with(")")
+}
+
 pub(crate) fn check_implicit_boolean_conversion(
     statements_analyzer: &StatementsAnalyzer,
     analysis_data: &mut FunctionAnalysisData,
@@ -27,6 +49,7 @@ pub(crate) fn check_implicit_boolean_conversion(
 ) {
     let mut negation_depth: u32 = 0;
     let mut pos = expr.pos();
+    let negation_start_offset = pos.start_offset();
     while let aast::Expr_::Unop(inner) = &expr.2
         && let oxidized::ast_defs::Uop::Unot = inner.0
     {
@@ -53,6 +76,12 @@ pub(crate) fn check_implicit_boolean_conversion(
                     Box::new(NullableStringMigration {
                         handle_nullable: false,
                     }),
+                    Box::new(ContainerMigration {
+                        handle_nullable: true,
+                    }),
+                    Box::new(ContainerMigration {
+                        handle_nullable: false,
+                    }),
                 ]
             });
 
@@ -69,13 +98,15 @@ pub(crate) fn check_implicit_boolean_conversion(
             );
 
             if statements_analyzer.should_autofix(context, analysis_data, &issue) {
-                analysis_data.add_replacement(
-                    (
-                        pos.start_offset() as u32 - negation_depth,
-                        pos.start_offset() as u32,
-                    ),
-                    Replacement::Remove,
-                );
+                // Get rid of all negations, but preserve any potential parentheses in between
+                if negation_depth > 0 {
+                    let negations = &statements_analyzer.file_analyzer.file_source.file_contents
+                        [negation_start_offset..pos.start_offset()];
+                    analysis_data.add_replacement(
+                        (negation_start_offset as u32, pos.start_offset() as u32),
+                        Replacement::Substitute(negations.replace("!", "")),
+                    );
+                }
                 if is_negated {
                     migration.migrate_negated(statements_analyzer, analysis_data, expr, pos);
                 } else {

--- a/src/analyzer/truthiness/nullable_string_migration.rs
+++ b/src/analyzer/truthiness/nullable_string_migration.rs
@@ -12,25 +12,6 @@ pub(super) struct NullableStringMigration {
     pub(super) handle_nullable: bool,
 }
 
-impl NullableStringMigration {
-    fn is_trivial(expr: &aast::Expr<(), ()>) -> bool {
-        matches!(
-            expr.2,
-            aast::Expr_::Lvar(..)
-                | aast::Expr_::ArrayGet(..)
-                | aast::Expr_::ClassGet(..)
-                | aast::Expr_::ObjGet(..)
-        )
-    }
-
-    fn is_sole_condition(statements_analyzer: &StatementsAnalyzer, pos: &Pos) -> bool {
-        let file_contents = &statements_analyzer.file_analyzer.file_source.file_contents;
-        (file_contents[..pos.start_offset()].ends_with("if (")
-            || file_contents[..pos.start_offset()].ends_with("if (!"))
-            && file_contents[pos.end_offset()..].starts_with(")")
-    }
-}
-
 impl ImplicitBooleanConversionMigration for NullableStringMigration {
     fn matches(&self, expr_type: &TUnion) -> bool {
         if self.handle_nullable {
@@ -47,10 +28,10 @@ impl ImplicitBooleanConversionMigration for NullableStringMigration {
         expr: &aast::Expr<(), ()>,
         pos: &Pos,
     ) {
-        if Self::is_trivial(expr) {
+        if super::is_trivial(expr) {
             let expr_text = &statements_analyzer.file_analyzer.file_source.file_contents
                 [pos.start_offset()..pos.end_offset()];
-            let close_paren = if !Self::is_sole_condition(statements_analyzer, pos) {
+            let close_paren = if !super::is_sole_condition(statements_analyzer, pos) {
                 analysis_data.insert_at(pos.start_offset() as u32, "(".to_string());
                 ")"
             } else {
@@ -86,10 +67,10 @@ impl ImplicitBooleanConversionMigration for NullableStringMigration {
         expr: &aast::Expr<(), ()>,
         pos: &Pos,
     ) {
-        if Self::is_trivial(expr) {
+        if super::is_trivial(expr) {
             let expr_text = &statements_analyzer.file_analyzer.file_source.file_contents
                 [pos.start_offset()..pos.end_offset()];
-            let close_paren = if !Self::is_sole_condition(statements_analyzer, pos) {
+            let close_paren = if !super::is_sole_condition(statements_analyzer, pos) {
                 analysis_data.insert_at(pos.start_offset() as u32, "(".to_string());
                 ")"
             } else {

--- a/src/code_info/issue.rs
+++ b/src/code_info/issue.rs
@@ -84,6 +84,7 @@ pub enum IssueKind {
     NonBoolCondition,
     NonBoolNumericCondition,
     NonBoolStringCondition,
+    NonBoolContainerCondition,
     NonExhaustiveSwitchStatement,
     NonExistentClass,
     NonExistentClassConstant,
@@ -164,7 +165,7 @@ pub enum IssueKind {
     VariableDefinedOutsideIf,
 }
 
-static AUTOFIXABLE_ISSUES: [IssueKind; 26] = [
+static AUTOFIXABLE_ISSUES: [IssueKind; 27] = [
     IssueKind::UnusedClass,
     IssueKind::UnusedTypeDefinition,
     IssueKind::UnusedFunction,
@@ -189,6 +190,7 @@ static AUTOFIXABLE_ISSUES: [IssueKind; 26] = [
     IssueKind::NonBoolCondition,
     IssueKind::NonBoolNumericCondition,
     IssueKind::NonBoolStringCondition,
+    IssueKind::NonBoolContainerCondition,
     IssueKind::MissingIndirectServiceCallsAttribute,
     IssueKind::RedundantIssetCheck,
 ];

--- a/src/code_info/t_atomic.rs
+++ b/src/code_info/t_atomic.rs
@@ -1519,14 +1519,14 @@ impl TAtomic {
         }
     }
 
-    pub fn is_array_accessible_with_int_or_string_key(&self, interner: &Interner) -> bool {
+    pub fn is_array_accessible_with_int_or_string_key(&self) -> bool {
         match self {
             TAtomic::TDict(TDict { .. }) | TAtomic::TVec(TVec { .. }) | TAtomic::TKeyset { .. } => {
                 true
             }
             TAtomic::TNamedObject(TNamedObject { name, .. }) => matches!(
-                interner.lookup(name),
-                "HH\\KeyedContainer" | "HH\\Container" | "HH\\AnyArray"
+                *name,
+                StrId::KEYED_CONTAINER | StrId::CONTAINER | StrId::ANY_ARRAY
             ),
             _ => false,
         }

--- a/tests/fix/NonBoolContainerCondition/input.hack
+++ b/tests/fix/NonBoolContainerCondition/input.hack
@@ -1,0 +1,41 @@
+type input_t = shape(
+    ?'container' => \HH\Container
+);
+
+function returns_nullable(bool $b): ?dict<string, int> {
+    return $b ? dict[] : null;
+}
+
+function main(?\HH\Container $nc, \HH\Container $c, input_t $input, bool $b): void {
+    if ($nc) {
+        echo "test";
+    }
+
+    if (!$c || !$b) {
+        echo "test";
+    }
+
+    if ($c && $b) {
+        echo "foo";
+    }
+
+    if ($nc ?? dict[]) {
+        echo "test";
+    }
+
+    if ($b && !$nc) {
+        echo "foo";
+    }
+
+    if (!($input['container'] ?? null)) {
+        echo "test";
+    }
+
+    if (returns_nullable()) {
+        echo "foo";
+    }
+
+    if (returns_nullable() ?? dict[]) {
+        echo "foo";
+    }
+}

--- a/tests/fix/NonBoolContainerCondition/output.txt
+++ b/tests/fix/NonBoolContainerCondition/output.txt
@@ -1,0 +1,41 @@
+type input_t = shape(
+    ?'container' => \HH\Container
+);
+
+function returns_nullable(bool $b): ?dict<string, int> {
+    return $b ? dict[] : null;
+}
+
+function main(?\HH\Container $nc, \HH\Container $c, input_t $input, bool $b): void {
+    if ($nc is nonnull && !C\is_empty($nc)) {
+        echo "test";
+    }
+
+    if (C\is_empty($c) || !$b) {
+        echo "test";
+    }
+
+    if (!C\is_empty($c) && $b) {
+        echo "foo";
+    }
+
+    if (!C\is_empty($nc ?? dict[])) {
+        echo "test";
+    }
+
+    if ($b && ($nc is null || C\is_empty($nc))) {
+        echo "foo";
+    }
+
+    if ((C\is_empty($input['container'] ?? vec[]))) {
+        echo "test";
+    }
+
+    if (!C\is_empty(returns_nullable() ?? vec[])) {
+        echo "foo";
+    }
+
+    if (!C\is_empty(returns_nullable() ?? dict[])) {
+        echo "foo";
+    }
+}

--- a/tests/inference/ArrayAccess/arrayKeyCannotBeBool/output.txt
+++ b/tests/inference/ArrayAccess/arrayKeyCannotBeBool/output.txt
@@ -1,1 +1,2 @@
-ImpossibleTypeComparison
+ERROR: NonBoolContainerCondition - input.hack:2:10 - Only bool values can be used as a condition
+ERROR: ImpossibleTypeComparison - input.hack:8:9 - Type arraykey is never bool

--- a/tests/inference/ArrayAssignment/checkEmptinessAfterConditionalArrayAdjustment/output.txt
+++ b/tests/inference/ArrayAssignment/checkEmptinessAfterConditionalArrayAdjustment/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:9:14 - Only bool values can be used as a condition

--- a/tests/inference/ArrayAssignment/dictAssignArbitraryKey/output.txt
+++ b/tests/inference/ArrayAssignment/dictAssignArbitraryKey/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:8:9 - Only bool values can be used as a condition

--- a/tests/inference/ArrayAssignment/dictAssignEitherLiteralKey/output.txt
+++ b/tests/inference/ArrayAssignment/dictAssignEitherLiteralKey/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:10:9 - Only bool values can be used as a condition

--- a/tests/inference/Async/awaitMapped/output.txt
+++ b/tests/inference/Async/awaitMapped/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:7:9 - Only bool values can be used as a condition

--- a/tests/inference/FunctionCall/allowListEqualToRange/output.txt
+++ b/tests/inference/FunctionCall/allowListEqualToRange/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:2:9 - Only bool values can be used as a condition

--- a/tests/inference/Loop/Foreach/loopWithIfElseNoParadox/output.txt
+++ b/tests/inference/Loop/Foreach/loopWithIfElseNoParadox/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:15:5 - Only bool values can be used as a condition

--- a/tests/inference/Loop/While/propertyAssertionInsideWhile/output.txt
+++ b/tests/inference/Loop/While/propertyAssertionInsideWhile/output.txt
@@ -1,0 +1,8 @@
+ERROR: NonBoolContainerCondition - input.hack:20:16 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:20:28 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:31:16 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:31:28 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:31:40 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:42:17 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:42:29 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:42:42 - Only bool values can be used as a condition

--- a/tests/inference/Loop/While/propertyAssertionInsideWhileNested/output.txt
+++ b/tests/inference/Loop/While/propertyAssertionInsideWhileNested/output.txt
@@ -1,0 +1,3 @@
+ERROR: NonBoolContainerCondition - input.hack:9:16 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:9:29 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:9:41 - Only bool values can be used as a condition

--- a/tests/inference/NonBoolCondition/nullableContainer/input.hack
+++ b/tests/inference/NonBoolCondition/nullableContainer/input.hack
@@ -1,0 +1,48 @@
+type input_t = shape(
+    ?'container' => \HH\Container
+);
+function main(?\HH\Container $nc, \HH\Container $c, input_t $input, bool $b, ?input_t $foo, ?shape(?'foo' => string) $bar = null): void {
+    if ($nc) {
+        echo "test";
+    }
+
+    if (!$c || !$b) {
+        echo "test";
+    }
+
+    if ($c && $b) {
+        echo "foo";
+    }
+
+    if ($nc ?? dict[]) {
+        echo "test";
+    }
+
+    if ($b && !$nc) {
+        echo "foo";
+    }
+
+    if (!($input['container'] ?? null)) {
+        echo "test";
+    }
+
+    if ($foo) {
+        echo "test";
+    }
+
+    if (returns_tuple($b)) {
+        echo "test";
+    }
+
+    if ($bar && Shapes::keyExists($bar, 'foo')) {
+        echo "test";
+    }
+
+    if ($bar) {
+        echo "test";
+    }
+}
+
+function returns_tuple(bool $b): ?(int, string) {
+    return $b ? tuple(5, "a") : null;
+}

--- a/tests/inference/NonBoolCondition/nullableContainer/output.txt
+++ b/tests/inference/NonBoolCondition/nullableContainer/output.txt
@@ -1,0 +1,6 @@
+ERROR: NonBoolContainerCondition - input.hack:5:9 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:9:10 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:13:9 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:17:9 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:21:16 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:25:11 - Only bool values can be used as a condition

--- a/tests/inference/NonBoolCondition/traversable/output.txt
+++ b/tests/inference/NonBoolCondition/traversable/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:2:9 - Only bool values can be used as a condition

--- a/tests/inference/TypeReconciliation/Conditional/assertIssetOnArray/output.txt
+++ b/tests/inference/TypeReconciliation/Conditional/assertIssetOnArray/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:2:15 - Only bool values can be used as a condition

--- a/tests/inference/TypeReconciliation/Conditional/noLeakyClassType/output.txt
+++ b/tests/inference/TypeReconciliation/Conditional/noLeakyClassType/output.txt
@@ -1,0 +1,3 @@
+ERROR: NonBoolContainerCondition - input.hack:6:13 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:12:16 - Only bool values can be used as a condition
+ERROR: NonBoolContainerCondition - input.hack:12:30 - Only bool values can be used as a condition

--- a/tests/inference/TypeReconciliation/RedundantCondition/unsetArrayWithKnownOffset/output.txt
+++ b/tests/inference/TypeReconciliation/RedundantCondition/unsetArrayWithKnownOffset/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:4:9 - Only bool values can be used as a condition

--- a/tests/inference/TypeReconciliation/TypeAlgebra/noParadoxAfterArrayAppending/output.txt
+++ b/tests/inference/TypeReconciliation/TypeAlgebra/noParadoxAfterArrayAppending/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:2:9 - Only bool values can be used as a condition

--- a/tests/unused/UnusedExpression/unusedArrayAdditionWithArrayChecked/output.txt
+++ b/tests/unused/UnusedExpression/unusedArrayAdditionWithArrayChecked/output.txt
@@ -1,0 +1,1 @@
+ERROR: NonBoolContainerCondition - input.hack:7:5 - Only bool values can be used as a condition


### PR DESCRIPTION
Implement inference and autofix to detect places where containers are implicitly converted into booleans. The autofix tries to use `C\is_empty` with an associated null check where possible.

Update many tests that were triggering implicit container -> bool conversions. Once truthiness is removed from Hack, we can update or remove these.